### PR TITLE
fix: add emulate -L zsh to completion function for shell option safety

### DIFF
--- a/.changeset/fix-zsh-completion-emulate.md
+++ b/.changeset/fix-zsh-completion-emulate.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": patch
+---
+
+Add `emulate -L zsh` to zsh completion function to prevent user shell options from interfering with completion logic.

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -2,6 +2,7 @@ import type { CAC } from "cac";
 
 const ZSH_SCRIPT = `\
 _dot_completions() {
+  emulate -L zsh
   local -a completions
   local current_word="\${words[CURRENT]}"
   local preceding=("\${words[2,CURRENT-1]}")


### PR DESCRIPTION
## Summary
- Adds `emulate -L zsh` to the zsh completion function to reset shell options to zsh defaults within the function scope
- Prevents user-configured options like `KSH_ARRAYS`, `SH_WORD_SPLIT`, etc. from breaking completion logic (array indexing, string splitting)
- This is the standard defensive pattern used by well-written zsh completion scripts

## Test plan
- [ ] Run `eval "$(dot completions zsh)"` in a clean zsh session and verify completions work
- [ ] Run `setopt KSH_ARRAYS && eval "$(dot completions zsh)"` and verify completions still work correctly
- [ ] Verify bash and fish completion scripts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)