### PR TITLE
feat: remove Smoldot light client support

### DIFF
--- a/.changeset/remove-light-client.md
+++ b/.changeset/remove-light-client.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Remove Smoldot light client support. The `--light-client` global flag, `dot chain add <name> --light-client` command, and all underlying light client connection logic have been removed. Chains now always connect via WebSocket RPC. Existing user configs with `lightClient: true` are gracefully ignored and fall through to the configured RPC endpoints. Light client support will be reintroduced properly in a future release (see #142).

--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ Ships with Polkadot and all system parachains preconfigured with multiple fallba
 
 ### Preconfigured chains
 
-| Network | Chain | Light client |
-|---------|-------|:---:|
-| Polkadot | `polkadot` (relay, default) | yes |
-| | `polkadot-asset-hub` | yes |
-| | `polkadot-bridge-hub` | yes |
-| | `polkadot-collectives` | yes |
-| | `polkadot-coretime` | yes |
-| | `polkadot-people` | yes |
-| Paseo (testnet) | `paseo` (relay) | yes |
-| | `paseo-asset-hub` | yes |
-| | `paseo-bridge-hub` | — |
-| | `paseo-collectives` | — |
-| | `paseo-coretime` | yes |
-| | `paseo-people` | yes |
+| Network | Chain |
+|---------|-------|
+| Polkadot | `polkadot` (relay, default) |
+| | `polkadot-asset-hub` |
+| | `polkadot-bridge-hub` |
+| | `polkadot-collectives` |
+| | `polkadot-coretime` |
+| | `polkadot-people` |
+| Paseo (testnet) | `paseo` (relay) |
+| | `paseo-asset-hub` |
+| | `paseo-bridge-hub` |
+| | `paseo-collectives` |
+| | `paseo-coretime` |
+| | `paseo-people` |
 
 Each chain ships with multiple RPC endpoints from decentralized infrastructure providers (IBP, Dotters, Dwellir, and others). The CLI automatically falls back to the next endpoint if the primary is unreachable.
 
@@ -67,9 +67,6 @@ dot chain add kusama --rpc wss://kusama-rpc.polkadot.io
 
 # Add a chain with fallback RPCs (repeat --rpc for each endpoint)
 dot chain add kusama --rpc wss://kusama-rpc.polkadot.io --rpc wss://kusama-rpc.dwellir.com
-
-# Add a chain via light client
-dot chain add westend --light-client
 
 # List configured chains
 dot chain list
@@ -982,7 +979,7 @@ dot tx.System.remark 0xdead               # shows call help (no error)
 | `--help` | Show help (global or command-specific) |
 | `--chain <name>` | Target chain (default from config) |
 | `--rpc <url>` | Override RPC endpoint(s) for this call (repeat for fallback) |
-| `--light-client` | Use Smoldot light client |
+
 | `--output json` | Raw JSON output (default: pretty) |
 | `--dump` | Dump all entries of a storage map (required for keyless map queries) |
 | `-w, --wait <level>` | Tx wait level: `broadcast`, `best-block` / `best`, `finalized` (default) |

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -33,32 +33,32 @@ This installs the `dot` command globally. Ships with Polkadot and all system par
 
 ## Chains
 
-Manage chain connections. Polkadot is configured by default along with all system parachains for both Polkadot and Paseo networks. Add any Substrate-based chain by RPC endpoint or Smoldot light client.
+Manage chain connections. Polkadot is configured by default along with all system parachains for both Polkadot and Paseo networks. Add any Substrate-based chain by pointing to its RPC endpoint(s).
 
 ### Preconfigured chains
 
 The following chains are available out of the box — no `dot chain add` needed:
 
-| Network | Chain | Light client |
-|---------|-------|:---:|
-| Polkadot | `polkadot` (relay, default) | yes |
-| | `polkadot-asset-hub` | yes |
-| | `polkadot-bridge-hub` | yes |
-| | `polkadot-collectives` | yes |
-| | `polkadot-coretime` | yes |
-| | `polkadot-people` | yes |
-| Paseo (testnet) | `paseo` (relay) | yes |
-| | `paseo-asset-hub` | yes |
-| | `paseo-bridge-hub` | — |
-| | `paseo-collectives` | — |
-| | `paseo-coretime` | yes |
-| | `paseo-people` | yes |
+| Network | Chain |
+|---------|-------|
+| Polkadot | `polkadot` (relay, default) |
+| | `polkadot-asset-hub` |
+| | `polkadot-bridge-hub` |
+| | `polkadot-collectives` |
+| | `polkadot-coretime` |
+| | `polkadot-people` |
+| Paseo (testnet) | `paseo` (relay) |
+| | `paseo-asset-hub` |
+| | `paseo-bridge-hub` |
+| | `paseo-collectives` |
+| | `paseo-coretime` |
+| | `paseo-people` |
 
 Each chain ships with multiple RPC endpoints from decentralized infrastructure providers (IBP, Dotters, Dwellir, and others). The CLI automatically falls back to the next endpoint if the primary is unreachable. Use `dot chain list` to see all endpoints for each chain.
 
 ### Add a chain
 
-Connect to a chain via WebSocket RPC or the embedded Smoldot light client. Use repeated `--rpc` flags to configure multiple endpoints with automatic fallback — if the primary is unreachable, the CLI tries the next one:
+Connect to a chain via WebSocket RPC. Use repeated `--rpc` flags to configure multiple endpoints with automatic fallback — if the primary is unreachable, the CLI tries the next one:
 
 ```
 # Single RPC
@@ -66,9 +66,6 @@ dot chain add kusama --rpc wss://kusama-rpc.polkadot.io
 
 # Multiple RPCs with fallback
 dot chain add kusama --rpc wss://kusama-rpc.polkadot.io --rpc wss://kusama-rpc.dwellir.com
-
-# Light client
-dot chain add westend --light-client
 ```
 
 ### List chains
@@ -1525,7 +1522,7 @@ These flags work with any command:
 | `--help` | Show help (global or command-specific) |
 | `--chain <name>` | Target chain (default from config) |
 | `--rpc <url>` | Override RPC endpoint(s) for this call (repeat for fallback) |
-| `--light-client` | Use Smoldot light client |
+
 | `--output json` | Raw JSON output (default: pretty) |
 | `--dump` | Dump all entries of a storage map (required for keyless map queries) |
 | `-w, --wait <level>` | Tx wait level: `broadcast`, `best-block` / `best`, `finalized` (default) |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,6 @@ if (process.argv[2] === "__complete") {
 
   cli.option("--chain <name>", "Target chain (default from config)");
   cli.option("--rpc <url>", "Override RPC endpoint for this call");
-  cli.option("--light-client", "Use Smoldot light client instead of WebSocket");
   cli.option("--output <format>", "Output format: pretty or json", {
     default: "pretty",
   });
@@ -308,7 +307,6 @@ if (process.argv[2] === "__complete") {
     console.log("Global options:");
     console.log("  --chain <name>     Target chain (default from config)");
     console.log("  --rpc <url>        Override RPC endpoint");
-    console.log("  --light-client     Use Smoldot light client");
     console.log("  --output <format>  Output format: pretty or json");
     console.log("  --help, -h         Display this message");
     console.log("  --version          Show version");

--- a/src/commands/chain.test.ts
+++ b/src/commands/chain.test.ts
@@ -124,17 +124,24 @@ describe("dot chain", () => {
     );
   });
 
-  test("list with light-client chain", async () => {
-    const { stdout, exitCode } = await runCli(["chain", "list"], {
-      config: {
-        chains: {
-          kusama: { rpc: "", lightClient: true },
-        },
-      },
-    });
+  test("help text does not mention --light-client", async () => {
+    const { stdout, exitCode } = await runCli(["chain"]);
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("kusama");
-    expect(stdout).toContain("light-client");
+    expect(stdout).not.toContain("--light-client");
+    expect(stdout).not.toContain("light client");
+    expect(stdout).not.toContain("Smoldot");
+  });
+
+  test("add mychain (no --rpc) error does not mention --light-client", async () => {
+    const { stderr, exitCode } = await runCli(["chain", "add", "mychain"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).not.toContain("--light-client");
+  });
+
+  test("list shows RPC for all chains (no light-client display)", async () => {
+    const { stdout, exitCode } = await runCli(["chain", "list"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("light-client");
   });
 
   test("default kusama succeeds", async () => {
@@ -250,7 +257,7 @@ describe("dot chain", () => {
   test("add mychain (no --rpc) errors", async () => {
     const { stderr, exitCode } = await runCli(["chain", "add", "mychain"]);
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("Must provide either --rpc");
+    expect(stderr).toContain("Must provide --rpc");
   });
 
   test("remove Polkadot (case-insensitive) errors as built-in", async () => {

--- a/src/commands/chain.ts
+++ b/src/commands/chain.ts
@@ -14,7 +14,6 @@ import { BOLD, CHECK_MARK, CYAN, DIM, GREEN, printHeading, RED, RESET } from "..
 const CHAIN_HELP = `
 ${BOLD}Usage:${RESET}
   $ dot chain add <name> --rpc <url>    Add a chain via WebSocket RPC
-  $ dot chain add <name> --light-client Add a chain via Smoldot light client
   $ dot chain remove <name>             Remove a chain
   $ dot chain update [name]             Re-fetch metadata (default chain if omitted)
   $ dot chain update --all              Re-fetch metadata for all configured chains
@@ -24,7 +23,6 @@ ${BOLD}Usage:${RESET}
 ${BOLD}Examples:${RESET}
   $ dot chain add kusama --rpc wss://kusama-rpc.polkadot.io
   $ dot chain add kusama --rpc wss://kusama-rpc.polkadot.io --rpc wss://kusama-rpc.dwellir.com
-  $ dot chain add westend --light-client
   $ dot chain default kusama
   $ dot chain list
   $ dot chain update
@@ -42,7 +40,7 @@ export function registerChainCommands(cli: CAC) {
       async (
         action: string | undefined,
         name: string | undefined,
-        opts: { rpc?: string | string[]; lightClient?: boolean; all?: boolean },
+        opts: { rpc?: string | string[]; all?: boolean },
       ) => {
         if (!action) {
           if (process.argv[2] === "chains") return chainList();
@@ -71,24 +69,21 @@ export function registerChainCommands(cli: CAC) {
 
 async function chainAdd(
   name: string | undefined,
-  opts: { rpc?: string | string[]; lightClient?: boolean },
+  opts: { rpc?: string | string[] },
 ) {
   if (!name) {
     console.error("Chain name is required.\n");
     console.error("Usage: dot chain add <name> --rpc <url>");
-    console.error("       dot chain add <name> --light-client");
     process.exit(1);
   }
-  if (!opts.rpc && !opts.lightClient) {
-    console.error("Must provide either --rpc <url> or --light-client.\n");
+  if (!opts.rpc) {
+    console.error("Must provide --rpc <url>.\n");
     console.error("Usage: dot chain add <name> --rpc <url>");
-    console.error("       dot chain add <name> --light-client");
     process.exit(1);
   }
 
   const chainConfig = {
-    rpc: opts.rpc ?? "",
-    ...(opts.lightClient ? { lightClient: true } : {}),
+    rpc: opts.rpc,
   };
 
   console.error(`Connecting to ${name}...`);
@@ -145,14 +140,10 @@ async function chainList() {
   for (const [name, chainConfig] of Object.entries(config.chains)) {
     const isDefault = name === config.defaultChain;
     const marker = isDefault ? ` ${BOLD}(default)${RESET}` : "";
-    if (chainConfig.lightClient) {
-      console.log(`  ${CYAN}${name}${RESET}${marker}  ${DIM}light-client${RESET}`);
-    } else {
-      const rpcs = Array.isArray(chainConfig.rpc) ? chainConfig.rpc : [chainConfig.rpc];
-      console.log(`  ${CYAN}${name}${RESET}${marker}  ${DIM}${rpcs[0]}${RESET}`);
-      for (let i = 1; i < rpcs.length; i++) {
-        console.log(`    ${DIM}${rpcs[i]}${RESET}`);
-      }
+    const rpcs = Array.isArray(chainConfig.rpc) ? chainConfig.rpc : [chainConfig.rpc];
+    console.log(`  ${CYAN}${name}${RESET}${marker}  ${DIM}${rpcs[0]}${RESET}`);
+    for (let i = 1; i < rpcs.length; i++) {
+      console.log(`    ${DIM}${rpcs[i]}${RESET}`);
     }
   }
   console.log();

--- a/src/commands/chain.ts
+++ b/src/commands/chain.ts
@@ -67,10 +67,7 @@ export function registerChainCommands(cli: CAC) {
     );
 }
 
-async function chainAdd(
-  name: string | undefined,
-  opts: { rpc?: string | string[] },
-) {
+async function chainAdd(name: string | undefined, opts: { rpc?: string | string[] }) {
   if (!name) {
     console.error("Chain name is required.\n");
     console.error("Usage: dot chain add <name> --rpc <url>");

--- a/src/completions/complete.test.ts
+++ b/src/completions/complete.test.ts
@@ -147,7 +147,6 @@ describe("option name completion", () => {
     expect(l).toContain("--output");
     expect(l).toContain("--help");
     expect(l).toContain("--version");
-
   });
 
   test("-- prefix does not include removed --light-client option", async () => {

--- a/src/completions/complete.test.ts
+++ b/src/completions/complete.test.ts
@@ -147,7 +147,13 @@ describe("option name completion", () => {
     expect(l).toContain("--output");
     expect(l).toContain("--help");
     expect(l).toContain("--version");
-    expect(l).toContain("--light-client");
+
+  });
+
+  test("-- prefix does not include removed --light-client option", async () => {
+    const { stdout } = await runCli(["__complete", "--", "--", ""]);
+    const l = lines(stdout);
+    expect(l).not.toContain("--light-client");
   });
 
   test("-- with tx dotpath includes tx-specific options", async () => {

--- a/src/completions/complete.ts
+++ b/src/completions/complete.ts
@@ -37,7 +37,7 @@ const ACCOUNT_SUBCOMMANDS = [
   "inspect",
 ];
 
-const GLOBAL_OPTIONS = ["--chain", "--rpc", "--light-client", "--output", "--help", "--version"];
+const GLOBAL_OPTIONS = ["--chain", "--rpc", "--output", "--help", "--version"];
 const TX_OPTIONS = [
   "--from",
   "--dry-run",

--- a/src/config/types.test.ts
+++ b/src/config/types.test.ts
@@ -19,6 +19,14 @@ describe("primaryRpc", () => {
   });
 });
 
+describe("ChainConfig", () => {
+  test("no built-in chain has a lightClient field", () => {
+    for (const [_name, config] of Object.entries(DEFAULT_CONFIG.chains)) {
+      expect(config).not.toHaveProperty("lightClient");
+    }
+  });
+});
+
 describe("DEFAULT_CONFIG", () => {
   test("built-in chains use array rpc", () => {
     for (const [_name, config] of Object.entries(DEFAULT_CONFIG.chains)) {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,6 +1,5 @@
 export interface ChainConfig {
   rpc: string | string[];
-  lightClient?: boolean;
 }
 
 export interface Config {

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -83,6 +83,21 @@ describe("createChainClient", () => {
     );
   });
 
+  test("ignores legacy lightClient field and uses RPC", async () => {
+    mockGetWsProvider.mockClear();
+
+    // Old configs may have lightClient: true — the field is no longer in the
+    // ChainConfig interface but could still exist in user config files on disk.
+    const legacyConfig = { rpc: "wss://example.com", lightClient: true } as ChainConfig;
+    const handle = await createChainClient("polkadot", legacyConfig);
+
+    expect(mockGetWsProvider).toHaveBeenCalledTimes(1);
+    const [endpoints] = mockGetWsProvider.mock.calls[0]!;
+    expect(endpoints).toBe("wss://example.com");
+
+    handle.destroy();
+  });
+
   test("wraps provider with withPolkadotSdkCompat", async () => {
     mockWithCompat.mockClear();
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -61,4 +61,3 @@ export async function createChainClient(
     },
   };
 }
-

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -7,27 +7,6 @@ import { loadMetadata, saveMetadata } from "../config/store.ts";
 import type { ChainConfig } from "../config/types.ts";
 import { ConnectionError } from "../utils/errors.ts";
 
-// Known chain specs for light client usage
-interface ChainSpecEntry {
-  spec: string;
-  relay?: string;
-}
-
-const KNOWN_CHAIN_SPECS: Record<string, ChainSpecEntry> = {
-  polkadot: { spec: "polkadot-api/chains/polkadot" },
-  kusama: { spec: "polkadot-api/chains/ksmcc3" },
-  westend: { spec: "polkadot-api/chains/westend2" },
-  paseo: { spec: "polkadot-api/chains/paseo" },
-  "polkadot-asset-hub": { spec: "polkadot-api/chains/polkadot_asset_hub", relay: "polkadot" },
-  "polkadot-bridge-hub": { spec: "polkadot-api/chains/polkadot_bridge_hub", relay: "polkadot" },
-  "polkadot-collectives": { spec: "polkadot-api/chains/polkadot_collectives", relay: "polkadot" },
-  "polkadot-coretime": { spec: "polkadot-api/chains/polkadot_coretime", relay: "polkadot" },
-  "polkadot-people": { spec: "polkadot-api/chains/polkadot_people", relay: "polkadot" },
-  "paseo-asset-hub": { spec: "polkadot-api/chains/paseo_asset_hub", relay: "paseo" },
-  "paseo-coretime": { spec: "polkadot-api/chains/paseo_coretime", relay: "paseo" },
-  "paseo-people": { spec: "polkadot-api/chains/paseo_people", relay: "paseo" },
-};
-
 export interface ClientHandle {
   client: ReturnType<typeof createClient>;
   destroy: () => void;
@@ -51,29 +30,21 @@ export async function createChainClient(
   chainConfig: ChainConfig,
   rpcOverride?: string | string[],
 ): Promise<ClientHandle> {
-  const useLight = !rpcOverride && chainConfig.lightClient;
-
   const restoreConsole = suppressWsNoise();
 
-  let provider: JsonRpcProvider;
-
-  if (useLight) {
-    provider = await createSmoldotProvider(chainName);
-  } else {
-    const rpc = rpcOverride ?? chainConfig.rpc;
-    if (!rpc) {
-      restoreConsole();
-      throw new ConnectionError(
-        `No RPC endpoint configured for chain "${chainName}". Use --rpc or configure one with: dot chain add ${chainName} --rpc <url>`,
-      );
-    }
-    provider = withPolkadotSdkCompat(
-      getWsProvider(rpc, {
-        timeout: 10_000,
-        websocketClass: WebSocket as unknown as typeof globalThis.WebSocket,
-      }),
+  const rpc = rpcOverride ?? chainConfig.rpc;
+  if (!rpc) {
+    restoreConsole();
+    throw new ConnectionError(
+      `No RPC endpoint configured for chain "${chainName}". Use --rpc or configure one with: dot chain add ${chainName} --rpc <url>`,
     );
   }
+  const provider: JsonRpcProvider = withPolkadotSdkCompat(
+    getWsProvider(rpc, {
+      timeout: 10_000,
+      websocketClass: WebSocket as unknown as typeof globalThis.WebSocket,
+    }),
+  );
 
   const client = createClient(provider, {
     getMetadata: async () => loadMetadata(chainName),
@@ -91,32 +62,3 @@ export async function createChainClient(
   };
 }
 
-async function createSmoldotProvider(chainName: string) {
-  const { start } = await import("polkadot-api/smoldot");
-  const { getSmProvider } = await import("polkadot-api/sm-provider");
-
-  const entry = KNOWN_CHAIN_SPECS[chainName];
-  if (!entry) {
-    throw new ConnectionError(
-      `Light client is only supported for known chains: ${Object.keys(KNOWN_CHAIN_SPECS).join(", ")}. ` +
-        `Use --rpc to connect to "${chainName}" instead.`,
-    );
-  }
-
-  const { chainSpec } = await import(entry.spec);
-  const smoldot = start();
-
-  if (entry.relay) {
-    const relayEntry = KNOWN_CHAIN_SPECS[entry.relay];
-    if (!relayEntry) {
-      throw new ConnectionError(`Relay chain "${entry.relay}" not found in known chain specs.`);
-    }
-    const { chainSpec: relaySpec } = await import(relayEntry.spec);
-    const relayChain = await smoldot.addChain({ chainSpec: relaySpec, disableJsonRpc: true });
-    const chain = await smoldot.addChain({ chainSpec, potentialRelayChains: [relayChain] });
-    return getSmProvider(chain);
-  }
-
-  const chain = await smoldot.addChain({ chainSpec });
-  return getSmProvider(chain);
-}


### PR DESCRIPTION
## Summary

- Remove `--light-client` global CLI flag, `dot chain add <name> --light-client`, and all underlying Smoldot light client connection logic
- Chains now always connect via WebSocket RPC
- Existing user configs with `lightClient: true` are gracefully ignored and fall through to configured RPC endpoints
- Add tests verifying light client references are absent from help, completions, chain list, and that legacy configs are handled

## Motivation

The light client feature was not working correctly. This PR removes it cleanly so it can be reintroduced properly in a future release — see #142 for the reintroduction plan.

## Changed files

| Area | Files |
|------|-------|
| Core logic | `src/core/client.ts`, `src/config/types.ts` |
| CLI & commands | `src/cli.ts`, `src/commands/chain.ts`, `src/completions/complete.ts` |
| Tests | `src/core/client.test.ts`, `src/config/types.test.ts`, `src/commands/chain.test.ts`, `src/completions/complete.test.ts` |
| Docs | `README.md`, `docs/content/_index.md` |
| Changeset | `.changeset/remove-light-client.md` |

## Test plan

- [x] All 138 affected tests pass (`bun test` on chain, completions, client, types test files)
- [x] `dot --help` no longer shows `--light-client`
- [x] `dot chain` help no longer mentions light client
- [x] `dot chain list` shows RPC for all chains (no light-client display)
- [x] No `light-client`/`smoldot`/`lightClient` references in source or docs (only `bun.lock` sub-deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)