### PR TITLE
feat: support unsigned/authorized transaction submission (--unsigned flag)

### DIFF
--- a/.changeset/unsigned-transactions.md
+++ b/.changeset/unsigned-transactions.md
@@ -1,0 +1,51 @@
+---
+"polkadot-cli": minor
+---
+
+Add `--unsigned` flag for submitting unsigned/authorized transactions (v5 general transactions).
+
+**New: `--unsigned` flag on `dot tx`**
+
+Submit transactions without a signer. Used for governance-authorized calls like `People.create_people_collection` on the People chain, where authorization comes from on-chain mechanisms (e.g. `AuthorizeCall` extension) rather than cryptographic signatures.
+
+```bash
+# Submit an authorized transaction on the People chain
+dot tx People.create_people_collection --unsigned --chain people
+
+# Dry-run to inspect before submitting
+dot tx People.create_people_collection --unsigned --chain people --dry-run
+
+# Encode the full general transaction bytes
+dot tx People.create_people_collection --unsigned --chain people --encode
+
+# JSON output for scripting
+dot tx People.create_people_collection --unsigned --chain people --json
+```
+
+**How it works**
+
+The CLI constructs a v5 general transaction (`0x45` format) with all signed extension "extra" values auto-defaulted:
+- `VerifySignature` → `Disabled`
+- `Option<T>` extensions → `None`
+- `void` extensions → empty
+- `CheckMortality` → `Immortal`
+- `CheckNonce` → `0`
+- `ChargeAssetTxPayment` → zero tip, no asset
+
+User overrides via `--ext` are supported for chains with non-standard extension requirements.
+
+**File-based input**
+
+YAML/JSON files now support an `unsigned: true` field:
+
+```yaml
+chain: people
+unsigned: true
+tx:
+  People:
+    create_people_collection: null
+```
+
+**Mutually exclusive flags**
+
+`--unsigned` cannot be combined with `--from`, `--nonce`, `--tip`, or `--mortality`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Ships with Polkadot and all system parachains preconfigured with multiple fallba
 - ✅ File-based commands — run any command from a YAML/JSON file with variable substitution
 - ✅ Parachain sovereign accounts — derive child and sibling addresses from a parachain ID
 - ✅ Message signing — sign arbitrary bytes with account keypairs for use as `MultiSignature` arguments
+- ✅ Unsigned/authorized transactions — submit governance-authorized calls without a signer (`--unsigned`)
 - ✅ Bandersnatch member keys — derive Ring VRF member keys from mnemonics for on-chain member sets
 
 ### Preconfigured chains
@@ -691,6 +692,39 @@ dot tx System.remark 0xdead --from alice --nonce 5 --tip 500000 --wait broadcast
 ```
 
 When set, nonce / tip / mortality / at are shown in both `--dry-run` and submission output. These flags are silently ignored with `--encode`, `--to-yaml`, and `--to-json` (which return before signing).
+
+#### Unsigned/authorized transactions
+
+Submit transactions without a signer using `--unsigned`. This is for calls authorized by on-chain mechanisms (e.g. the `AuthorizeCall` extension) rather than cryptographic signatures — typically governance-authorized calls on chains like the People chain.
+
+```bash
+# Submit an authorized call on the People chain
+dot tx People.create_people_collection --unsigned --chain people
+
+# Dry-run to inspect before submitting
+dot tx People.create_people_collection --unsigned --chain people --dry-run
+
+# Encode the full general transaction bytes
+dot tx People.create_people_collection --unsigned --chain people --encode
+
+# With raw hex call data
+dot tx 0x3306 --unsigned --chain people
+
+# JSON output for scripting
+dot tx People.create_people_collection --unsigned --chain people --json
+```
+
+The CLI constructs a v5 general transaction with all extension values auto-defaulted (`VerifySignature::Disabled`, `Era::Immortal`, nonce `0`, tip `0`, etc.). Override individual extensions with `--ext` if needed.
+
+`--unsigned` is mutually exclusive with `--from`, `--nonce`, `--tip`, and `--mortality`. File-based input supports `unsigned: true`:
+
+```yaml
+chain: people
+unsigned: true
+tx:
+  People:
+    create_people_collection: null
+```
 
 ### File-based commands
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -18,6 +18,7 @@ A command-line tool for interacting with Polkadot-ecosystem chains. Manage chain
 - ✅ Batteries included — all system parachains and testnets already setup to be used
 - ✅ File-based commands — run any command from a YAML/JSON file with variable substitution
 - ✅ Parachain sovereign accounts — derive child and sibling addresses from a parachain ID
+- ✅ Unsigned/authorized transactions — submit governance-authorized calls without a signer (`--unsigned`)
 - ✅ Message signing — sign arbitrary bytes with account keypairs for use as `MultiSignature` arguments
 - ✅ Bandersnatch member keys — derive Ring VRF member keys from mnemonics for on-chain member sets
 
@@ -920,6 +921,64 @@ dot tx.System.remark 0xdead --from alice --nonce 5 --tip 500000 --wait broadcast
 ```
 
 When set, nonce / tip / mortality / at are shown in both `--dry-run` and submission output. These flags are silently ignored with `--encode`, `--to-yaml`, and `--to-json` (which return before signing).
+
+### Unsigned/authorized transactions
+
+Submit transactions without a signer using `--unsigned`. This is for calls authorized by on-chain mechanisms (e.g. the `AuthorizeCall` signed extension) rather than cryptographic signatures. Typically used for governance-authorized calls on chains like the People chain.
+
+```
+# Submit an authorized call on the People chain
+dot tx People.create_people_collection --unsigned --chain people
+
+# Dry-run to inspect before submitting
+dot tx People.create_people_collection --unsigned --chain people --dry-run
+
+# Encode the full general transaction bytes
+dot tx People.create_people_collection --unsigned --chain people --encode
+
+# With raw hex call data
+dot tx 0x3306 --unsigned --chain people
+
+# JSON output for scripting
+dot tx People.create_people_collection --unsigned --chain people --json
+```
+
+The CLI constructs a v5 general transaction (`0x45` format) with all signed extension "extra" values auto-defaulted:
+
+- `VerifySignature` → `Disabled` (no cryptographic signature)
+- `Option<T>` extensions (e.g. `AsPerson`) → `None`
+- `void` extensions (e.g. `AuthorizeCall`) → empty
+- `CheckMortality` → `Immortal`
+- `CheckNonce` → `0`
+- `ChargeAssetTxPayment` → zero tip, no asset
+- `bool` extensions (e.g. `RestrictOrigins`) → `false`
+
+Override individual extensions with `--ext` if needed:
+
+```
+dot tx People.create_people_collection --unsigned --chain people \
+  --ext '{"RestrictOrigins":{"value":true}}'
+```
+
+`--unsigned` is mutually exclusive with `--from`, `--nonce`, `--tip`, and `--mortality`.
+
+#### File-based unsigned transactions
+
+YAML/JSON command files support an `unsigned: true` field. The CLI `--unsigned` flag overrides the file value:
+
+```yaml
+# create-people-collection.yaml
+chain: people
+unsigned: true
+tx:
+  People:
+    create_people_collection: null
+```
+
+```
+dot ./create-people-collection.yaml
+dot ./create-people-collection.yaml --dry-run
+```
 
 ## File-Based Commands
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,6 +85,7 @@ if (process.argv[2] === "__complete") {
     .option("--tip <amount>", "Tip to prioritize transaction (for tx)")
     .option("--mortality <spec>", '"immortal" or period number (for tx)')
     .option("--at <block>", 'Block hash, "best", or "finalized" to validate against (for tx)')
+    .option("--unsigned", "Submit as unsigned/bare transaction (no signer required, for tx)")
     .action(
       async (
         dotpath: string | undefined,
@@ -105,6 +106,7 @@ if (process.argv[2] === "__complete") {
           tip?: string;
           mortality?: string;
           at?: string;
+          unsigned?: boolean;
           dump?: boolean;
           var?: string | string[];
         },
@@ -135,6 +137,7 @@ if (process.argv[2] === "__complete") {
               await handleTx(target, args, {
                 ...handlerOpts,
                 from: opts.from,
+                unsigned: opts.unsigned ?? cmd.unsigned,
                 dryRun: opts.dryRun,
                 encode: opts.encode,
                 toYaml: opts.toYaml,
@@ -227,6 +230,7 @@ if (process.argv[2] === "__complete") {
             const txOpts = {
               ...handlerOpts,
               from: opts.from,
+              unsigned: opts.unsigned,
               dryRun: opts.dryRun,
               encode: opts.encode,
               toYaml: opts.toYaml,
@@ -298,6 +302,7 @@ if (process.argv[2] === "__complete") {
     console.log("  dot query.System.Account <addr>         Query a storage item");
     console.log("  dot query.System                        List storage items in System");
     console.log("  dot tx.System.remark 0xdead --from alice");
+    console.log("  dot tx.System.remark 0xdead --unsigned    Submit unsigned/bare tx");
     console.log("  dot const.Balances.ExistentialDeposit");
     console.log("  dot events.Balances                     List events in Balances");
     console.log("  dot apis.Core.version                    Call a runtime API");

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -9,6 +9,7 @@ import { runCli } from "./__fixtures__/run-cli.ts";
 import {
   autoDefaultForType,
   buildCustomSignedExtensions,
+  buildGeneralTx,
   decodeCallFallback,
   decodeCallToFileFormat,
   fileArgsToStrings,
@@ -30,6 +31,7 @@ import {
   parseWaitLevel,
   sanitizeForSerialization,
   typeHint,
+  unsignedDefaultForType,
 } from "./tx.ts";
 
 const meta = getTestMetadata();
@@ -1945,5 +1947,216 @@ describe("dot tx CLI integration", () => {
     const { stdout, exitCode } = await runCli(["tx.System.remark", "0xdeadbeef", "--encode"]);
     expect(exitCode).toBe(0);
     expect(stdout).toMatch(/^0x[0-9a-f]+$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --unsigned flag validation
+// ---------------------------------------------------------------------------
+
+describe("--unsigned flag validation", () => {
+  test("--unsigned and --from are mutually exclusive", async () => {
+    const { stderr, exitCode } = await runCli([
+      "tx.System.remark",
+      "0xaa",
+      "--unsigned",
+      "--from",
+      "alice",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("mutually exclusive");
+  });
+
+  test("--unsigned does not support --nonce", async () => {
+    const { stderr, exitCode } = await runCli([
+      "tx.System.remark",
+      "0xaa",
+      "--unsigned",
+      "--nonce",
+      "5",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--unsigned does not support --nonce");
+  });
+
+  test("--unsigned does not support --tip", async () => {
+    const { stderr, exitCode } = await runCli([
+      "tx.System.remark",
+      "0xaa",
+      "--unsigned",
+      "--tip",
+      "1000",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--unsigned does not support --tip");
+  });
+
+  test("--unsigned does not support --mortality", async () => {
+    const { stderr, exitCode } = await runCli([
+      "tx.System.remark",
+      "0xaa",
+      "--unsigned",
+      "--mortality",
+      "immortal",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--unsigned does not support --mortality");
+  });
+
+  test("--unsigned alone (without --from) passes gate check for raw hex", async () => {
+    // Raw hex + --unsigned should not error about missing --from
+    // It will error during submission (no chain connection in test) but should
+    // get past the gate check
+    const { stderr } = await runCli(["tx.0x0001", "--unsigned"]);
+    expect(stderr).not.toContain("--from is required");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unsignedDefaultForType
+// ---------------------------------------------------------------------------
+
+describe("unsignedDefaultForType", () => {
+  test("void returns empty Uint8Array", () => {
+    const result = unsignedDefaultForType("SomeExt", { type: "void" });
+    expect(result).toEqual(new Uint8Array([]));
+  });
+
+  test("option returns undefined (None)", () => {
+    const result = unsignedDefaultForType("AsPerson", { type: "option", value: {} });
+    expect(result).toBeUndefined();
+  });
+
+  test("enum with Disabled returns Disabled variant", () => {
+    const result = unsignedDefaultForType("VerifyMultiSignature", {
+      type: "enum",
+      value: { Signed: {}, Disabled: { type: "void" } },
+    });
+    expect(result).toEqual({ type: "Disabled", value: undefined });
+  });
+
+  test("enum with Immortal returns Immortal variant", () => {
+    const result = unsignedDefaultForType("SomeEra", {
+      type: "enum",
+      value: { Immortal: { type: "void" }, Mortal1: {} },
+    });
+    expect(result).toEqual({ type: "Immortal" });
+  });
+
+  test("CheckMortality returns Immortal regardless of entry", () => {
+    const result = unsignedDefaultForType("CheckMortality", { type: "enum", value: {} });
+    expect(result).toEqual({ type: "Immortal" });
+  });
+
+  test("CheckNonce returns 0", () => {
+    const result = unsignedDefaultForType("CheckNonce", { type: "compact" });
+    expect(result).toBe(0);
+  });
+
+  test("ChargeTransactionPayment returns 0n", () => {
+    const result = unsignedDefaultForType("ChargeTransactionPayment", { type: "compact" });
+    expect(result).toBe(0n);
+  });
+
+  test("ChargeAssetTxPayment returns zero tip and no asset", () => {
+    const result = unsignedDefaultForType("ChargeAssetTxPayment", { type: "struct" });
+    expect(result).toEqual({ tip: 0n, asset_id: undefined });
+  });
+
+  test("primitive bool returns false", () => {
+    const result = unsignedDefaultForType("RestrictOrigins", {
+      type: "primitive",
+      value: "bool",
+    });
+    expect(result).toBe(false);
+  });
+
+  test("primitive u32 returns 0", () => {
+    const result = unsignedDefaultForType("SomeExt", { type: "primitive", value: "u32" });
+    expect(result).toBe(0);
+  });
+
+  test("primitive u128 returns 0n", () => {
+    const result = unsignedDefaultForType("SomeExt", { type: "primitive", value: "u128" });
+    expect(result).toBe(0n);
+  });
+
+  test("compact returns 0", () => {
+    const result = unsignedDefaultForType("SomeExt", { type: "compact" });
+    expect(result).toBe(0);
+  });
+
+  test("unknown type returns NO_DEFAULT", () => {
+    const result = unsignedDefaultForType("SomeExt", { type: "struct", value: {} });
+    expect(result).toBe(NO_DEFAULT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGeneralTx
+// ---------------------------------------------------------------------------
+
+describe("buildGeneralTx", () => {
+  test("produces bytes starting with compact length, 0x45, 0x00", () => {
+    const callData = new Uint8Array([0x00, 0x01]); // minimal call data
+    const result = buildGeneralTx(meta, callData, {});
+    // First byte(s) are compact length, then 0x45 (general v5), then 0x00 (ext version)
+    // Find where 0x45 appears (after compact prefix)
+    let idx = 0;
+    // Skip compact prefix (1-4 bytes depending on value)
+    while (idx < result.length && (result[idx]! & 0b11) !== 0) idx++;
+    if (idx === 0) idx = 1; // single-byte compact
+    expect(result[idx]).toBe(0x45);
+    expect(result[idx + 1]).toBe(0x00);
+  });
+
+  test("call data appears at end of general tx", () => {
+    const callData = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const result = buildGeneralTx(meta, callData, {});
+    const tail = result.slice(-4);
+    expect(tail).toEqual(callData);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --unsigned help text and gate logic
+// ---------------------------------------------------------------------------
+
+describe("--unsigned help and gate", () => {
+  test("missing --from and --unsigned shows call help with --unsigned hint", async () => {
+    const { stdout, exitCode } = await runCli(["tx.System.remark", "0xaa"]);
+    expect(exitCode).toBe(0);
+    // Should show help, not error about missing flags
+    expect(stdout).toContain("(Call)");
+    expect(stdout).toContain("Usage:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --unsigned file-based input
+// ---------------------------------------------------------------------------
+
+describe("--unsigned with file-based input", () => {
+  test("YAML file with unsigned: true and --dry-run works", async () => {
+    const yaml = [
+      "chain: polkadot",
+      "unsigned: true",
+      "tx:",
+      "  System:",
+      '    remark: "0xdeadbeef"',
+    ].join("\n");
+    const { stdout, exitCode, stderr } = await runCli(
+      ["{{HOME}}/unsigned-remark.yaml", "--dry-run"],
+      { files: { "unsigned-remark.yaml": yaml } },
+    );
+    // This will fail to connect (no live chain in tests), but the flag parsing
+    // should work. Check that it doesn't error about missing --from
+    if (exitCode === 0) {
+      expect(stdout).toContain("unsigned");
+      expect(stdout).toContain("N/A");
+    } else {
+      // Connection error is fine, but --from error is not
+      expect(stderr).not.toContain("--from is required");
+    }
   });
 });

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -1,3 +1,4 @@
+import { compact as scaleCompact } from "@polkadot-api/substrate-bindings";
 import type { Decoded } from "@polkadot-api/view-builder";
 import { getViewBuilder } from "@polkadot-api/view-builder";
 import type { TxBestBlocksState, TxBroadcasted, TxEvent, TxFinalized } from "polkadot-api";
@@ -118,6 +119,7 @@ export async function handleTx(
     chain?: string;
     rpc?: string;
     from?: string;
+    unsigned?: boolean;
     dryRun?: boolean;
     encode?: boolean;
     toYaml?: boolean;
@@ -206,9 +208,11 @@ export async function handleTx(
     return;
   }
 
-  if (!opts.from && !opts.encode && !opts.toYaml && !opts.toJson) {
+  if (!opts.from && !opts.unsigned && !opts.encode && !opts.toYaml && !opts.toJson) {
     if (isRawCall) {
-      throw new Error("--from is required (or use --encode to output hex without signing)");
+      throw new Error(
+        "--from is required (or use --unsigned for bare tx, --encode for hex without signing)",
+      );
     }
     await showItemHelp("tx", target, opts);
     return;
@@ -232,6 +236,19 @@ export async function handleTx(
     throw new Error("--to-yaml and --to-json are mutually exclusive");
   }
 
+  if (opts.unsigned && opts.from) {
+    throw new Error("--unsigned and --from are mutually exclusive");
+  }
+  if (opts.unsigned && opts.nonce) {
+    throw new Error("--unsigned does not support --nonce");
+  }
+  if (opts.unsigned && opts.tip) {
+    throw new Error("--unsigned does not support --tip");
+  }
+  if (opts.unsigned && opts.mortality) {
+    throw new Error("--unsigned does not support --mortality");
+  }
+
   const config = await loadConfig();
   const effectiveChain: string | undefined = opts.chain;
   let pallet: string | undefined;
@@ -247,11 +264,11 @@ export async function handleTx(
   const { name: chainName, chain: chainConfig } = resolveChain(config, effectiveChain);
 
   const decodeOnly = opts.encode || opts.toYaml || opts.toJson;
-  const signer = decodeOnly ? undefined : await resolveAccountSigner(opts.from!);
+  const signer = decodeOnly || opts.unsigned ? undefined : await resolveAccountSigner(opts.from!);
 
   let clientHandle: ClientHandle | undefined;
 
-  if (!decodeOnly) {
+  if (!decodeOnly || opts.unsigned) {
     clientHandle = await createChainClient(chainName, chainConfig, opts.rpc);
   }
 
@@ -277,7 +294,7 @@ export async function handleTx(
     const mortality = parseMortalityOption(opts.mortality);
     const at = parseAtOption(opts.at);
 
-    if (!decodeOnly) {
+    if (!decodeOnly || opts.unsigned) {
       const userExtOverrides = parseExtOption(opts.ext);
       const customSignedExtensions = buildCustomSignedExtensions(meta, userExtOverrides);
 
@@ -335,7 +352,7 @@ export async function handleTx(
         opts.parsedArgs !== undefined ? fileArgsToStrings(opts.parsedArgs) : args;
       const callData = await parseCallArgs(meta, palletInfo.name, callInfo.name, effectiveArgs);
 
-      if (opts.encode || opts.toYaml || opts.toJson) {
+      if ((opts.encode && !opts.unsigned) || opts.toYaml || opts.toJson) {
         const { codec, location } = meta.builder.buildCall(palletInfo.name, callInfo.name);
         const encodedArgs = codec.enc(callData);
         const fullCall = new Uint8Array([location[0], location[1], ...encodedArgs]);
@@ -361,6 +378,28 @@ export async function handleTx(
 
     // Decode for display (works for both paths)
     const decodedStr = decodeCall(meta, callHex);
+
+    // --- Unsigned dry-run ---
+    if (opts.dryRun && opts.unsigned) {
+      if (isJsonOutput(opts)) {
+        console.log(
+          formatJson({
+            chain: chainName,
+            unsigned: true,
+            callHex,
+            decoded: decodedStr,
+            estimatedFees: null,
+          }),
+        );
+        return;
+      }
+      console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
+      console.log(`  ${BOLD}Type:${RESET}   unsigned (bare)`);
+      console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
+      console.log(`  ${BOLD}Decode:${RESET} ${decodedStr}`);
+      console.log(`  ${BOLD}Fees:${RESET}   ${DIM}N/A (unsigned transaction)${RESET}`);
+      return;
+    }
 
     if (opts.dryRun) {
       const signerAddress = toSs58(signer!.publicKey);
@@ -410,6 +449,123 @@ export async function handleTx(
     }
 
     const waitLevel = parseWaitLevel(opts.wait);
+
+    // --- Unsigned submission ---
+    if (opts.unsigned) {
+      const callDataBytes = await tx.getEncodedData();
+      const userExtOverrides = parseExtOption(opts.ext);
+      const generalTx = buildGeneralTx(meta, callDataBytes, userExtOverrides);
+
+      if (opts.encode) {
+        const hex = Binary.toHex(generalTx);
+        if (isJsonOutput(opts)) {
+          console.log(formatJson({ generalTxHex: hex }));
+        } else {
+          console.log(hex);
+        }
+        return;
+      }
+
+      const observable = clientHandle!.client.submitAndWatch(
+        generalTx,
+        at,
+      ) as import("rxjs").Observable<TxEvent>;
+
+      if (isJsonOutput(opts)) {
+        const result = await watchTransactionJson(observable, waitLevel, { unsigned: true });
+        const rpcUrl = primaryRpc(opts.rpc ?? chainConfig.rpc);
+        if (result.type === "broadcasted") {
+          printJsonLine({ event: "broadcasted", txHash: result.txHash });
+          return;
+        }
+        const blockHash = result.block.hash;
+        const explorer: Record<string, string> = {};
+        if (rpcUrl) {
+          explorer.polkadotjs = pjsAppsLink(rpcUrl, blockHash);
+          explorer.papi = papiLink(rpcUrl, blockHash);
+        }
+        printJsonLine({
+          event: result.type === "finalized" ? "finalized" : "bestBlock",
+          unsigned: true,
+          blockNumber: result.block.number,
+          blockHash,
+          txHash: result.txHash,
+          ok: result.ok,
+          events: result.events?.map((e: any) => ({
+            pallet: e.type,
+            name: e.value?.type,
+            fields: e.value?.value,
+          })),
+          dispatchError: result.ok ? null : formatDispatchError(result.dispatchError),
+          explorer,
+        });
+        if (!result.ok) {
+          throw new CliError(
+            `Transaction dispatch error: ${formatDispatchError(result.dispatchError)}`,
+          );
+        }
+        return;
+      }
+
+      const result = await watchTransaction(observable, waitLevel, { unsigned: true });
+
+      console.log();
+      console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
+      console.log(`  ${BOLD}Type:${RESET}   unsigned (bare)`);
+      console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
+      console.log(`  ${BOLD}Decode:${RESET} ${decodedStr}`);
+      console.log(`  ${BOLD}Tx:${RESET}     ${result.txHash}`);
+
+      if (result.type === "broadcasted") {
+        console.log(`  ${BOLD}Status:${RESET} ${GREEN}broadcasted${RESET}`);
+        console.log(`  ${DIM}Note: tx was broadcast but not yet included in a block${RESET}`);
+        console.log();
+        return;
+      }
+
+      let dispatchErrorMsg: string | undefined;
+      if (result.ok) {
+        const hint =
+          result.type === "txBestBlocksState"
+            ? ` ${DIM}(best block, not yet finalized)${RESET}`
+            : "";
+        console.log(`  ${BOLD}Status:${RESET} ${GREEN}ok${RESET}${hint}`);
+      } else {
+        dispatchErrorMsg = formatDispatchError(result.dispatchError);
+        console.log(`  ${BOLD}Status:${RESET} ${RED}dispatch error${RESET}`);
+        console.log(`  ${BOLD}Error:${RESET}  ${dispatchErrorMsg}`);
+      }
+
+      if (result.events && result.events.length > 0) {
+        console.log(`  ${BOLD}Events:${RESET}`);
+        for (const event of result.events) {
+          const name = `${CYAN}${event.type}${RESET}.${CYAN}${event.value?.type ?? ""}${RESET}`;
+          const payload = event.value?.value;
+          if (payload && typeof payload === "object") {
+            const fields = Object.entries(payload)
+              .map(([k, v]) => `${k}: ${formatEventValue(v)}`)
+              .join(", ");
+            console.log(`    ${name} { ${fields} }`);
+          } else {
+            console.log(`    ${name}`);
+          }
+        }
+      }
+
+      const rpcUrl = primaryRpc(opts.rpc ?? chainConfig.rpc);
+      if (rpcUrl) {
+        const blockHash = result.block.hash;
+        console.log(`  ${BOLD}Block:${RESET}  #${result.block.number} (${blockHash})`);
+        console.log(`  ${DIM}${pjsAppsLink(rpcUrl, blockHash)}${RESET}`);
+        console.log(`  ${DIM}${papiLink(rpcUrl, blockHash)}${RESET}`);
+      }
+      console.log();
+
+      if (!result.ok) {
+        throw new CliError(`Transaction dispatch error: ${dispatchErrorMsg}`);
+      }
+      return;
+    }
 
     // JSON output: NDJSON stream
     if (isJsonOutput(opts)) {
@@ -1326,6 +1482,143 @@ function autoDefaultForType(entry: any): any {
   return NO_DEFAULT;
 }
 
+// --- General (unsigned) transaction construction ---
+
+/**
+ * Determine the default "extra" (transaction body) value for an extension
+ * in an unsigned general transaction. More aggressive than autoDefaultForType:
+ * also handles primitives, compacts, enums with Immortal, and structs.
+ */
+function unsignedDefaultForType(identifier: string, entry: any): any {
+  // Handle well-known builtin extensions with specific unsigned defaults
+  switch (identifier) {
+    case "CheckMortality":
+      return { type: "Immortal" };
+    case "CheckNonce":
+      return 0;
+    case "ChargeTransactionPayment":
+      return 0n;
+    case "ChargeAssetTxPayment":
+      return { tip: 0n, asset_id: undefined };
+  }
+
+  // Try the existing auto-default logic (void, option, enum with Disabled)
+  const auto = autoDefaultForType(entry);
+  if (auto !== NO_DEFAULT) return auto;
+
+  // Additional defaults for unsigned transactions
+  if (entry.type === "primitive") {
+    switch (entry.value) {
+      case "bool":
+        return false;
+      case "u8":
+      case "u16":
+      case "u32":
+      case "i8":
+      case "i16":
+      case "i32":
+        return 0;
+      case "u64":
+      case "u128":
+      case "u256":
+      case "i64":
+      case "i128":
+      case "i256":
+        return 0n;
+      case "str":
+      case "char":
+        return "";
+    }
+  }
+  if (entry.type === "compact") return 0;
+
+  // Enum: pick first variant that is void (simplest default)
+  if (entry.type === "enum") {
+    const variants = entry.value as Record<string, any>;
+    if ("Immortal" in variants) return { type: "Immortal" };
+    for (const [name, variant] of Object.entries(variants)) {
+      if ((variant as any).type === "void") return { type: name };
+    }
+  }
+
+  return NO_DEFAULT;
+}
+
+/**
+ * Build a v5 general transaction (0x45) with all extension "extra" values
+ * defaulted for unsigned/authorized submission.
+ *
+ * Byte layout:
+ *   compact(payload_len) | 0x45 | ext_version(0x00) | ext_extras... | call_data
+ */
+function buildGeneralTx(
+  meta: MetadataBundle,
+  callData: Uint8Array,
+  userExtOverrides: Record<string, any>,
+): Uint8Array {
+  const extensions = getSignedExtensions(meta);
+  const extBytes: Uint8Array[] = [];
+
+  for (const ext of extensions) {
+    const valueEntry = meta.lookup(ext.type);
+
+    // void types encode as nothing
+    if (valueEntry.type === "void") continue;
+
+    // Check for user override
+    let value: any;
+    if (ext.identifier in userExtOverrides) {
+      const override = userExtOverrides[ext.identifier];
+      value = override.value !== undefined ? override.value : override;
+    } else {
+      value = unsignedDefaultForType(ext.identifier, valueEntry);
+      if (value === NO_DEFAULT) {
+        throw new CliError(
+          `Cannot determine default unsigned value for extension "${ext.identifier}" ` +
+            `(type: ${valueEntry.type}). Provide it via --ext '{"${ext.identifier}":{"value":...}}'`,
+        );
+      }
+    }
+
+    // SCALE-encode the value using the metadata builder
+    const codec = meta.builder.buildDefinition(ext.type);
+    extBytes.push(codec.enc(value));
+  }
+
+  // Assemble: 0x45 | ext_version(0x00) | ext_extras | call_data
+  const extVersion = new Uint8Array([0x00]);
+  const versionByte = new Uint8Array([0x45]);
+
+  // Calculate total payload length
+  let payloadLen = 1 + 1; // version byte + ext version
+  for (const b of extBytes) payloadLen += b.length;
+  payloadLen += callData.length;
+
+  const lengthPrefix = scaleCompact.enc(payloadLen);
+
+  // Concatenate all parts
+  const total = new Uint8Array(lengthPrefix.length + payloadLen);
+  let offset = 0;
+
+  total.set(lengthPrefix, offset);
+  offset += lengthPrefix.length;
+
+  total.set(versionByte, offset);
+  offset += 1;
+
+  total.set(extVersion, offset);
+  offset += 1;
+
+  for (const b of extBytes) {
+    total.set(b, offset);
+    offset += b.length;
+  }
+
+  total.set(callData, offset);
+
+  return total;
+}
+
 // --- Progressive transaction tracking ---
 
 type WatchResult = TxFinalized | (TxBestBlocksState & { found: true }) | TxBroadcasted;
@@ -1333,19 +1626,22 @@ type WatchResult = TxFinalized | (TxBestBlocksState & { found: true }) | TxBroad
 function watchTransaction(
   observable: import("rxjs").Observable<TxEvent>,
   level: WaitLevel,
+  options?: { unsigned?: boolean },
 ): Promise<WatchResult> {
   const spinner = new Spinner();
   return new Promise<WatchResult>((resolve, reject) => {
     let settled = false;
-    spinner.start("Signing...");
+    spinner.start(options?.unsigned ? "Submitting..." : "Signing...");
     const subscription = observable.subscribe({
       next(event: TxEvent) {
         if (settled) return;
         switch (event.type) {
           case "signed":
-            spinner.succeed("Signed");
-            console.log(`  ${BOLD}Tx:${RESET}     ${event.txHash}`);
-            spinner.start("Broadcasting...");
+            if (!options?.unsigned) {
+              spinner.succeed("Signed");
+              console.log(`  ${BOLD}Tx:${RESET}     ${event.txHash}`);
+              spinner.start("Broadcasting...");
+            }
             break;
           case "broadcasted":
             if (level === "broadcast") {
@@ -1392,6 +1688,7 @@ function watchTransaction(
 function watchTransactionJson(
   observable: import("rxjs").Observable<TxEvent>,
   level: WaitLevel,
+  options?: { unsigned?: boolean },
 ): Promise<WatchResult> {
   return new Promise<WatchResult>((resolve, reject) => {
     let settled = false;
@@ -1400,7 +1697,9 @@ function watchTransactionJson(
         if (settled) return;
         switch (event.type) {
           case "signed":
-            printJsonLine({ event: "signed", txHash: event.txHash });
+            if (!options?.unsigned) {
+              printJsonLine({ event: "signed", txHash: event.txHash });
+            }
             break;
           case "broadcasted":
             printJsonLine({ event: "broadcasted", txHash: event.txHash });
@@ -1437,6 +1736,7 @@ function watchTransactionJson(
 export {
   autoDefaultForType,
   buildCustomSignedExtensions,
+  buildGeneralTx,
   decodeCallFallback,
   decodeCallToFileFormat,
   formatDispatchError,
@@ -1452,4 +1752,5 @@ export {
   parseTypedArg,
   sanitizeForSerialization,
   typeHint,
+  unsignedDefaultForType,
 };

--- a/src/completions/complete.ts
+++ b/src/completions/complete.ts
@@ -40,6 +40,7 @@ const ACCOUNT_SUBCOMMANDS = [
 const GLOBAL_OPTIONS = ["--chain", "--rpc", "--output", "--help", "--version"];
 const TX_OPTIONS = [
   "--from",
+  "--unsigned",
   "--dry-run",
   "--encode",
   "--ext",

--- a/src/core/file-loader.test.ts
+++ b/src/core/file-loader.test.ts
@@ -515,4 +515,49 @@ tx:
     );
     await expect(loadCommandFile(path, {})).rejects.toThrow("exactly one item");
   });
+
+  // --- unsigned field ---
+
+  test("parses unsigned: true from JSON", async () => {
+    const path = await writeTemp(
+      "unsigned.json",
+      JSON.stringify({
+        chain: "people",
+        unsigned: true,
+        tx: { People: { create_people_collection: null } },
+      }),
+    );
+    const result = await loadCommandFile(path, {});
+    expect(result.unsigned).toBe(true);
+    expect(result.chain).toBe("people");
+    expect(result.pallet).toBe("People");
+    expect(result.item).toBe("create_people_collection");
+  });
+
+  test("parses unsigned: true from YAML", async () => {
+    const path = await writeTemp(
+      "unsigned.yaml",
+      "chain: people\nunsigned: true\ntx:\n  People:\n    create_people_collection: null\n",
+    );
+    const result = await loadCommandFile(path, {});
+    expect(result.unsigned).toBe(true);
+  });
+
+  test("unsigned defaults to undefined when not set", async () => {
+    const path = await writeTemp(
+      "no-unsigned.json",
+      JSON.stringify({ tx: { System: { remark: null } } }),
+    );
+    const result = await loadCommandFile(path, {});
+    expect(result.unsigned).toBeUndefined();
+  });
+
+  test("unsigned: false is treated as undefined", async () => {
+    const path = await writeTemp(
+      "unsigned-false.json",
+      JSON.stringify({ unsigned: false, tx: { System: { remark: null } } }),
+    );
+    const result = await loadCommandFile(path, {});
+    expect(result.unsigned).toBeUndefined();
+  });
 });

--- a/src/core/file-loader.ts
+++ b/src/core/file-loader.ts
@@ -11,6 +11,7 @@ export interface ParsedFileCommand {
   pallet: string;
   item: string;
   args: unknown; // object | array | scalar | undefined
+  unsigned?: boolean;
 }
 
 /** File extensions recognized as command files */
@@ -177,6 +178,7 @@ export async function loadCommandFile(
 
   // Extract metadata
   const chain = doc.chain != null ? String(doc.chain) : undefined;
+  const unsigned = doc.unsigned === true ? true : undefined;
 
   // Find the category key
   const foundCategories = CATEGORIES.filter((c) => c in doc);
@@ -236,5 +238,6 @@ export async function loadCommandFile(
     pallet,
     item,
     args: args ?? undefined,
+    unsigned,
   };
 }


### PR DESCRIPTION
## Summary

- Add `--unsigned` flag to the `tx` command for submitting v5 general transactions without a signer
- Enables governance-authorized calls (e.g. `People.create_people_collection`) where authorization comes from on-chain mechanisms (`AuthorizeCall` extension) rather than cryptographic signatures
- Constructs v5 general transaction (`0x45` format) with all signed extension values auto-defaulted (`VerifySignature::Disabled`, `Era::Immortal`, nonce `0`, tip `0`, etc.)
- Supports `--dry-run`, `--encode`, `--json`, `--ext` overrides, and file-based input with `unsigned: true`
- `--unsigned` is mutually exclusive with `--from`, `--nonce`, `--tip`, `--mortality`

## Test plan

- [x] Unit tests for `unsignedDefaultForType` (12 tests covering void, option, enum, primitive, compact, struct, builtins)
- [x] Unit tests for `buildGeneralTx` (2 tests: version byte header, call data placement)
- [x] CLI integration tests for flag validation (5 tests: mutual exclusivity with `--from`, `--nonce`, `--tip`, `--mortality`, gate logic)
- [x] File-loader tests for `unsigned: true` field (4 tests: JSON, YAML, default, false)
- [x] Completions test: `--unsigned` in TX_OPTIONS
- [x] Full test suite: 1209 pass, 0 fail
- [x] E2E verified against `preview-people` chain (general tx format accepted, `People.create_people_collection` dispatched successfully)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)