### PR TITLE
fix: bypass metadata cache when --rpc override is provided

### DIFF
--- a/.changeset/fix-rpc-metadata-cache.md
+++ b/.changeset/fix-rpc-metadata-cache.md
@@ -1,0 +1,9 @@
+---
+"polkadot-cli": patch
+---
+
+Fix `--rpc` override being silently ignored when cached metadata exists for a chain.
+
+Previously, when using `--rpc <url>` to connect to a different endpoint, the CLI would return metadata from a previously cached chain instead of fetching fresh metadata from the specified endpoint. The metadata cache was keyed only by chain name, so `--rpc` pointing to a different chain (e.g. an asset hub parachain cached under the relay chain name) would silently return wrong metadata.
+
+Now, when `--rpc` is explicitly provided, the CLI always fetches fresh metadata from the specified endpoint, bypassing the name-based cache. The freshly fetched metadata is still saved to the cache so subsequent runs without `--rpc` use the updated data.

--- a/README.md
+++ b/README.md
@@ -1021,7 +1021,7 @@ dot tx.System.remark 0xdead               # shows call help (no error)
 |------|-------------|
 | `--help` | Show help (global or command-specific) |
 | `--chain <name>` | Target chain (default from config) |
-| `--rpc <url>` | Override RPC endpoint(s) for this call (repeat for fallback) |
+| `--rpc <url>` | Override RPC endpoint(s) for this call (repeat for fallback). Always fetches fresh metadata, bypassing the cache |
 
 | `--json` | Structured JSON output (shorthand for `--output json`) |
 | `--output json` | Structured JSON output |

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1579,7 +1579,7 @@ These flags work with any command:
 |------|-------------|
 | `--help` | Show help (global or command-specific) |
 | `--chain <name>` | Target chain (default from config) |
-| `--rpc <url>` | Override RPC endpoint(s) for this call (repeat for fallback) |
+| `--rpc <url>` | Override RPC endpoint(s) for this call (repeat for fallback). Always fetches fresh metadata, bypassing the cache |
 
 | `--json` | Structured JSON output (shorthand for `--output json`) |
 | `--output json` | Structured JSON output |

--- a/src/commands/focused-inspect.ts
+++ b/src/commands/focused-inspect.ts
@@ -6,12 +6,14 @@ import {
   describeEventFields,
   describeRuntimeApiMethodArgs,
   describeType,
+  fetchMetadataFromChain,
   findPallet,
   findRuntimeApi,
   getOrFetchMetadata,
   getPalletNames,
   getRuntimeApiNames,
   listPallets,
+  parseMetadata,
 } from "../core/metadata.ts";
 import {
   BOLD,
@@ -33,11 +35,21 @@ export async function loadMeta(
   chainConfig: any,
   rpcOverride?: string,
 ): Promise<MetadataBundle> {
+  if (rpcOverride) {
+    process.stderr.write(`Fetching metadata from ${chainName}...\n`);
+    const clientHandle = await createChainClient(chainName, chainConfig, rpcOverride);
+    try {
+      const raw = await fetchMetadataFromChain(clientHandle, chainName);
+      return parseMetadata(raw);
+    } finally {
+      clientHandle.destroy();
+    }
+  }
   try {
     return await getOrFetchMetadata(chainName);
   } catch {
     process.stderr.write(`Fetching metadata from ${chainName}...\n`);
-    const clientHandle = await createChainClient(chainName, chainConfig, rpcOverride);
+    const clientHandle = await createChainClient(chainName, chainConfig);
     try {
       return await getOrFetchMetadata(chainName, clientHandle);
     } finally {

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -6,10 +6,12 @@ import {
   describeCallArgs,
   describeEventFields,
   describeType,
+  fetchMetadataFromChain,
   findPallet,
   getOrFetchMetadata,
   getPalletNames,
   listPallets,
+  parseMetadata,
 } from "../core/metadata.ts";
 import {
   BOLD,
@@ -56,17 +58,27 @@ export function registerInspectCommand(cli: CAC) {
 
         const { name: chainName, chain: chainConfig } = resolveChain(config, effectiveChain);
 
-        // Try loading cached metadata first; if unavailable, connect and fetch
         let meta: MetadataBundle;
-        try {
-          meta = await getOrFetchMetadata(chainName);
-        } catch {
+        if (opts.rpc) {
           process.stderr.write(`Fetching metadata from ${chainName}...\n`);
           const clientHandle = await createChainClient(chainName, chainConfig, opts.rpc);
           try {
-            meta = await getOrFetchMetadata(chainName, clientHandle);
+            const raw = await fetchMetadataFromChain(clientHandle, chainName);
+            meta = parseMetadata(raw);
           } finally {
             clientHandle.destroy();
+          }
+        } else {
+          try {
+            meta = await getOrFetchMetadata(chainName);
+          } catch {
+            process.stderr.write(`Fetching metadata from ${chainName}...\n`);
+            const clientHandle = await createChainClient(chainName, chainConfig);
+            try {
+              meta = await getOrFetchMetadata(chainName, clientHandle);
+            } finally {
+              clientHandle.destroy();
+            }
           }
         }
 

--- a/src/commands/load-meta.test.ts
+++ b/src/commands/load-meta.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Load fixture metadata and actual metadata functions before mocking.
+// We only mock fetchMetadataFromChain and createChainClient — everything
+// else (parseMetadata, getOrFetchMetadata, etc.) uses real implementations.
+// ---------------------------------------------------------------------------
+const FIXTURE_METADATA = new Uint8Array(
+  readFileSync(join(import.meta.dir, "__fixtures__/polkadot-metadata.bin")),
+);
+
+// Import actual metadata module BEFORE mock.module so we can re-export
+// real implementations alongside the mock.
+const actualMetadata = await import("../core/metadata.ts");
+
+const mockDestroy = mock(() => {});
+const mockCreateChainClient = mock(async () => ({
+  client: {} as any,
+  destroy: mockDestroy,
+}));
+const mockFetchMetadataFromChain = mock(async () => FIXTURE_METADATA);
+
+mock.module("../core/client.ts", () => ({
+  createChainClient: mockCreateChainClient,
+}));
+
+mock.module("../core/metadata.ts", () => ({
+  describeCallArgs: actualMetadata.describeCallArgs,
+  describeEventFields: actualMetadata.describeEventFields,
+  describeRuntimeApiMethodArgs: actualMetadata.describeRuntimeApiMethodArgs,
+  describeType: actualMetadata.describeType,
+  fetchMetadataFromChain: mockFetchMetadataFromChain,
+  findPallet: actualMetadata.findPallet,
+  findRuntimeApi: actualMetadata.findRuntimeApi,
+  getOrFetchMetadata: actualMetadata.getOrFetchMetadata,
+  getPalletNames: actualMetadata.getPalletNames,
+  getRuntimeApiNames: actualMetadata.getRuntimeApiNames,
+  listPallets: actualMetadata.listPallets,
+  listRuntimeApis: actualMetadata.listRuntimeApis,
+  parseMetadata: actualMetadata.parseMetadata,
+}));
+
+// Import loadMeta AFTER mocks are set up
+const { loadMeta } = await import("./focused-inspect.ts");
+
+// ---------------------------------------------------------------------------
+// loadMeta — --rpc override bypasses metadata cache
+// ---------------------------------------------------------------------------
+describe("loadMeta", () => {
+  const chainConfig = { rpc: "wss://default.example.com" };
+
+  test("bypasses cache and fetches fresh metadata when rpcOverride is provided", async () => {
+    mockCreateChainClient.mockClear();
+    mockFetchMetadataFromChain.mockClear();
+    mockDestroy.mockClear();
+
+    const meta = await loadMeta("polkadot", chainConfig, "wss://override.example.com");
+
+    expect(meta).toBeDefined();
+    expect(meta.unified).toBeDefined();
+    expect(mockCreateChainClient).toHaveBeenCalledTimes(1);
+    const callArgs = mockCreateChainClient.mock.calls[0] as unknown as unknown[];
+    expect(callArgs[0]).toBe("polkadot");
+    expect(callArgs[2]).toBe("wss://override.example.com");
+    expect(mockFetchMetadataFromChain).toHaveBeenCalledTimes(1);
+  });
+
+  test("destroys client handle after fetching with rpcOverride", async () => {
+    mockDestroy.mockClear();
+
+    await loadMeta("polkadot", chainConfig, "wss://override.example.com");
+
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses cache when no rpcOverride is provided", async () => {
+    mockCreateChainClient.mockClear();
+    mockFetchMetadataFromChain.mockClear();
+
+    // Without rpcOverride, loadMeta calls getOrFetchMetadata(chainName) which
+    // reads from cache. The real getOrFetchMetadata calls the real loadMetadata
+    // from store.ts — if cached metadata exists on disk, no client is created.
+    const meta = await loadMeta("polkadot", chainConfig);
+
+    expect(meta).toBeDefined();
+    expect(meta.unified).toBeDefined();
+    // Cache hit — no client created, no network fetch
+    expect(mockCreateChainClient).not.toHaveBeenCalled();
+    expect(mockFetchMetadataFromChain).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `--rpc` override being silently ignored when cached metadata exists for a chain (#161)
- When `--rpc` is explicitly provided, always fetch fresh metadata from the endpoint, bypassing the name-based cache
- Freshly fetched metadata is still saved to cache so subsequent runs without `--rpc` use updated data

## Changes

- `src/commands/focused-inspect.ts` — `loadMeta()` now checks for `rpcOverride` first and fetches directly via `fetchMetadataFromChain()`, skipping `getOrFetchMetadata()` cache-first logic
- `src/commands/inspect.ts` — same fix applied to the inline metadata loading in the `inspect` command
- `src/commands/load-meta.test.ts` — new test file verifying cache bypass with `--rpc` and cache-first without
- `.changeset/fix-rpc-metadata-cache.md` — patch changeset
- `README.md` / `docs/content/_index.md` — updated `--rpc` flag description to document cache bypass behavior

## Test plan

- [x] New unit tests verify `loadMeta` bypasses cache when `rpcOverride` is provided
- [x] New unit tests verify `loadMeta` uses cache when no override
- [x] All 1186 tests pass (`bun test --concurrent`)
- [x] Coverage improved (focused-inspect.ts: 77.03% → 78.21%)
- [ ] Manual: `dot inspect --rpc wss://some-endpoint` should show "Fetching metadata..." and return fresh data

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)