### PR TITLE
feat!: remove implicit default chain

### DIFF
--- a/.changeset/remove-default-chain.md
+++ b/.changeset/remove-default-chain.md
@@ -1,0 +1,31 @@
+---
+"polkadot-cli": minor
+---
+
+Remove the default chain feature. Every command that targets a chain must now specify one explicitly — either via the `--chain <name>` flag or a dotpath chain prefix (e.g. `dot polkadot.query.System.Number`). When neither is provided, the CLI fails with a clear error listing the available chains instead of silently falling back to a saved default.
+
+**Why:** the implicit fallback made commands non-transparent — especially in scripts or when switching contexts, users could not tell which chain was actually being hit (see #158).
+
+**Breaking changes:**
+
+- `dot chain default <name>` subcommand removed.
+- `dot chain update` now requires a chain name or `--all`; it no longer implicitly targets a default chain.
+- `dot chain list` no longer prints a `(default)` marker, and `dot chain list --json` no longer includes a `default` field per chain.
+- The `--chain` global-option help text changed from "Target chain (default from config)" to "Target chain (required)".
+
+**Config migration:** any pre-existing `defaultChain` field in `~/.polkadot/config.json` is silently ignored on read and dropped on the next save — no manual migration needed.
+
+**Before:**
+
+```bash
+dot chain default kusama
+dot query.System.Number     # implicitly targeted kusama
+```
+
+**After:**
+
+```bash
+dot query.System.Number --chain kusama
+# or, equivalently:
+dot kusama.query.System.Number
+```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Ships with Polkadot and all system parachains preconfigured with multiple fallba
 
 | Network | Chain |
 |---------|-------|
-| Polkadot | `polkadot` (relay, default) |
+| Polkadot | `polkadot` (relay) |
 | | `polkadot-asset-hub` |
 | | `polkadot-bridge-hub` |
 | | `polkadot-collectives` |
@@ -82,12 +82,8 @@ dot chain add my-para --rpc wss://rpc.example.com --relay polkadot --parachain-i
 dot chain list
 
 # Re-fetch metadata after a runtime upgrade
-dot chain update          # updates default chain
 dot chain update kusama   # updates a specific chain
 dot chain update --all    # updates all configured chains in parallel
-
-# Set default chain
-dot chain default kusama
 
 # Remove a chain
 dot chain remove westend
@@ -100,7 +96,7 @@ dot chain remove westend
 ```
 Configured Chains
 
-  polkadot (default)  wss://polkadot.ibp.network
+  polkadot  wss://polkadot.ibp.network
   ├─ polkadot-asset-hub [1000]  wss://...
   ├─ polkadot-bridge-hub [1002]  wss://...
   ├─ polkadot-collectives [1001]  wss://...
@@ -117,6 +113,23 @@ Configured Chains
 All built-in system parachains are preconfigured with their relay chain and parachain ID. When adding a custom parachain with `--relay`, the CLI auto-detects the parachain ID from on-chain `ParachainInfo` storage. Use `--parachain-id` to set it explicitly if auto-detection is not available.
 
 Removing a relay chain that has parachains prints a warning listing the orphaned chains. The parachains remain in the config and can be re-associated later.
+
+#### Selecting a chain
+
+Every chain-consuming command must specify a chain explicitly — either with the global `--chain <name>` flag or with a dotpath chain prefix. There is no hidden default; running a command without a chain errors out with a message listing the configured chains.
+
+```bash
+# Via --chain flag
+dot query.System.Number --chain polkadot
+
+# Via dotpath chain prefix
+dot polkadot.query.System.Number
+
+# Both at once errors
+dot polkadot.query.System.Number --chain polkadot  # ✗ errors
+```
+
+Chain names are case-insensitive. The prefix form also works with the space-separated syntax (`dot query polkadot.System.Account ...`).
 
 #### Export/import chain configuration
 
@@ -376,9 +389,9 @@ dot inspect kusama.System
 dot inspect kusama.System.Account
 ```
 
-Chain names are case-insensitive — `Polkadot.System.Account`, `POLKADOT.System.Account`, and `polkadot.System.Account` all resolve the same way. The same applies to `--chain Polkadot` and `dot chain default Polkadot`.
+Chain names are case-insensitive — `Polkadot.System.Account`, `POLKADOT.System.Account`, and `polkadot.System.Account` all resolve the same way. The same applies to `--chain Polkadot`.
 
-The `--chain` flag and default chain still work as before. If both a chain prefix and `--chain` flag are provided, the CLI errors.
+Every invocation must specify a chain explicitly: either via a dotpath prefix (as above) or via `--chain <name>`. If both are provided, the CLI errors.
 
 ### Space-separated syntax
 
@@ -537,7 +550,6 @@ dot apis.Core.version --help
 Runtime API info requires v15 metadata. If `dot apis` shows 0 APIs, update the cached metadata:
 
 ```bash
-dot chain update              # default chain
 dot chain update people-paseo # specific chain
 dot chain update --all        # all configured chains
 ```
@@ -1155,7 +1167,7 @@ dot tx.System.remark 0xdead               # shows call help (no error)
 | Flag | Description |
 |------|-------------|
 | `--help` | Show help (global or command-specific) |
-| `--chain <name>` | Target chain (default from config) |
+| `--chain <name>` | Target chain (required unless a dotpath chain prefix is used) |
 | `--rpc <url>` | Override RPC endpoint(s) for this call (repeat for fallback). Always fetches fresh metadata, bypassing the cache |
 
 | `--json` | Structured JSON output (shorthand for `--output json`) |
@@ -1227,7 +1239,7 @@ dot apis.Core.<Tab>      # → apis.Core.version, ...
 dot polkadot.<Tab>       # → polkadot.query, polkadot.tx, ..., polkadot.apis
 dot --chain <Tab>        # → polkadot, paseo, ...
 dot --from <Tab>         # → alice, bob, ..., stored account names
-dot chain <Tab>          # → add, remove, update, list, default
+dot chain <Tab>          # → add, remove, update, list
 ```
 
 Completions are context-aware: `query.` shows pallets with storage items, `tx.` shows pallets with calls, `events.` and `errors.` filter accordingly, `apis.` shows runtime API names. Chain prefix paths like `polkadot.query.System.` work at any depth.
@@ -1276,7 +1288,7 @@ Config and metadata caches live in `~/.polkadot/`:
 
 ```
 ~/.polkadot/
-├── config.json          # chains and default chain
+├── config.json          # configured chains
 ├── accounts.json        # stored accounts (⚠️ secrets are NOT encrypted — see below)
 ├── update-check.json    # cached update check result
 └── chains/

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -36,7 +36,7 @@ This installs the `dot` command globally. Ships with Polkadot and all system par
 
 ## Chains
 
-Manage chain connections. Polkadot is configured by default along with all system parachains for both Polkadot and Paseo networks. Add any Substrate-based chain by pointing to its RPC endpoint(s).
+Manage chain connections. Polkadot and all system parachains for both Polkadot and Paseo networks come preconfigured. Add any Substrate-based chain by pointing to its RPC endpoint(s).
 
 ### Preconfigured chains
 
@@ -44,7 +44,7 @@ The following chains are available out of the box — no `dot chain add` needed:
 
 | Network | Chain |
 |---------|-------|
-| Polkadot | `polkadot` (relay, default) |
+| Polkadot | `polkadot` (relay) |
 | | `polkadot-asset-hub` |
 | | `polkadot-bridge-hub` |
 | | `polkadot-collectives` |
@@ -109,7 +109,7 @@ Both forms are equivalent. `dot chains` is a shorthand that skips the `list` sub
 ```
 Configured Chains
 
-  polkadot (default)  wss://polkadot.ibp.network
+  polkadot  wss://polkadot.ibp.network
   ├─ polkadot-asset-hub [1000]  wss://...
   ├─ polkadot-bridge-hub [1002]  wss://...
   ├─ polkadot-collectives [1001]  wss://...
@@ -127,20 +127,11 @@ Standalone chains (no `relay` field, not referenced as a relay by other chains) 
 
 ### Update metadata
 
-Re-fetch metadata after a runtime upgrade. Targets the default chain if no name is given:
+Re-fetch metadata after a runtime upgrade. Either name a specific chain or use `--all`:
 
 ```
-dot chain update
 dot chain update kusama
 dot chain update --all
-```
-
-### Set default chain
-
-Change which chain commands target by default:
-
-```
-dot chain default kusama
 ```
 
 ### Remove a chain
@@ -148,6 +139,20 @@ dot chain default kusama
 ```
 dot chain remove westend
 ```
+
+### Selecting a chain
+
+Every chain-consuming command must specify a chain explicitly — either with the global `--chain <name>` flag or with a dotpath chain prefix. There is no implicit default; running a command without a chain errors out with a message listing the configured chains.
+
+```
+# Via --chain flag
+dot query.System.Number --chain polkadot
+
+# Via dotpath chain prefix
+dot polkadot.query.System.Number
+```
+
+Providing both a dotpath prefix and `--chain` at once errors with a clear message. Chain names are case-insensitive. See [Chain Prefix](#chain-prefix) below for the full dotpath form.
 
 Removing a chain that other chains reference as their `relay` prints a warning listing orphaned parachains. The removal still proceeds — orphaned chains keep their `relay` field but render as standalone until the relay is re-added.
 
@@ -172,11 +177,10 @@ dot chain export --file my-chains.json
 dot chain export --all --file my-chains.json
 ```
 
-The export format is JSON with `defaultChain` and `chains` fields:
+The export format is JSON with a `chains` field:
 
 ```json
 {
-  "defaultChain": "my-local-relay",
   "chains": {
     "my-local-relay": { "rpc": ["ws://localhost:9944"] },
     "my-para": { "rpc": ["ws://localhost:9945"], "relay": "my-local-relay", "parachainId": 2000 }
@@ -206,7 +210,6 @@ Import behavior:
 
 - **Existing chains** are skipped with a warning unless `--overwrite` is passed
 - **Relay references** are validated — a warning is printed if a chain references a relay that doesn't exist in the import file or current config
-- **Default chain** is updated only when `--overwrite` is used
 - After import, run `dot chain update --all` to fetch metadata for the new chains
 
 ## Accounts
@@ -521,9 +524,9 @@ dot inspect kusama.System
 dot inspect kusama.System.Account
 ```
 
-Chain names are case-insensitive — `polkadot.query.System.Account`, `Polkadot.query.System.Account`, and `POLKADOT.query.System.Account` all resolve the same way. The same applies to `--chain Polkadot` and `dot chain default Polkadot`.
+Chain names are case-insensitive — `polkadot.query.System.Account`, `Polkadot.query.System.Account`, and `POLKADOT.query.System.Account` all resolve the same way. The same applies to `--chain Polkadot`.
 
-The `--chain` flag and default chain still work as before. Using a dot-path without a chain prefix continues to target the default chain. If both a chain prefix and `--chain` flag are provided, the CLI errors with a clear message.
+Every invocation must specify a chain explicitly: either via a dotpath prefix (as above) or via `--chain <name>`. If both are provided, the CLI errors with a clear message.
 
 For `inspect`, a two-segment input like `kusama.System` is disambiguated by checking configured chain names. Chain names (lowercase, e.g. `kusama`) and pallet names (PascalCase, e.g. `System`) don't collide in practice. If they did, the chain prefix takes priority and `--chain` serves as an escape hatch.
 
@@ -1725,7 +1728,7 @@ dot polkadot.query.<Tab> # → polkadot.query.System, ...
 dot --chain <Tab>        # → polkadot, paseo, ...
 dot --from <Tab>         # → alice, bob, ..., stored account names
 dot --output <Tab>       # → pretty, json
-dot chain <Tab>          # → add, remove, update, list, default
+dot chain <Tab>          # → add, remove, update, list
 dot account <Tab>        # → create, import, derive, list, remove, ...
 dot hash <Tab>           # → blake2b256, blake2b128, keccak256, sha256
 ```
@@ -1810,7 +1813,7 @@ These flags work with any command:
 | Flag | Description |
 |------|-------------|
 | `--help` | Show help (global or command-specific) |
-| `--chain <name>` | Target chain (default from config) |
+| `--chain <name>` | Target chain (required unless a dotpath chain prefix is used) |
 | `--rpc <url>` | Override RPC endpoint(s) for this call (repeat for fallback). Always fetches fresh metadata, bypassing the cache |
 
 | `--json` | Structured JSON output (shorthand for `--output json`) |
@@ -1889,7 +1892,7 @@ Config and metadata caches live in `~/.polkadot/`:
 
 ```
 ~/.polkadot/
-├── config.json          # chains and default chain
+├── config.json          # configured chains
 ├── accounts.json        # stored accounts
 ├── update-check.json    # cached update check result
 └── chains/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ if (process.argv[2] === "__complete") {
 
   const cli = cac("dot");
 
-  cli.option("--chain <name>", "Target chain (default from config)");
+  cli.option("--chain <name>", "Target chain (required)");
   cli.option("--rpc <url>", "Override RPC endpoint for this call");
   cli.option("--output <format>", "Output format: pretty or json", {
     default: "pretty",
@@ -327,7 +327,7 @@ if (process.argv[2] === "__complete") {
     console.log("  completions <sh>   Generate shell completions (zsh, bash, fish)");
     console.log();
     console.log("Global options:");
-    console.log("  --chain <name>     Target chain (default from config)");
+    console.log("  --chain <name>     Target chain (required)");
     console.log("  --rpc <url>        Override RPC endpoint");
     console.log("  --json             Output as JSON");
     console.log("  --output <format>  Output format: pretty or json");

--- a/src/commands/__fixtures__/run-cli.ts
+++ b/src/commands/__fixtures__/run-cli.ts
@@ -17,6 +17,8 @@ export interface RunCliOptions {
   files?: Record<string, string | Uint8Array>;
   stdin?: string | Uint8Array;
   env?: Record<string, string>;
+  /** Opt out of the default `--chain polkadot` auto-injection used by test fixtures. */
+  noDefaultChain?: boolean;
 }
 
 function deepMergeConfig(base: Config, override: Partial<Config>): Config {
@@ -33,10 +35,7 @@ function deepMergeConfig(base: Config, override: Partial<Config>): Config {
       }
     }
   }
-  return {
-    defaultChain: override.defaultChain ?? base.defaultChain,
-    chains,
-  };
+  return { chains };
 }
 
 export async function runCli(
@@ -79,6 +78,27 @@ export async function runCli(
 
   // Replace {{HOME}} placeholder in args
   const resolvedArgs = args.map((arg) => arg.replace(/\{\{HOME\}\}/g, tmpHome));
+
+  // Auto-inject `--chain polkadot` for command invocations so tests that don't
+  // care about chain resolution still work after the default-chain removal.
+  // Skip when:
+  //   - the test opts out (noDefaultChain),
+  //   - args already contain --chain,
+  //   - args[0] is __complete (its own --chain handling lives in precedingWords),
+  //   - any arg starts with a known chain name + "." (chain-prefixed dotpath).
+  const hasChainFlag = resolvedArgs.some((a) => a === "--chain" || a.startsWith("--chain="));
+  const isCompletion = resolvedArgs[0] === "__complete";
+  const chainPrefixRegex = new RegExp(`^(${Object.keys(finalConfig.chains).join("|")})\\.`, "i");
+  const hasChainPrefix = resolvedArgs.some((a) => chainPrefixRegex.test(a));
+  if (
+    !options?.noDefaultChain &&
+    !hasChainFlag &&
+    !isCompletion &&
+    !hasChainPrefix &&
+    resolvedArgs.length > 0
+  ) {
+    resolvedArgs.push("--chain", "polkadot");
+  }
 
   try {
     const spawnOpts: Parameters<typeof Bun.spawn>[1] = {

--- a/src/commands/chain-required.test.ts
+++ b/src/commands/chain-required.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { runCli } from "./__fixtures__/run-cli.ts";
+
+// End-to-end tests for the "no default chain" contract:
+// every chain-consuming command must have a chain source (flag or dotpath prefix).
+
+// @ts-expect-error Bun supports describe(label, options, fn) at runtime
+describe("chain is required (no default chain fallback)", { timeout: 15_000 }, () => {
+  test("dot query.System.Number errors without --chain or prefix", async () => {
+    const { stderr, exitCode } = await runCli(["query.System.Number"], { noDefaultChain: true });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No chain specified");
+    expect(stderr).toContain("--chain");
+    expect(stderr).toContain("polkadot");
+  });
+
+  test("dot tx.System.remark errors without --chain or prefix", async () => {
+    const { stderr, exitCode } = await runCli(["tx.System.remark", "0xdead", "--from", "alice"], {
+      noDefaultChain: true,
+    });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No chain specified");
+  });
+
+  test("dot const.Balances.ExistentialDeposit errors without --chain or prefix", async () => {
+    const { stderr, exitCode } = await runCli(["const.Balances.ExistentialDeposit"], {
+      noDefaultChain: true,
+    });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No chain specified");
+  });
+
+  test("dot events.Balances errors without --chain or prefix", async () => {
+    const { stderr, exitCode } = await runCli(["events.Balances"], { noDefaultChain: true });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No chain specified");
+  });
+
+  test("dot errors.Balances errors without --chain or prefix", async () => {
+    const { stderr, exitCode } = await runCli(["errors.Balances"], { noDefaultChain: true });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No chain specified");
+  });
+
+  test("dot apis.Core errors without --chain or prefix", async () => {
+    const { stderr, exitCode } = await runCli(["apis.Core"], { noDefaultChain: true });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No chain specified");
+  });
+
+  test("dot inspect System errors without --chain or prefix", async () => {
+    const { stderr, exitCode } = await runCli(["inspect", "System"], { noDefaultChain: true });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No chain specified");
+  });
+
+  test("error message lists available chains", async () => {
+    const { stderr, exitCode } = await runCli(["query.System.Number"], { noDefaultChain: true });
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/Available chains:.*polkadot/);
+    expect(stderr).toMatch(/Available chains:.*paseo/);
+  });
+
+  test("--chain flag satisfies the requirement", async () => {
+    const { stdout, exitCode } = await runCli(
+      ["const.Balances.ExistentialDeposit", "--chain", "polkadot"],
+      { noDefaultChain: true },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toBeDefined();
+  });
+
+  test("dotpath chain prefix satisfies the requirement", async () => {
+    const { stdout, exitCode } = await runCli(["polkadot.const.Balances.ExistentialDeposit"], {
+      noDefaultChain: true,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBeDefined();
+  });
+
+  test("both --chain and dotpath prefix at once errors", async () => {
+    const { stderr, exitCode } = await runCli(
+      ["polkadot.const.Balances.ExistentialDeposit", "--chain", "polkadot"],
+      { noDefaultChain: true },
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Chain specified both as prefix");
+  });
+
+  test("cli help text advertises --chain as required", async () => {
+    const { stdout, exitCode } = await runCli([]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--chain");
+    expect(stdout).toContain("required");
+    expect(stdout).not.toContain("default from config");
+  });
+
+  test("chain list --json does not expose a default field", async () => {
+    const { stdout, exitCode } = await runCli(["chain", "list", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    for (const chain of parsed.chains) {
+      expect(chain.default).toBeUndefined();
+    }
+  });
+});

--- a/src/commands/chain.test.ts
+++ b/src/commands/chain.test.ts
@@ -35,7 +35,7 @@ describe("dot chain", () => {
     const { stdout, exitCode } = await runCli(["chain", "list"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("polkadot");
-    expect(stdout).toContain("(default)");
+    expect(stdout).not.toContain("(default)");
     expect(stdout).toContain("rpc.polkadot.io");
     expect(stdout).toContain("paseo");
     // Polkadot system parachains
@@ -144,29 +144,16 @@ describe("dot chain", () => {
     expect(stdout).not.toContain("light-client");
   });
 
-  test("default kusama succeeds", async () => {
-    const { stdout, exitCode } = await runCli(["chain", "default", "kusama"], {
-      config: {
-        chains: {
-          kusama: { rpc: "wss://kusama-rpc.polkadot.io" },
-        },
-      },
-    });
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("Default chain set");
+  test("default action is now unknown (feature removed)", async () => {
+    const { stderr, exitCode } = await runCli(["chain", "default", "kusama"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Unknown action "default"');
   });
 
-  test("default (no name) errors", async () => {
-    const { stderr, exitCode } = await runCli(["chain", "default"]);
+  test("update (no name, no --all) errors with usage", async () => {
+    const { stderr, exitCode } = await runCli(["chain", "update"]);
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("Usage:");
-  });
-
-  test("default nonexistent errors", async () => {
-    const { stderr, exitCode } = await runCli(["chain", "default", "nonexistent"]);
-    expect(exitCode).toBe(1);
-    expect(stderr).toContain("not found");
-    expect(stderr).toContain("Available");
+    expect(stderr).toContain("Usage: dot chain update");
   });
 
   test("remove kusama succeeds", async () => {
@@ -229,19 +216,6 @@ describe("dot chain", () => {
     expect(stderr).toContain("Usage:");
   });
 
-  test("remove default chain resets to polkadot", async () => {
-    const { stdout, exitCode } = await runCli(["chain", "remove", "kusama"], {
-      config: {
-        defaultChain: "kusama",
-        chains: {
-          kusama: { rpc: "wss://kusama-rpc.polkadot.io" },
-        },
-      },
-    });
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain('Default chain reset to "polkadot"');
-  });
-
   test("add (no name) errors", async () => {
     const { stderr, exitCode } = await runCli(["chain", "add"]);
     expect(exitCode).toBe(1);
@@ -266,18 +240,6 @@ describe("dot chain", () => {
     expect(stderr).toContain("Cannot remove");
   });
 
-  test("default Polkadot (case-insensitive) succeeds", async () => {
-    const { stdout, exitCode } = await runCli(["chain", "default", "Polkadot"]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain('Default chain set to "polkadot"');
-  });
-
-  test("default POLKADOT (all-caps) succeeds", async () => {
-    const { stdout, exitCode } = await runCli(["chain", "default", "POLKADOT"]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain('Default chain set to "polkadot"');
-  });
-
   // --json output tests
   test("list --json returns valid JSON with all chains", async () => {
     const { stdout, exitCode } = await runCli(["chain", "list", "--json"]);
@@ -286,7 +248,7 @@ describe("dot chain", () => {
     expect(Array.isArray(parsed.chains)).toBe(true);
     const polkadot = parsed.chains.find((c: any) => c.name === "polkadot");
     expect(polkadot).toBeDefined();
-    expect(polkadot.default).toBe(true);
+    expect(polkadot.default).toBeUndefined();
     expect(Array.isArray(polkadot.rpc)).toBe(true);
     expect(polkadot.rpc[0]).toContain("polkadot");
   });
@@ -296,14 +258,6 @@ describe("dot chain", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(Array.isArray(parsed.chains)).toBe(true);
-  });
-
-  test("default --json returns action JSON", async () => {
-    const { stdout, exitCode } = await runCli(["chain", "default", "polkadot", "--json"]);
-    expect(exitCode).toBe(0);
-    const parsed = JSON.parse(stdout);
-    expect(parsed.action).toBe("default");
-    expect(parsed.chain).toBe("polkadot");
   });
 
   // Topology tests
@@ -533,7 +487,6 @@ describe("dot chain", () => {
     const { stdout, exitCode } = await runCli(["chain", "export"]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.defaultChain).toBe("polkadot");
     expect(Object.keys(parsed.chains).length).toBe(0);
   });
 

--- a/src/commands/chain.ts
+++ b/src/commands/chain.ts
@@ -33,10 +33,9 @@ const CHAIN_HELP = `
 ${BOLD}Usage:${RESET}
   $ dot chain add <name> --rpc <url>    Add a chain via WebSocket RPC
   $ dot chain remove <name>             Remove a chain
-  $ dot chain update [name]             Re-fetch metadata (default chain if omitted)
+  $ dot chain update <name>             Re-fetch metadata for a chain
   $ dot chain update --all              Re-fetch metadata for all configured chains
   $ dot chain list                      List configured chains
-  $ dot chain default <name>            Set the default chain
   $ dot chain export [names...]         Export chain configuration to stdout
   $ dot chain import <file>             Import chain configuration from a file
 
@@ -45,9 +44,7 @@ ${BOLD}Examples:${RESET}
   $ dot chain add kusama --rpc wss://kusama-rpc.polkadot.io --rpc wss://kusama-rpc.dwellir.com
   $ dot chain add my-para --rpc wss://rpc.example.com --relay polkadot
   $ dot chain add my-para --rpc wss://rpc.example.com --relay polkadot --parachain-id 2000
-  $ dot chain default kusama
   $ dot chain list
-  $ dot chain update
   $ dot chain update kusama
   $ dot chain update --all
   $ dot chain remove kusama
@@ -63,7 +60,7 @@ export function registerChainCommands(cli: CAC) {
   cli
     .command(
       "chain [action] [...names]",
-      "Manage chains (add, remove, update, list, default, export, import)",
+      "Manage chains (add, remove, update, list, export, import)",
     )
     .alias("chains")
     .option("--all", "Update/export all configured chains")
@@ -102,8 +99,6 @@ export function registerChainCommands(cli: CAC) {
             return chainList(opts);
           case "update":
             return chainUpdate(names[0], opts);
-          case "default":
-            return chainDefault(names[0], opts);
           case "export":
             return chainExport(names, opts);
           case "import":
@@ -230,11 +225,6 @@ async function chainRemove(
 
   delete config.chains[resolved];
 
-  if (config.defaultChain === resolved) {
-    config.defaultChain = "polkadot";
-    if (!isJsonOutput(opts)) console.log(`Default chain reset to "polkadot".`);
-  }
-
   await saveConfig(config);
   await removeChainData(resolved);
 
@@ -251,7 +241,6 @@ async function chainList(opts: { output?: string; json?: boolean } = {}) {
   if (isJsonOutput(opts)) {
     const chains = Object.entries(config.chains).map(([name, chainConfig]) => ({
       name,
-      default: name === config.defaultChain,
       rpc: Array.isArray(chainConfig.rpc) ? chainConfig.rpc : [chainConfig.rpc],
       ...(chainConfig.relay && { relay: chainConfig.relay }),
       ...(chainConfig.parachainId != null && { parachainId: chainConfig.parachainId }),
@@ -284,7 +273,7 @@ async function chainList(opts: { output?: string; json?: boolean } = {}) {
   for (const relayName of relayNames) {
     const relayConfig = config.chains[relayName];
     if (relayConfig) {
-      printChainLine("  ", relayName, relayConfig, config.defaultChain);
+      printChainLine("  ", relayName, relayConfig);
     }
 
     const paras = parachainsByRelay.get(relayName) ?? [];
@@ -294,28 +283,20 @@ async function chainList(opts: { output?: string; json?: boolean } = {}) {
       const prefix = isLast ? "  └─ " : "  ├─ ";
       const idSuffix =
         chainConfig.parachainId != null ? ` ${DIM}[${chainConfig.parachainId}]${RESET}` : "";
-      printChainLine(prefix, name, chainConfig, config.defaultChain, idSuffix);
+      printChainLine(prefix, name, chainConfig, idSuffix);
     }
     console.log();
   }
 
   for (const [name, chainConfig] of standalone) {
-    printChainLine("  ", name, chainConfig, config.defaultChain);
+    printChainLine("  ", name, chainConfig);
   }
   if (standalone.length > 0) console.log();
 }
 
-function printChainLine(
-  prefix: string,
-  name: string,
-  chainConfig: ChainConfig,
-  defaultChain: string,
-  suffix = "",
-) {
-  const isDefault = name === defaultChain;
-  const marker = isDefault ? ` ${BOLD}(default)${RESET}` : "";
+function printChainLine(prefix: string, name: string, chainConfig: ChainConfig, suffix = "") {
   const rpcs = Array.isArray(chainConfig.rpc) ? chainConfig.rpc : [chainConfig.rpc];
-  console.log(`${prefix}${CYAN}${name}${RESET}${suffix}${marker}  ${DIM}${rpcs[0]}${RESET}`);
+  console.log(`${prefix}${CYAN}${name}${RESET}${suffix}  ${DIM}${rpcs[0]}${RESET}`);
   const indent = prefix.replace(/[^\s]/g, " ");
   for (let i = 1; i < rpcs.length; i++) {
     console.log(`${indent}  ${DIM}${rpcs[i]}${RESET}`);
@@ -331,6 +312,11 @@ async function chainUpdate(
   if (opts.all) {
     await chainUpdateAll(config);
     return;
+  }
+
+  if (!name) {
+    console.error("Usage: dot chain update <name> | --all");
+    process.exit(1);
   }
 
   const { name: chainName, chain: chainConfig } = resolveChain(config, name);
@@ -389,33 +375,6 @@ async function chainUpdateAll(config: {
   }
 }
 
-async function chainDefault(
-  name: string | undefined,
-  opts: { output?: string; json?: boolean } = {},
-) {
-  if (!name) {
-    console.error("Usage: dot chain default <name>");
-    process.exit(1);
-  }
-
-  const config = await loadConfig();
-
-  const resolved = findChainName(config, name);
-  if (!resolved) {
-    const available = Object.keys(config.chains).join(", ");
-    throw new Error(`Chain "${name}" not found. Available: ${available}`);
-  }
-
-  config.defaultChain = resolved;
-  await saveConfig(config);
-
-  if (isJsonOutput(opts)) {
-    console.log(formatJson({ action: "default", chain: resolved }));
-  } else {
-    console.log(`Default chain set to "${resolved}".`);
-  }
-}
-
 function isBuiltinModified(name: string, config: Config): boolean {
   const defaultRpc = DEFAULT_CONFIG.chains[name]?.rpc;
   const currentRpc = config.chains[name]?.rpc;
@@ -432,7 +391,6 @@ async function readStdin(): Promise<string> {
 }
 
 interface ChainExportData {
-  defaultChain: string;
   chains: Record<string, ChainConfig>;
 }
 
@@ -468,7 +426,6 @@ async function chainExport(
   }
 
   const exportData: ChainExportData = {
-    defaultChain: config.defaultChain,
     chains: exportChains,
   };
 
@@ -564,16 +521,6 @@ async function chainImport(
     }
   }
 
-  // Update defaultChain if present in import and overwrite is set
-  let defaultChanged = false;
-  if (importData.defaultChain && opts.overwrite) {
-    const resolvedDefault = findChainName(config, importData.defaultChain);
-    if (resolvedDefault) {
-      config.defaultChain = resolvedDefault;
-      defaultChanged = true;
-    }
-  }
-
   if (!opts.dryRun) {
     await saveConfig(config);
   }
@@ -586,7 +533,6 @@ async function chainImport(
         overwritten,
         skipped,
         warnings,
-        defaultChanged: defaultChanged ? config.defaultChain : undefined,
       }),
     );
     return;
@@ -596,7 +542,6 @@ async function chainImport(
   if (added.length > 0) console.log(`${prefix}Added: ${added.join(", ")}`);
   if (overwritten.length > 0) console.log(`${prefix}Overwritten: ${overwritten.join(", ")}`);
   if (skipped.length > 0) console.log(`${prefix}Skipped: ${skipped.join(", ")}`);
-  if (defaultChanged) console.log(`${prefix}Default chain set to "${config.defaultChain}".`);
 
   if (added.length === 0 && overwritten.length === 0) {
     console.log(`${prefix}No chains imported.`);

--- a/src/commands/focused-inspect.test.ts
+++ b/src/commands/focused-inspect.test.ts
@@ -43,67 +43,73 @@ beforeAll(() => {
 // @ts-expect-error Bun supports describe(label, options, fn) at runtime
 describe("showItemHelp (in-process coverage)", { timeout: 15_000 }, () => {
   test("tx item completes without error", async () => {
-    await showItemHelp("tx", "System.remark", {});
+    await showItemHelp("tx", "System.remark", { chain: "polkadot" });
   });
 
   test("query map item completes without error", async () => {
-    await showItemHelp("query", "System.Account", {});
+    await showItemHelp("query", "System.Account", { chain: "polkadot" });
   });
 
   test("query plain item completes without error", async () => {
-    await showItemHelp("query", "System.Number", {});
+    await showItemHelp("query", "System.Number", { chain: "polkadot" });
   });
 
   test("const item completes without error", async () => {
-    await showItemHelp("const", "Balances.ExistentialDeposit", {});
+    await showItemHelp("const", "Balances.ExistentialDeposit", { chain: "polkadot" });
   });
 
   test("events item completes without error", async () => {
-    await showItemHelp("events", "Balances.Transfer", {});
+    await showItemHelp("events", "Balances.Transfer", { chain: "polkadot" });
   });
 
   test("errors item completes without error", async () => {
-    await showItemHelp("errors", "Balances.InsufficientBalance", {});
+    await showItemHelp("errors", "Balances.InsufficientBalance", { chain: "polkadot" });
   });
 
   test("unknown tx item throws with suggestion", async () => {
-    await expect(showItemHelp("tx", "System.remrk", {})).rejects.toThrow(/remark/);
+    await expect(showItemHelp("tx", "System.remrk", { chain: "polkadot" })).rejects.toThrow(
+      /remark/,
+    );
   });
 
   test("unknown query item throws with suggestion", async () => {
-    await expect(showItemHelp("query", "System.Acccount", {})).rejects.toThrow(/Account/);
+    await expect(showItemHelp("query", "System.Acccount", { chain: "polkadot" })).rejects.toThrow(
+      /Account/,
+    );
   });
 
   test("unknown const item throws with suggestion", async () => {
-    await expect(showItemHelp("const", "Balances.ExistentialDepoist", {})).rejects.toThrow(
-      /ExistentialDeposit/,
-    );
+    await expect(
+      showItemHelp("const", "Balances.ExistentialDepoist", { chain: "polkadot" }),
+    ).rejects.toThrow(/ExistentialDeposit/);
   });
 
   test("unknown event item throws with suggestion", async () => {
-    await expect(showItemHelp("events", "Balances.Transferr", {})).rejects.toThrow(/Transfer/);
+    await expect(
+      showItemHelp("events", "Balances.Transferr", { chain: "polkadot" }),
+    ).rejects.toThrow(/Transfer/);
   });
 
   test("unknown error item throws with suggestion", async () => {
-    await expect(showItemHelp("errors", "Balances.InsufficientBalanc", {})).rejects.toThrow(
-      /InsufficientBalance/,
-    );
+    await expect(
+      showItemHelp("errors", "Balances.InsufficientBalanc", { chain: "polkadot" }),
+    ).rejects.toThrow(/InsufficientBalance/);
   });
 
   test("pallet-only tx delegates to listing", async () => {
-    await showItemHelp("tx", "System", {});
+    await showItemHelp("tx", "System", { chain: "polkadot" });
   });
 
   test("pallet-only query delegates to listing", async () => {
-    await showItemHelp("query", "System", {});
+    await showItemHelp("query", "System", { chain: "polkadot" });
   });
 
   test("pallet-only events delegates to listing", async () => {
-    await showItemHelp("events", "Balances", {});
+    await showItemHelp("events", "Balances", { chain: "polkadot" });
   });
 
   test("pallet-only errors delegates to listing", async () => {
-    await showItemHelp("errors", "Balances", {});
+    await showItemHelp("errors", "Balances", { chain: "polkadot" });
   });
 });
 
@@ -117,60 +123,60 @@ describe("showItemHelp (in-process coverage)", { timeout: 15_000 }, () => {
 describe("handler JSON output (in-process coverage)", { timeout: 15_000 }, () => {
   // handleCalls
   test("handleCalls category-only with json", async () => {
-    await handleCalls(undefined, { json: true });
+    await handleCalls(undefined, { json: true, chain: "polkadot" });
   });
   test("handleCalls pallet-only with json", async () => {
-    await handleCalls("System", { json: true });
+    await handleCalls("System", { json: true, chain: "polkadot" });
   });
   test("handleCalls pallet.item with json", async () => {
-    await handleCalls("System.remark", { json: true });
+    await handleCalls("System.remark", { json: true, chain: "polkadot" });
   });
 
   // handleEvents
   test("handleEvents category-only with json", async () => {
-    await handleEvents(undefined, { json: true });
+    await handleEvents(undefined, { json: true, chain: "polkadot" });
   });
   test("handleEvents pallet-only with json", async () => {
-    await handleEvents("Balances", { json: true });
+    await handleEvents("Balances", { json: true, chain: "polkadot" });
   });
   test("handleEvents pallet.item with json", async () => {
-    await handleEvents("Balances.Transfer", { json: true });
+    await handleEvents("Balances.Transfer", { json: true, chain: "polkadot" });
   });
 
   // handleErrors
   test("handleErrors category-only with json", async () => {
-    await handleErrors(undefined, { json: true });
+    await handleErrors(undefined, { json: true, chain: "polkadot" });
   });
   test("handleErrors pallet-only with json", async () => {
-    await handleErrors("Balances", { json: true });
+    await handleErrors("Balances", { json: true, chain: "polkadot" });
   });
   test("handleErrors pallet.item with json", async () => {
-    await handleErrors("Balances.InsufficientBalance", { json: true });
+    await handleErrors("Balances.InsufficientBalance", { json: true, chain: "polkadot" });
   });
 
   // handleStorage
   test("handleStorage category-only with json", async () => {
-    await handleStorage(undefined, { json: true });
+    await handleStorage(undefined, { json: true, chain: "polkadot" });
   });
   test("handleStorage pallet-only with json", async () => {
-    await handleStorage("System", { json: true });
+    await handleStorage("System", { json: true, chain: "polkadot" });
   });
   test("handleStorage pallet.item with json", async () => {
-    await handleStorage("System.Account", { json: true });
+    await handleStorage("System.Account", { json: true, chain: "polkadot" });
   });
 
   // showItemHelp with json
   test("showItemHelp tx item with json", async () => {
-    await showItemHelp("tx", "System.remark", { json: true });
+    await showItemHelp("tx", "System.remark", { json: true, chain: "polkadot" });
   });
   test("showItemHelp query item with json", async () => {
-    await showItemHelp("query", "System.Account", { json: true });
+    await showItemHelp("query", "System.Account", { json: true, chain: "polkadot" });
   });
   test("showItemHelp events item with json", async () => {
-    await showItemHelp("events", "Balances.Transfer", { json: true });
+    await showItemHelp("events", "Balances.Transfer", { json: true, chain: "polkadot" });
   });
   test("showItemHelp errors item with json", async () => {
-    await showItemHelp("errors", "Balances.InsufficientBalance", { json: true });
+    await showItemHelp("errors", "Balances.InsufficientBalance", { json: true, chain: "polkadot" });
   });
 });
 

--- a/src/commands/query.test.ts
+++ b/src/commands/query.test.ts
@@ -36,10 +36,10 @@ beforeAll(() => {
 // @ts-expect-error Bun supports describe(label, options, fn) at runtime
 describe("handleQuery JSON output (in-process coverage)", { timeout: 15_000 }, () => {
   test("category-only with json", async () => {
-    await handleQuery(undefined, [], { json: true });
+    await handleQuery(undefined, [], { json: true, chain: "polkadot" });
   });
   test("pallet-only with json", async () => {
-    await handleQuery("System", [], { json: true });
+    await handleQuery("System", [], { json: true, chain: "polkadot" });
   });
 });
 

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -63,10 +63,10 @@ beforeAll(() => {
 // @ts-expect-error Bun supports describe(label, options, fn) at runtime
 describe("handleTx JSON output (in-process coverage)", { timeout: 15_000 }, () => {
   test("category-only with json", async () => {
-    await handleTx(undefined, [], { json: true });
+    await handleTx(undefined, [], { json: true, chain: "polkadot" });
   });
   test("pallet-only with json", async () => {
-    await handleTx("System", [], { json: true });
+    await handleTx("System", [], { json: true, chain: "polkadot" });
   });
 });
 

--- a/src/completions/complete.test.ts
+++ b/src/completions/complete.test.ts
@@ -203,7 +203,7 @@ describe("named subcommand completion", () => {
     expect(l).toContain("remove");
     expect(l).toContain("update");
     expect(l).toContain("list");
-    expect(l).toContain("default");
+    expect(l).not.toContain("default");
   });
 
   test("chain subcommand with prefix", async () => {
@@ -254,30 +254,30 @@ describe("named subcommand completion", () => {
 });
 
 describe("dotpath completion — apis category", () => {
-  test("'apis.' returns API names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "apis.", ""]);
+  test("'apis.' with --chain returns API names", async () => {
+    const { stdout } = await runCli(["__complete", "--", "apis.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("apis."))).toBe(true);
     expect(l.some((s) => s === "apis.Core.")).toBe(true);
   });
 
-  test("'apis.Core.' returns method names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "apis.Core.", ""]);
+  test("'apis.Core.' with --chain returns method names", async () => {
+    const { stdout } = await runCli(["__complete", "--", "apis.Core.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("apis.Core."))).toBe(true);
     expect(l.some((s) => s === "apis.Core.version")).toBe(true);
   });
 
-  test("'apis.Co' filters to matching API names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "apis.Co", ""]);
+  test("'apis.Co' with --chain filters to matching API names", async () => {
+    const { stdout } = await runCli(["__complete", "--", "apis.Co", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l).toContain("apis.Core.");
   });
 
   test("apis method completions (terminal) do NOT end with dot", async () => {
-    const { stdout } = await runCli(["__complete", "--", "apis.Core.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "apis.Core.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     for (const s of l) {
@@ -286,18 +286,23 @@ describe("dotpath completion — apis category", () => {
   });
 
   test("apis API-level completions (intermediate) end with dot", async () => {
-    const { stdout } = await runCli(["__complete", "--", "apis.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "apis.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     for (const s of l) {
       expect(s.endsWith(".")).toBe(true);
     }
   });
+
+  test("'apis.' without --chain or dotpath prefix returns empty", async () => {
+    const { stdout } = await runCli(["__complete", "--", "apis.", ""]);
+    expect(stdout.trim()).toBe("");
+  });
 });
 
-describe("dotpath completion — category paths", () => {
+describe("dotpath completion — category paths (with --chain)", () => {
   test("'query.' returns pallet names with storage", async () => {
-    const { stdout } = await runCli(["__complete", "--", "query.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "query.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("query."))).toBe(true);
@@ -306,7 +311,7 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'tx.' returns pallets with calls", async () => {
-    const { stdout } = await runCli(["__complete", "--", "tx.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "tx.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("tx."))).toBe(true);
@@ -315,7 +320,7 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'const.' returns pallets with constants", async () => {
-    const { stdout } = await runCli(["__complete", "--", "const.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "const.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("const."))).toBe(true);
@@ -323,7 +328,7 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'events.' returns pallets with events", async () => {
-    const { stdout } = await runCli(["__complete", "--", "events.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "events.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("events."))).toBe(true);
@@ -331,7 +336,7 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'errors.' returns pallets with errors", async () => {
-    const { stdout } = await runCli(["__complete", "--", "errors.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "errors.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("errors."))).toBe(true);
@@ -339,14 +344,14 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'query.Sy' filters pallet names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "query.Sy", ""]);
+    const { stdout } = await runCli(["__complete", "--", "query.Sy", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l).toContain("query.System.");
     expect(l).not.toContain("query.Balances.");
   });
 
   test("'query.System.' returns storage item names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "query.System.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "query.System.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("query.System."))).toBe(true);
@@ -355,7 +360,7 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'tx.System.' returns call names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "tx.System.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "tx.System.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("tx.System."))).toBe(true);
@@ -363,7 +368,7 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'const.Balances.' returns constant names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "const.Balances.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "const.Balances.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("const.Balances."))).toBe(true);
@@ -371,7 +376,13 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'events.Balances.' returns event names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "events.Balances.", ""]);
+    const { stdout } = await runCli([
+      "__complete",
+      "--",
+      "events.Balances.",
+      "--chain",
+      "polkadot",
+    ]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("events.Balances."))).toBe(true);
@@ -379,7 +390,13 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'errors.Balances.' returns error names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "errors.Balances.", ""]);
+    const { stdout } = await runCli([
+      "__complete",
+      "--",
+      "errors.Balances.",
+      "--chain",
+      "polkadot",
+    ]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     expect(l.every((s) => s.startsWith("errors.Balances."))).toBe(true);
@@ -387,19 +404,36 @@ describe("dotpath completion — category paths", () => {
   });
 
   test("'query.System.Ac' filters item names", async () => {
-    const { stdout } = await runCli(["__complete", "--", "query.System.Ac", ""]);
+    const { stdout } = await runCli(["__complete", "--", "query.System.Ac", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l).toContain("query.System.Account");
     expect(l).not.toContain("query.System.Number");
   });
 
   test("item completion for nonexistent pallet returns empty", async () => {
-    const { stdout } = await runCli(["__complete", "--", "query.Nonexistent.", ""]);
+    const { stdout } = await runCli([
+      "__complete",
+      "--",
+      "query.Nonexistent.",
+      "--chain",
+      "polkadot",
+    ]);
     expect(stdout.trim()).toBe("");
   });
 
   test("too many segments returns empty", async () => {
-    const { stdout } = await runCli(["__complete", "--", "query.System.Account.extra.", ""]);
+    const { stdout } = await runCli([
+      "__complete",
+      "--",
+      "query.System.Account.extra.",
+      "--chain",
+      "polkadot",
+    ]);
+    expect(stdout.trim()).toBe("");
+  });
+
+  test("bare 'query.' without --chain or dotpath prefix returns empty", async () => {
+    const { stdout } = await runCli(["__complete", "--", "query.", ""]);
     expect(stdout.trim()).toBe("");
   });
 });
@@ -524,7 +558,7 @@ describe("dot suffix on intermediate completions", () => {
   });
 
   test("category-first pallets end with dot", async () => {
-    const { stdout } = await runCli(["__complete", "--", "query.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "query.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     for (const s of l) {
@@ -533,7 +567,7 @@ describe("dot suffix on intermediate completions", () => {
   });
 
   test("category-first pallets with partial also end with dot", async () => {
-    const { stdout } = await runCli(["__complete", "--", "query.Sy", ""]);
+    const { stdout } = await runCli(["__complete", "--", "query.Sy", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     for (const s of l) {
@@ -542,7 +576,7 @@ describe("dot suffix on intermediate completions", () => {
   });
 
   test("category-first items (terminal) do NOT end with dot", async () => {
-    const { stdout } = await runCli(["__complete", "--", "query.System.", ""]);
+    const { stdout } = await runCli(["__complete", "--", "query.System.", "--chain", "polkadot"]);
     const l = lines(stdout);
     expect(l.length).toBeGreaterThan(0);
     for (const s of l) {
@@ -624,7 +658,7 @@ describe("dot suffix on intermediate completions", () => {
 
   test("all five categories produce dot-suffixed pallets", async () => {
     for (const cat of ["query", "tx", "const", "events", "errors"]) {
-      const { stdout } = await runCli(["__complete", "--", `${cat}.`, ""]);
+      const { stdout } = await runCli(["__complete", "--", `${cat}.`, "--chain", "polkadot"]);
       const l = lines(stdout);
       if (l.length > 0) {
         for (const s of l) {
@@ -637,18 +671,15 @@ describe("dot suffix on intermediate completions", () => {
 
 describe("graceful degradation", () => {
   test("no metadata returns empty for pallet completion", async () => {
-    // Use a config with a chain that has no metadata file
     const { stdout } = await runCli(["__complete", "--", "query.", ""], {
-      config: {
-        defaultChain: "nochain",
-        chains: { nochain: { rpc: "wss://example.com" } },
-      },
+      config: { chains: { nochain: { rpc: "wss://example.com" } } },
     });
-    // runCli copies metadata for all chains in config, but "nochain" gets one too
-    // Let's use --chain to force a chain that doesn't exist
-    // Actually runCli copies metadata for ALL chains in finalConfig, so this will have metadata
-    // We can't easily test this without hacking the fixture. Skip.
     expect(stdout).toBeDefined();
+  });
+
+  test("pallet completion without --chain or dotpath prefix returns empty", async () => {
+    const { stdout } = await runCli(["__complete", "--", "query.", ""]);
+    expect(stdout.trim()).toBe("");
   });
 
   test("unknown first segment returns empty", async () => {

--- a/src/completions/complete.ts
+++ b/src/completions/complete.ts
@@ -24,7 +24,7 @@ const CATEGORY_ALIASES: Record<string, string> = {
 
 const NAMED_COMMANDS = ["chain", "account", "inspect", "hash", "sign", "parachain", "completions"];
 
-const CHAIN_SUBCOMMANDS = ["add", "remove", "update", "list", "default"];
+const CHAIN_SUBCOMMANDS = ["add", "remove", "update", "list"];
 const ACCOUNT_SUBCOMMANDS = [
   "add",
   "create",
@@ -258,7 +258,8 @@ async function completeDotpath(
 
     if (numComplete === 1 && endsWithDot) {
       // "category." → pallet names
-      const chainName = chainFromFlag ?? config.defaultChain;
+      const chainName = chainFromFlag;
+      if (!chainName) return [];
       const pallets = await loadPallets(config, chainName);
       if (!pallets) return [];
       const filtered = filterPallets(pallets, category);
@@ -268,7 +269,8 @@ async function completeDotpath(
 
     if (numComplete === 1 && !endsWithDot) {
       // "category.partial" → filter pallet names
-      const chainName = chainFromFlag ?? config.defaultChain;
+      const chainName = chainFromFlag;
+      if (!chainName) return [];
       const pallets = await loadPallets(config, chainName);
       if (!pallets) return [];
       const filtered = filterPallets(pallets, category);
@@ -279,7 +281,8 @@ async function completeDotpath(
     if (numComplete === 2) {
       // "category.Pallet." or "category.Pallet.partial" → item names
       const palletName = completeSegments[1]!;
-      const chainName = chainFromFlag ?? config.defaultChain;
+      const chainName = chainFromFlag;
+      if (!chainName) return [];
       const pallets = await loadPallets(config, chainName);
       if (!pallets) return [];
       const pallet = pallets.find((p) => p.name.toLowerCase() === palletName.toLowerCase());
@@ -381,7 +384,8 @@ async function completeApisCategory(
   config: Config,
   chainNameOverride?: string,
 ): Promise<string[]> {
-  const chainName = chainNameOverride ?? config.defaultChain;
+  const chainName = chainNameOverride;
+  if (!chainName) return [];
   const apis = await loadRuntimeApiNames(config, chainName);
   if (!apis) return [];
 

--- a/src/config/store.test.ts
+++ b/src/config/store.test.ts
@@ -4,7 +4,6 @@ import type { Config } from "./types.ts";
 import { DEFAULT_CONFIG } from "./types.ts";
 
 const config: Config = {
-  defaultChain: "polkadot",
   chains: {
     polkadot: { rpc: "wss://rpc.polkadot.io" },
     kusama: { rpc: "wss://kusama-rpc.polkadot.io" },
@@ -12,12 +11,10 @@ const config: Config = {
 };
 
 describe("resolveChain", () => {
-  test("returns default chain when no flag provided", () => {
-    const result = resolveChain(config);
-    expect(result).toEqual({
-      name: "polkadot",
-      chain: { rpc: "wss://rpc.polkadot.io" },
-    });
+  test("throws with helpful error when no chain flag is provided", () => {
+    expect(() => resolveChain(config, undefined)).toThrow(
+      /No chain specified.*--chain.*polkadot, kusama/s,
+    );
   });
 
   test("returns the flagged chain when flag is provided", () => {
@@ -31,16 +28,6 @@ describe("resolveChain", () => {
   test("throws with descriptive error for unknown chain name", () => {
     expect(() => resolveChain(config, "westend")).toThrow(
       'Unknown chain "westend". Available chains: polkadot, kusama',
-    );
-  });
-
-  test("throws for unknown chain when flag overrides valid default", () => {
-    const cfg: Config = {
-      defaultChain: "polkadot",
-      chains: { polkadot: { rpc: "wss://rpc.polkadot.io" } },
-    };
-    expect(() => resolveChain(cfg, "noexist")).toThrow(
-      'Unknown chain "noexist". Available chains: polkadot',
     );
   });
 
@@ -93,12 +80,11 @@ describe("loadConfig merge behavior", () => {
         chains[name] = config;
       }
     }
-    return { ...saved, chains };
+    return { chains };
   }
 
   test("saved config with only custom chains still includes all built-in chains", () => {
     const saved: Config = {
-      defaultChain: "my-chain",
       chains: { "my-chain": { rpc: "wss://my-chain.example" } },
     };
     const merged = simulateMerge(saved);
@@ -110,7 +96,6 @@ describe("loadConfig merge behavior", () => {
 
   test("saved config overrides for built-in chain are preserved", () => {
     const saved: Config = {
-      defaultChain: "polkadot",
       chains: { polkadot: { rpc: "wss://my-custom-rpc.example" } },
     };
     const merged = simulateMerge(saved);
@@ -120,14 +105,19 @@ describe("loadConfig merge behavior", () => {
   });
 
   test("empty saved chains still gets all built-in chains", () => {
-    const saved: Config = { defaultChain: "polkadot", chains: {} };
+    const saved: Config = { chains: {} };
     const merged = simulateMerge(saved);
     expect(Object.keys(merged.chains)).toEqual(Object.keys(DEFAULT_CONFIG.chains));
   });
 
+  test("merge silently drops legacy defaultChain field on saved config", () => {
+    const saved = { defaultChain: "kusama", chains: {} } as unknown as Config;
+    const merged = simulateMerge(saved);
+    expect("defaultChain" in merged).toBe(false);
+  });
+
   test("saved config with custom RPC for built-in chain preserves default topology", () => {
     const saved: Config = {
-      defaultChain: "polkadot",
       chains: { "polkadot-asset-hub": { rpc: "wss://my-custom-asset-hub.example" } },
     };
     const merged = simulateMerge(saved);
@@ -138,7 +128,6 @@ describe("loadConfig merge behavior", () => {
 
   test("user-added chain with relay and parachainId is preserved", () => {
     const saved: Config = {
-      defaultChain: "polkadot",
       chains: {
         "my-para": { rpc: "wss://my-para.example", relay: "polkadot", parachainId: 2000 },
       },
@@ -181,7 +170,6 @@ describe("loadConfig merge behavior", () => {
 
   test("user override of topology on built-in parachain takes precedence", () => {
     const saved: Config = {
-      defaultChain: "polkadot",
       chains: {
         "polkadot-asset-hub": {
           rpc: "wss://custom.example",

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -1,6 +1,7 @@
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { CliError } from "../utils/errors.ts";
 import type { ChainConfig, Config } from "./types.ts";
 import { DEFAULT_CONFIG } from "./types.ts";
 
@@ -52,7 +53,7 @@ export async function loadConfig(): Promise<Config> {
         chains[name] = config;
       }
     }
-    return { ...saved, chains };
+    return { chains };
   }
   await saveConfig(DEFAULT_CONFIG);
   return DEFAULT_CONFIG;
@@ -89,13 +90,17 @@ export function findChainName(config: Config, input: string): string | undefined
 
 export function resolveChain(
   config: Config,
-  chainFlag?: string,
+  chainFlag: string | undefined,
 ): { name: string; chain: ChainConfig } {
-  const input = chainFlag ?? config.defaultChain;
-  const name = findChainName(config, input);
+  const available = Object.keys(config.chains).join(", ");
+  if (!chainFlag) {
+    throw new CliError(
+      `No chain specified. Pass --chain <name> or use a dotpath prefix (e.g. "dot polkadot.query.System.Number"). Available chains: ${available}`,
+    );
+  }
+  const name = findChainName(config, chainFlag);
   if (!name) {
-    const available = Object.keys(config.chains).join(", ");
-    throw new Error(`Unknown chain "${input}". Available chains: ${available}`);
+    throw new CliError(`Unknown chain "${chainFlag}". Available chains: ${available}`);
   }
   return { name, chain: config.chains[name]! };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -5,7 +5,6 @@ export interface ChainConfig {
 }
 
 export interface Config {
-  defaultChain: string;
   chains: Record<string, ChainConfig>;
 }
 
@@ -15,7 +14,6 @@ export function primaryRpc(rpc: string | string[]): string {
 }
 
 export const DEFAULT_CONFIG: Config = {
-  defaultChain: "polkadot",
   chains: {
     polkadot: {
       rpc: [


### PR DESCRIPTION
## Summary

Closes #158. Removes the implicit `defaultChain` fallback so every chain-consuming command must specify a chain explicitly — either via `--chain <name>` or a dotpath chain prefix (`dot polkadot.query.System.Number`). When neither is provided, the CLI fails with a clear error listing the configured chains instead of silently targeting a saved default.

### Breaking changes

- `dot chain default <name>` subcommand removed.
- `dot chain update` now requires a chain name or `--all`.
- `dot chain list` no longer renders a `(default)` marker; `--json` output drops the `default` field.
- `--chain` global-option help text updated from "(default from config)" to "(required)".

### Config migration

Any pre-existing `defaultChain` field in `~/.polkadot/config.json` is silently ignored on read and dropped on the next save — no user action required.

### Why

The implicit fallback made commands non-transparent: in scripts or when switching contexts, users could not tell from the command which chain was actually being hit. See #158.

## Test plan

- [ ] `bun test` passes (1194 tests, incl. 13 new end-to-end tests in `src/commands/chain-required.test.ts` covering every chain-consuming command)
- [ ] `dot query.System.Number` (no chain) → errors with "No chain specified…" listing available chains
- [ ] `dot --chain polkadot query.System.Number` → works
- [ ] `dot polkadot.query.System.Number` → works (dotpath prefix)
- [ ] `dot polkadot.query.System.Number --chain polkadot` → errors (both specified)
- [ ] `dot chain default polkadot` → errors: `Unknown action "default"`
- [ ] `dot chain update` (no args) → errors with usage; `dot chain update polkadot` and `dot chain update --all` still work
- [ ] `dot chain list` (pretty + `--json`) — no default-chain marker/field
- [ ] README "Selecting a chain" section and docs counterpart render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)