### PR TITLE
feat: add dot extensions inspector for transaction/signed extensions

### DIFF
--- a/.changeset/inspect-transaction-extensions.md
+++ b/.changeset/inspect-transaction-extensions.md
@@ -1,0 +1,32 @@
+---
+"polkadot-cli": minor
+---
+
+Add `dot extensions` to inspect a chain's transaction (signed) extensions.
+
+**New: `extensions` category**
+
+Users can now discover which transaction extensions a chain exposes, which ones
+polkadot-api fills in automatically, and which ones must be provided via
+`--ext` when building a transaction. This closes issue #169.
+
+```bash
+# List every transaction extension on a chain
+dot extensions --chain polkadot
+
+# Detail view for a single extension — shows value type, additionalSigned type,
+# and a usage hint for non-builtin extensions
+dot extensions.CheckMortality --chain polkadot
+
+# Chain-prefix form
+dot polkadot.extensions.ChargeTransactionPayment
+
+# Structured output for scripts and agents
+dot extensions --chain polkadot --json
+```
+
+Aliases: `extension`, `ext`. Typos produce suggestion-style errors. Shell
+completion proposes identifiers after `dot extensions.`.
+
+Each entry is tagged `[builtin]` (handled internally by polkadot-api) or
+`[custom]` (requires `--ext '{"<Identifier>":{"value":...}}'` when signing).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Ships with Polkadot and all system parachains preconfigured with multiple fallba
 - ✅ zsh, bash, and fish autocompletion
 - ✅ Exposes all on-chain metadata documentation
 - ✅ Encode, dry-run, and submit extrinsics
-- ✅ Support for custom signed extensions
+- ✅ Support for custom signed extensions — and a `dot extensions` inspector to discover them
 - ✅ Built with agent use in mind — structured JSON output on every command (`--json`)
 - ✅ Fuzzy matching with typo suggestions
 - ✅ Account management — BIP39 mnemonics, derivation paths, env-backed secrets, watch-only, dev accounts
@@ -409,7 +409,7 @@ dot polkadot.apis.Core
 dot apis Core --chain polkadot
 ```
 
-This works for all categories (`query`, `tx`, `const`, `events`, `errors`, `apis`). When passing positional method arguments, keep `Pallet` and `Item` either fully dot-joined (`query.System.Account 5Grw...`) or fully space-separated (`query System Account 5Grw...`) — mixing the two (`query System.Account 5Grw...`) does not work because the second arg gets parsed as a pallet name.
+This works for all categories (`query`, `tx`, `const`, `events`, `errors`, `apis`, `extensions`). When passing positional method arguments, keep `Pallet` and `Item` either fully dot-joined (`query.System.Account 5Grw...`) or fully space-separated (`query System Account 5Grw...`) — mixing the two (`query System.Account 5Grw...`) does not work because the second arg gets parsed as a pallet name.
 
 ### Query storage
 
@@ -637,9 +637,43 @@ dot polkadot.const.Balances.ExistentialDeposit  # look up value (connects to cha
 # Runtime APIs
 dot polkadot.apis                               # all runtime APIs
 dot polkadot.apis.Core                          # methods in Core
+
+# Transaction extensions (flat — no pallet sub-level)
+dot polkadot.extensions                         # all transaction extensions
+dot polkadot.extensions.CheckMortality          # extension detail
 ```
 
 `--chain <name>` works as an alternative to the prefix in every form (e.g. `dot tx.Balances --chain polkadot`). To browse pallets across all categories at once, use `dot inspect` (see [Inspect metadata](#inspect-metadata)).
+
+### Transaction extensions
+
+List the transaction extensions (also known as signed extensions) a chain declares in its runtime, with types and a marker indicating whether `polkadot-api` handles the extension automatically or whether you need to provide a value via `--ext` when building a transaction (see [Submit extrinsics](#submit-extrinsics)).
+
+```bash
+# List all transaction extensions on a chain
+dot polkadot.extensions
+
+# Detail view for a single extension
+dot polkadot.extensions.CheckMortality
+
+# --chain flag form is equivalent
+dot extensions.ChargeTransactionPayment --chain polkadot
+
+# Space-separated syntax also works
+dot extensions CheckMortality --chain polkadot
+
+# Structured output for scripts
+dot polkadot.extensions --json
+```
+
+`extension` and `ext` are aliases for `extensions`. Shell completion suggests identifiers after `dot polkadot.extensions.<Tab>`.
+
+The list view tags each entry:
+
+- `[builtin]` — `polkadot-api` fills this in for you (e.g. `CheckMortality`, `CheckNonce`, `ChargeTransactionPayment`, `CheckMetadataHash`)
+- `[custom]` — you must provide a value with `--ext` when signing, for example `--ext '{"<Identifier>":{"value":<v>}}'`
+
+The detail view shows the extension's value type, its `additionalSigned` type, and a ready-to-adapt `--ext` snippet for custom extensions. Use this to discover what `--ext` payload a chain expects before submitting a `dot tx` command.
 
 ### Submit extrinsics
 
@@ -805,6 +839,8 @@ For manual override, use `--ext` with a JSON object:
 ```bash
 dot tx.System.remark 0xdeadbeef --from alice --chain polkadot --ext '{"MyExtension":{"value":"..."}}'
 ```
+
+Not sure which extensions a chain exposes? Run `dot <chain>.extensions` (see [Transaction extensions](#transaction-extensions)) to list them all with value types and a `[builtin]` / `[custom]` marker.
 
 #### Transaction options
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -9,7 +9,7 @@ A command-line tool for interacting with Polkadot-ecosystem chains. Manage chain
 - ✅ zsh, bash, and fish autocompletion
 - ✅ Exposes all on-chain metadata documentation
 - ✅ Encode, dry-run, and submit extrinsics
-- ✅ Support for custom signed extensions
+- ✅ Support for custom signed extensions — and a `dot extensions` inspector to discover them
 - ✅ Built with agent use in mind — structured JSON output on every command (`--json`)
 - ✅ Fuzzy matching with typo suggestions
 - ✅ Account management — BIP39 mnemonics, derivation paths, env-backed secrets, watch-only, dev accounts
@@ -878,6 +878,33 @@ Notes:
 
 Run `dot <chain>.apis.<ApiName>.<method> --help` to see the exact argument signature for any method.
 
+### Transaction extensions
+
+Every Substrate transaction carries a list of transaction extensions (also known as signed extensions) that extend the transaction with metadata the runtime validates — nonce, mortality, fee payment, metadata hash, and chain-specific extras. Use `dot <chain>.extensions` to discover which extensions a chain declares, what their value types look like, and which ones you need to fill in yourself when building a transaction.
+
+```
+dot polkadot.extensions                              # list every transaction extension on the chain
+dot polkadot.extensions.CheckMortality               # detail view for one extension
+dot extensions.ChargeTransactionPayment --chain polkadot   # --chain flag form
+dot extensions CheckMortality --chain polkadot       # space-separated form
+dot polkadot.extensions --json                       # structured output for scripts / agents
+```
+
+`extension` and `ext` are aliases for `extensions`. Shell completion suggests identifiers after `dot polkadot.extensions.<Tab>`.
+
+Each entry is tagged:
+
+- `[builtin]` — `polkadot-api` handles this extension for you when signing. Examples: `CheckMortality`, `CheckNonce`, `ChargeTransactionPayment`, `CheckMetadataHash`, `StorageWeightReclaim`.
+- `[custom]` — you must provide a value via `--ext` when signing. The detail view shows the value type and a ready-to-adapt snippet:
+
+  ```
+  dot tx.<Pallet>.<Call> --from <acc> --chain <chain> --ext '{"<Identifier>":{"value":<v>}}'
+  ```
+
+The detail view also shows the extension's `additionalSigned` type (included in the signed payload but not in the transaction body). `--json` output emits structured records with `identifier`, `valueType`, `additionalSignedType`, `valueTypeId`, `additionalSignedTypeId`, and `isBuiltin` — handy for agents and scripts that generate `--ext` payloads automatically.
+
+This is the companion discovery surface for [Custom signed extensions](#custom-signed-extensions) below — run `dot <chain>.extensions` first to learn what the chain expects, then pass the right values to `dot tx ... --ext`.
+
 ## Transactions
 
 Build, sign, and submit extrinsics using dot-path syntax: `dot tx.Pallet.Call`. Pass arguments after the dot-path, or submit a raw SCALE-encoded call hex. Both forms display a decoded human-readable representation of the call.
@@ -1101,6 +1128,8 @@ For manual override, use `--ext` with a JSON object:
 dot tx.System.remark 0xdeadbeef --from alice --chain polkadot \
   --ext '{"MyExtension":{"value":"..."}}'
 ```
+
+Not sure which extensions a chain exposes or which ones need a `--ext` override? Run `dot extensions --chain <chain>` (see [Transaction extensions](#transaction-extensions)) to list every extension with its value type and a `[builtin]` / `[custom]` marker.
 
 ### Transaction options
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,12 @@ import { handleApis } from "./commands/apis.ts";
 import { registerChainCommands } from "./commands/chain.ts";
 import { registerCompletionsCommand } from "./commands/completions.ts";
 import { handleConst } from "./commands/const.ts";
-import { handleErrors, handleEvents, showItemHelp } from "./commands/focused-inspect.ts";
+import {
+  handleErrors,
+  handleEvents,
+  handleExtensions,
+  showItemHelp,
+} from "./commands/focused-inspect.ts";
 import { registerHashCommand } from "./commands/hash.ts";
 import { registerInspectCommand } from "./commands/inspect.ts";
 import { registerParachainCommand } from "./commands/parachain.ts";
@@ -265,6 +270,15 @@ if (process.argv[2] === "__complete") {
           case "apis":
             await handleApis(target, args, handlerOpts);
             break;
+          case "extensions": {
+            if (parsed.item) {
+              throw new CliError(
+                `Transaction extensions have no sub-items. Try "dot extensions.${parsed.pallet}".`,
+              );
+            }
+            await handleExtensions(parsed.pallet, handlerOpts);
+            break;
+          }
         }
       },
     );
@@ -301,6 +315,7 @@ if (process.argv[2] === "__complete") {
     console.log("  events    List or inspect pallet events");
     console.log("  errors    List or inspect pallet errors");
     console.log("  apis      Browse and call runtime APIs");
+    console.log("  extensions  List transaction extensions on a chain");
     console.log();
     console.log("Examples:");
     console.log("  dot polkadot.query.System.Account <addr>            Query a storage item");
@@ -312,6 +327,10 @@ if (process.argv[2] === "__complete") {
     console.log("  dot polkadot.const.Balances.ExistentialDeposit");
     console.log("  dot polkadot.events.Balances                        List events in Balances");
     console.log("  dot polkadot.apis.Core.version                      Call a runtime API");
+    console.log(
+      "  dot polkadot.extensions                             List transaction extensions",
+    );
+    console.log("  dot polkadot.extensions.CheckMortality              Inspect one extension");
     console.log("  dot query.System.Number --chain polkadot            --chain flag form");
     console.log(
       "  dot ./transfer.yaml --from alice                    Run from file (chain in YAML)",

--- a/src/commands/focused-inspect.test.ts
+++ b/src/commands/focused-inspect.test.ts
@@ -8,6 +8,7 @@ import {
   handleCalls,
   handleErrors,
   handleEvents,
+  handleExtensions,
   handleStorage,
   showItemHelp,
 } from "./focused-inspect.ts";
@@ -163,6 +164,25 @@ describe("handler JSON output (in-process coverage)", { timeout: 15_000 }, () =>
   });
   test("handleStorage pallet.item with json", async () => {
     await handleStorage("System.Account", { json: true, chain: "polkadot" });
+  });
+
+  // handleExtensions
+  test("handleExtensions category-only with json", async () => {
+    await handleExtensions(undefined, { json: true, chain: "polkadot" });
+  });
+  test("handleExtensions identifier with json", async () => {
+    await handleExtensions("CheckMortality", { json: true, chain: "polkadot" });
+  });
+  test("handleExtensions category-only pretty", async () => {
+    await handleExtensions(undefined, { chain: "polkadot" });
+  });
+  test("handleExtensions identifier pretty", async () => {
+    await handleExtensions("CheckMortality", { chain: "polkadot" });
+  });
+  test("handleExtensions unknown identifier throws with suggestion", async () => {
+    await expect(handleExtensions("CheckMortalty", { chain: "polkadot" })).rejects.toThrow(
+      /CheckMortality/,
+    );
   });
 
   // showItemHelp with json
@@ -623,5 +643,74 @@ describe("stdout/stderr separation (pipe-safe output)", () => {
     expect(parsed.pallet).toBe("Balances");
     expect(Array.isArray(parsed.errors)).toBe(true);
     expect(parsed.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("dot extensions", () => {
+  test("lists extensions with types", async () => {
+    const { stdout, exitCode } = await runCli(["extensions"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Transaction extensions");
+    expect(stdout).toContain("CheckMortality");
+    expect(stdout).toContain("[builtin]");
+  });
+
+  test("shows extension detail", async () => {
+    const { stdout, exitCode } = await runCli(["extensions.CheckMortality"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("(Transaction Extension)");
+    expect(stdout).toContain("Value type:");
+    expect(stdout).toContain("AdditionalSigned:");
+    expect(stdout).toContain("polkadot-api (builtin)");
+  });
+
+  test("extension alias works", async () => {
+    const { stdout, exitCode } = await runCli(["extension.CheckMortality"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("(Transaction Extension)");
+  });
+
+  test("typo suggests correct name", async () => {
+    const { stderr, exitCode } = await runCli(["extensions.CheckMortalty"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("CheckMortality");
+  });
+
+  test("chain prefix works", async () => {
+    const config = {
+      chains: { kusama: { rpc: "wss://kusama-rpc.polkadot.io" } },
+    };
+    const { stdout, exitCode } = await runCli(["kusama.extensions"], { config });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Transaction extensions");
+  });
+
+  test("rejects sub-items with a helpful message", async () => {
+    const { stderr, exitCode } = await runCli(["extensions.CheckMortality.value"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("no sub-items");
+  });
+
+  test("extensions --json lists identifiers", async () => {
+    const { stdout, exitCode } = await runCli(["extensions", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.chain).toBe("polkadot");
+    expect(Array.isArray(parsed.extensions)).toBe(true);
+    const mortality = parsed.extensions.find((e: any) => e.identifier === "CheckMortality");
+    expect(mortality).toBeDefined();
+    expect(mortality.isBuiltin).toBe(true);
+    expect(typeof mortality.valueType).toBe("string");
+    expect(typeof mortality.additionalSignedType).toBe("string");
+  });
+
+  test("extensions.CheckMortality --json returns extension detail", async () => {
+    const { stdout, exitCode } = await runCli(["extensions.CheckMortality", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.identifier).toBe("CheckMortality");
+    expect(parsed.isBuiltin).toBe(true);
+    expect(typeof parsed.valueTypeId).toBe("number");
+    expect(typeof parsed.additionalSignedTypeId).toBe("number");
   });
 });

--- a/src/commands/focused-inspect.ts
+++ b/src/commands/focused-inspect.ts
@@ -5,13 +5,17 @@ import {
   describeCallArgs,
   describeEventFields,
   describeRuntimeApiMethodArgs,
+  describeSignedExtension,
   describeType,
   fetchMetadataFromChain,
   findPallet,
   findRuntimeApi,
+  findSignedExtension,
   getOrFetchMetadata,
   getPalletNames,
   getRuntimeApiNames,
+  getSignedExtensionNames,
+  getSignedExtensions,
   listPallets,
   parseMetadata,
 } from "../core/metadata.ts";
@@ -705,4 +709,79 @@ export async function showItemHelp(
       return;
     }
   }
+}
+
+export async function handleExtensions(
+  target: string | undefined,
+  opts: { chain?: string; rpc?: string; output?: string; json?: boolean },
+) {
+  const config = await loadConfig();
+  const { name: chainName, chain: chainConfig } = resolveChain(config, opts.chain);
+  const meta = await loadMeta(chainName, chainConfig, opts.rpc);
+
+  if (!target) {
+    const extensions = getSignedExtensions(meta)
+      .map((e) => describeSignedExtension(meta, e))
+      .sort((a, b) => a.identifier.localeCompare(b.identifier));
+
+    if (isJsonOutput(opts)) {
+      console.log(
+        formatJson({
+          chain: chainName,
+          extensions: extensions.map((e) => ({
+            identifier: e.identifier,
+            valueType: e.valueType,
+            additionalSignedType: e.additionalSignedType,
+            isBuiltin: e.isBuiltin,
+          })),
+        }),
+      );
+      return;
+    }
+
+    printHeading(`Transaction extensions on ${chainName} (${extensions.length})`);
+    for (const e of extensions) {
+      const tag = e.isBuiltin ? `${DIM}[builtin]${RESET}` : `${CYAN}[custom]${RESET}`;
+      printItem(e.identifier, `${e.valueType}  ${tag}`);
+    }
+    console.log();
+    return;
+  }
+
+  const info = findSignedExtension(meta, target);
+  if (!info) {
+    const names = getSignedExtensionNames(meta);
+    throw new Error(suggestMessage("transaction extension", target, names));
+  }
+  const described = describeSignedExtension(meta, info);
+
+  if (isJsonOutput(opts)) {
+    console.log(
+      formatJson({
+        chain: chainName,
+        identifier: described.identifier,
+        valueType: described.valueType,
+        additionalSignedType: described.additionalSignedType,
+        valueTypeId: described.valueTypeId,
+        additionalSignedTypeId: described.additionalSignedTypeId,
+        isBuiltin: described.isBuiltin,
+      }),
+    );
+    return;
+  }
+
+  printHeading(`${described.identifier} (Transaction Extension)`);
+  console.log(`  ${BOLD}Value type:${RESET}       ${described.valueType}`);
+  console.log(`  ${BOLD}AdditionalSigned:${RESET} ${described.additionalSignedType}`);
+  console.log(
+    `  ${BOLD}Handled by:${RESET}       ${described.isBuiltin ? "polkadot-api (builtin)" : "user (custom — provide via --ext)"}`,
+  );
+  if (!described.isBuiltin) {
+    console.log();
+    console.log(`${BOLD}Usage:${RESET}`);
+    console.log(
+      `  dot tx.<Pallet>.<Call> --from <acc> --ext '{"${described.identifier}":{"value":<v>}}'`,
+    );
+  }
+  console.log();
 }

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -18,6 +18,7 @@ import {
   getPalletNames,
   getSignedExtensions,
   listPallets,
+  PAPI_BUILTIN_EXTENSIONS,
 } from "../core/metadata.ts";
 import {
   BOLD,
@@ -1443,22 +1444,6 @@ function parsePrimitive(prim: string, arg: string): string | number | bigint | b
 
 // --- Custom signed extensions support ---
 
-/** Extensions that polkadot-api handles internally */
-const PAPI_BUILTIN_EXTENSIONS = new Set([
-  "CheckNonZeroSender",
-  "CheckSpecVersion",
-  "CheckTxVersion",
-  "CheckGenesis",
-  "CheckMortality",
-  "CheckNonce",
-  "CheckWeight",
-  "ChargeTransactionPayment",
-  "ChargeAssetTxPayment",
-  "CheckMetadataHash",
-  "StorageWeightReclaim",
-  "PrevalidateAttests",
-]);
-
 function parseExtOption(ext: string | undefined): Record<string, any> {
   if (!ext) return {};
   try {
@@ -1482,7 +1467,7 @@ const NO_DEFAULT = Symbol("no-default");
 function buildCustomSignedExtensions(
   meta: MetadataBundle,
   userOverrides: Record<string, any>,
-  builtins: Set<string> = PAPI_BUILTIN_EXTENSIONS,
+  builtins: ReadonlySet<string> = PAPI_BUILTIN_EXTENSIONS,
 ): Record<string, { value?: any; additionalSigned?: any }> {
   const result: Record<string, { value?: any; additionalSigned?: any }> = {};
   const extensions = getSignedExtensions(meta);

--- a/src/completions/complete.ts
+++ b/src/completions/complete.ts
@@ -4,9 +4,14 @@ import type { Config } from "../config/types.ts";
 import { DEV_NAMES } from "../core/accounts.ts";
 import { getAlgorithmNames } from "../core/hash.ts";
 import type { PalletInfo } from "../core/metadata.ts";
-import { listPallets, listRuntimeApis, parseMetadata } from "../core/metadata.ts";
+import {
+  getSignedExtensionNames,
+  listPallets,
+  listRuntimeApis,
+  parseMetadata,
+} from "../core/metadata.ts";
 
-const CATEGORIES = ["query", "tx", "const", "events", "errors", "apis"] as const;
+const CATEGORIES = ["query", "tx", "const", "events", "errors", "apis", "extensions"] as const;
 
 const CATEGORY_ALIASES: Record<string, string> = {
   query: "query",
@@ -20,6 +25,9 @@ const CATEGORY_ALIASES: Record<string, string> = {
   error: "errors",
   apis: "apis",
   api: "apis",
+  extensions: "extensions",
+  extension: "extensions",
+  ext: "extensions",
 };
 
 const NAMED_COMMANDS = ["chain", "account", "inspect", "hash", "sign", "parachain", "completions"];
@@ -74,6 +82,15 @@ async function loadRuntimeApiNames(
     name: a.name,
     methodNames: a.methods.map((m) => m.name),
   }));
+}
+
+async function loadExtensionIdentifiers(
+  _config: Config,
+  chainName: string,
+): Promise<string[] | null> {
+  const raw = await loadMetadata(chainName);
+  if (!raw) return null;
+  return getSignedExtensionNames(parseMetadata(raw));
 }
 
 function filterPallets(pallets: PalletInfo[], category: string): PalletInfo[] {
@@ -256,6 +273,18 @@ async function completeDotpath(
       );
     }
 
+    // Transaction extensions are flat: <category>.<Identifier> (no sub-items)
+    if (category === "extensions") {
+      return completeExtensionsCategory(
+        first,
+        numComplete,
+        endsWithDot,
+        currentWord,
+        config,
+        chainFromFlag,
+      );
+    }
+
     if (numComplete === 1 && endsWithDot) {
       // "category." → pallet names
       const chainName = chainFromFlag;
@@ -321,6 +350,17 @@ async function completeDotpath(
           numComplete - 1,
           endsWithDot,
           completeSegments.slice(1),
+          currentWord,
+          config,
+          chainName,
+        );
+      }
+
+      if (category === "extensions") {
+        return completeExtensionsCategory(
+          `${first}.${completeSegments[1]!}`,
+          numComplete - 1,
+          endsWithDot,
           currentWord,
           config,
           chainName,
@@ -408,6 +448,38 @@ async function completeApisCategory(
     if (!api) return [];
     const candidates = api.methodNames.map((m) => `${prefix}.${apiName}.${m}`);
     return filterPrefix(candidates, endsWithDot ? currentWord.slice(0, -1) : currentWord);
+  }
+
+  return [];
+}
+
+/**
+ * Complete transaction extension identifiers.
+ * Extensions are flat: `extensions.<Identifier>` (no sub-items).
+ * `prefix` is the dotpath prefix before the identifier (e.g. "extensions" or "polkadot.extensions").
+ * `numComplete` is the number of complete segments after the category (0 or 1).
+ */
+async function completeExtensionsCategory(
+  prefix: string,
+  numComplete: number,
+  endsWithDot: boolean,
+  currentWord: string,
+  config: Config,
+  chainNameOverride?: string,
+): Promise<string[]> {
+  const chainName = chainNameOverride;
+  if (!chainName) return [];
+  const names = await loadExtensionIdentifiers(config, chainName);
+  if (!names) return [];
+
+  if (numComplete === 1 && endsWithDot) {
+    const candidates = names.map((n) => `${prefix}.${n}`);
+    return filterPrefix(candidates, currentWord.slice(0, -1));
+  }
+
+  if (numComplete === 1 && !endsWithDot) {
+    const candidates = names.map((n) => `${prefix}.${n}`);
+    return filterPrefix(candidates, currentWord);
   }
 
   return [];

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -4,17 +4,21 @@ import { MetadataError } from "../utils/errors.ts";
 import {
   describeCallArgs,
   describeRuntimeApiMethodArgs,
+  describeSignedExtension,
   describeType,
   findPallet,
   findRuntimeApi,
+  findSignedExtension,
   getOrFetchMetadata,
   getPalletNames,
   getRuntimeApiNames,
+  getSignedExtensionNames,
   getSignedExtensions,
   type Lookup,
   listPallets,
   listRuntimeApis,
   type MetadataBundle,
+  PAPI_BUILTIN_EXTENSIONS,
   parseMetadata,
 } from "./metadata.ts";
 
@@ -221,6 +225,59 @@ describe("getSignedExtensions", () => {
       expect(typeof ext.identifier).toBe("string");
       expect(typeof ext.type).toBe("number");
       expect(typeof ext.additionalSigned).toBe("number");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSignedExtensionNames / findSignedExtension / describeSignedExtension
+// ---------------------------------------------------------------------------
+describe("getSignedExtensionNames", () => {
+  test("returns sorted identifiers matching getSignedExtensions", () => {
+    const names = getSignedExtensionNames(meta);
+    const expected = getSignedExtensions(meta)
+      .map((e) => e.identifier)
+      .sort((a, b) => a.localeCompare(b));
+    expect(names).toEqual(expected);
+  });
+
+  test("CheckMortality is present", () => {
+    expect(getSignedExtensionNames(meta)).toContain("CheckMortality");
+  });
+});
+
+describe("findSignedExtension", () => {
+  test("finds by exact name", () => {
+    const ext = findSignedExtension(meta, "CheckMortality");
+    expect(ext?.identifier).toBe("CheckMortality");
+  });
+
+  test("matches case-insensitively", () => {
+    const ext = findSignedExtension(meta, "checkmortality");
+    expect(ext?.identifier).toBe("CheckMortality");
+  });
+
+  test("returns undefined for unknown identifier", () => {
+    expect(findSignedExtension(meta, "TotallyBogusExtension")).toBeUndefined();
+  });
+});
+
+describe("describeSignedExtension", () => {
+  test("marks builtin extensions as builtin", () => {
+    const info = findSignedExtension(meta, "CheckMortality")!;
+    const described = describeSignedExtension(meta, info);
+    expect(described.identifier).toBe("CheckMortality");
+    expect(described.isBuiltin).toBe(true);
+    expect(typeof described.valueType).toBe("string");
+    expect(typeof described.additionalSignedType).toBe("string");
+    expect(described.valueTypeId).toBe(info.type);
+    expect(described.additionalSignedTypeId).toBe(info.additionalSigned);
+  });
+
+  test("isBuiltin mirrors PAPI_BUILTIN_EXTENSIONS set", () => {
+    for (const info of getSignedExtensions(meta)) {
+      const described = describeSignedExtension(meta, info);
+      expect(described.isBuiltin).toBe(PAPI_BUILTIN_EXTENSIONS.has(info.identifier));
     }
   });
 });

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -219,12 +219,66 @@ export interface SignedExtensionInfo {
   additionalSigned: number;
 }
 
+/** Signed extensions that polkadot-api fills in automatically when building a tx. */
+export const PAPI_BUILTIN_EXTENSIONS: ReadonlySet<string> = new Set([
+  "CheckNonZeroSender",
+  "CheckSpecVersion",
+  "CheckTxVersion",
+  "CheckGenesis",
+  "CheckMortality",
+  "CheckNonce",
+  "CheckWeight",
+  "ChargeTransactionPayment",
+  "ChargeAssetTxPayment",
+  "CheckMetadataHash",
+  "StorageWeightReclaim",
+  "PrevalidateAttests",
+]);
+
 export function getSignedExtensions(meta: MetadataBundle): SignedExtensionInfo[] {
   const byVersion = meta.unified.extrinsic.signedExtensions;
   // Use the first (and typically only) version key
   const versionKeys = Object.keys(byVersion);
   if (versionKeys.length === 0) return [];
   return byVersion[Number(versionKeys[0])] ?? [];
+}
+
+export function getSignedExtensionNames(meta: MetadataBundle): string[] {
+  return getSignedExtensions(meta)
+    .map((e) => e.identifier)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function findSignedExtension(
+  meta: MetadataBundle,
+  identifier: string,
+): SignedExtensionInfo | undefined {
+  return getSignedExtensions(meta).find(
+    (e) => e.identifier.toLowerCase() === identifier.toLowerCase(),
+  );
+}
+
+export interface SignedExtensionDescription {
+  identifier: string;
+  valueType: string;
+  additionalSignedType: string;
+  valueTypeId: number;
+  additionalSignedTypeId: number;
+  isBuiltin: boolean;
+}
+
+export function describeSignedExtension(
+  meta: MetadataBundle,
+  info: SignedExtensionInfo,
+): SignedExtensionDescription {
+  return {
+    identifier: info.identifier,
+    valueType: describeType(meta.lookup, info.type),
+    additionalSignedType: describeType(meta.lookup, info.additionalSigned),
+    valueTypeId: info.type,
+    additionalSignedTypeId: info.additionalSigned,
+    isBuiltin: PAPI_BUILTIN_EXTENSIONS.has(info.identifier),
+  };
 }
 
 export function getPalletNames(meta: MetadataBundle): string[] {

--- a/src/utils/parse-dot-path.ts
+++ b/src/utils/parse-dot-path.ts
@@ -1,4 +1,4 @@
-export type DotCategory = "query" | "tx" | "const" | "events" | "errors" | "apis";
+export type DotCategory = "query" | "tx" | "const" | "events" | "errors" | "apis" | "extensions";
 
 export interface ParsedDotPath {
   chain?: string;
@@ -19,6 +19,9 @@ const CATEGORY_ALIASES: Record<string, DotCategory> = {
   error: "errors",
   apis: "apis",
   api: "apis",
+  extensions: "extensions",
+  extension: "extensions",
+  ext: "extensions",
 };
 
 function matchCategory(segment: string): DotCategory | undefined {
@@ -46,7 +49,7 @@ export function parseDotPath(input: string, knownChains: string[] = []): ParsedD
       const cat = matchCategory(parts[0]!);
       if (cat) return { category: cat };
       throw new Error(
-        `Unknown command "${parts[0]}". Expected a category (query, tx, const, events, errors, apis) or a named command.`,
+        `Unknown command "${parts[0]}". Expected a category (query, tx, const, events, errors, apis, extensions) or a named command.`,
       );
     }
 


### PR DESCRIPTION
## Summary

- New dot-path category `extensions` that lets users discover which transaction (signed) extensions a chain exposes, which ones polkadot-api handles automatically, and which ones need a `--ext` override. Closes #169.
- `dot <chain>.extensions` lists every extension with its value type and a `[builtin]` / `[custom]` tag; `dot <chain>.extensions.<Identifier>` shows detail (value type, additionalSigned type, handler, ready-to-adapt `--ext` snippet for custom extensions).
- Aliases `extension` / `ext`, chain-prefix + `--chain` flag forms, `--json` output, typo suggestions, shell-completion of identifiers, and a consolidated `PAPI_BUILTIN_EXTENSIONS` source-of-truth shared between the new inspector and the existing tx builder.

## Test plan

- [x] `bun run lint` (biome) — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 1304 pass / 0 fail
- [x] New unit tests in `src/core/metadata.test.ts` for `getSignedExtensionNames`, `findSignedExtension`, `describeSignedExtension`
- [x] New in-process + subprocess tests in `src/commands/focused-inspect.test.ts` covering list, detail, alias, typo, chain-prefix, `--json`, and sub-item rejection branches
- [x] Coverage spot-check — new metadata helpers fully covered; `handleExtensions` covered except the `[custom]` branch (polkadot fixture exposes only builtins)
- [ ] Manual smoke: `dot polkadot.extensions`, `dot polkadot.extensions.CheckMortality`, tab-completion on `dot polkadot.extensions.<Tab>`
- [ ] Regression check: `dot tx.System.remark 0xdead --from alice --chain polkadot` still builds with correct builtin-extension handling after `PAPI_BUILTIN_EXTENSIONS` relocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)