### PR TITLE
feat: improve chain and account import UX

### DIFF
--- a/.changeset/import-ux-improvements.md
+++ b/.changeset/import-ux-improvements.md
@@ -1,0 +1,51 @@
+---
+"polkadot-cli": minor
+---
+
+Improve `dot chain import` and `dot account import` UX.
+
+**Readable output.** Both commands now print one line per chain/account with
+status glyphs — `✓` added, `⟳` overwritten, `-` skipped — followed by a terse
+count summary. The old single-line comma-joined `Added: a, b, c, …` summary
+could span hundreds of characters for realistic imports; per-item lines are
+much easier to scan.
+
+```
+  ✓ preview
+  ✓ preview-people
+  ⟳ polkadot (overwritten)
+  - paseo (skipped)
+
+2 added, 1 overwritten, 1 skipped
+```
+
+**No more hangs on bare invocation.** `dot chain import` and
+`dot account import` with no file argument used to block forever reading
+from stdin. They now print the subcommand help when invoked in a terminal,
+while piped stdin (`cat file | dot chain import` or `dot chain import -`)
+still works.
+
+**Auto-metadata after chain import.** `dot chain import` now fetches metadata
+for newly imported or overwritten chains automatically, so tab completion,
+`dot chain.query.*`, and other metadata-dependent features start working
+immediately — no manual `dot chain update --all` step required. Pass
+`--no-metadata` to skip the fetch (useful for offline/CI bootstrapping).
+
+**`dot account import` is now file-only.** The single-account import form
+`dot account import <name> --secret "..."` / `--env VAR` has been removed to
+make the command a clean analog to `dot chain import`. The canonical
+single-account path is and remains `dot account add <name> --secret "..."`
+(`add --secret` / `add --env` have always been supported). Batch file import
+no longer requires the `--file` flag — just pass the path:
+
+```bash
+# Before
+dot account import treasury --secret "word1 word2 ..."    # no longer works
+dot account import --file accounts.json                    # still works
+
+# After
+dot account add treasury --secret "word1 word2 ..."        # canonical single
+dot account import accounts.json                           # positional file
+dot account import accounts.json --overwrite --dry-run
+dot account import -                                       # stdin
+```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Chain names are case-insensitive (`Polkadot.query.System.Number` works the same)
 
 #### Export/import chain configuration
 
-Export and import chain configurations for backup, sharing across machines, or team collaboration. Metadata is not included — re-fetch with `dot chain update --all` after importing.
+Export and import chain configurations for backup, sharing across machines, or team collaboration.
 
 ```bash
 # Export custom chains to stdout (pipe-friendly JSON)
@@ -157,11 +157,35 @@ dot chain import my-chains.json --dry-run
 # Overwrite existing chains
 dot chain import my-chains.json --overwrite
 
+# Skip automatic metadata fetch (faster for offline/CI bootstrap)
+dot chain import my-chains.json --no-metadata
+
 # Pipe between machines
 ssh remote-dev "dot chain export" | dot chain import -
 ```
 
 By default, `export` only includes user-added chains and built-ins with modified RPCs. Use `--all` to include everything. Import skips existing chains unless `--overwrite` is passed, and validates relay references with warnings for missing relays.
+
+After a non-dry-run import, metadata is fetched automatically for each newly added or overwritten chain so tab completion and metadata-dependent commands work immediately. Pass `--no-metadata` to skip the fetch — you can always backfill later with `dot chain update --all`.
+
+Output shows one line per chain with a status glyph and a terse summary:
+
+```
+  ✓ preview
+  ✓ preview-people
+  ⟳ polkadot (overwritten)
+  - paseo (skipped)
+
+2 added, 1 overwritten, 1 skipped
+
+Updating metadata for 3 chain(s)...
+
+  ✓ preview
+  ✓ preview-people
+  ✓ polkadot
+```
+
+Running `dot chain import` with no file path prints the subcommand help instead of blocking on stdin.
 
 ### Manage accounts
 
@@ -187,14 +211,14 @@ dot account create my-validator
 # Create with a derivation path
 dot account create my-staking --path //staking
 
-# Import from a BIP39 mnemonic
-dot account import treasury --secret "word1 word2 ... word12"
+# Add a keyed account from a BIP39 mnemonic
+dot account add treasury --secret "word1 word2 ... word12"
 
-# Import with a derivation path
-dot account import hot-wallet --secret "word1 word2 ... word12" --path //hot
+# Add with a derivation path
+dot account add hot-wallet --secret "word1 word2 ... word12" --path //hot
 
-# Import an env-var-backed account (secret stays off disk)
-dot account import ci-signer --env MY_SECRET
+# Add an env-var-backed account (secret stays off disk)
+dot account add ci-signer --env MY_SECRET
 
 # Derive a child account from an existing one
 dot account derive treasury treasury-staking --path //staking
@@ -212,9 +236,9 @@ dot account export --include-secrets --file backup.json
 dot account export --watch-only
 
 # Batch-import accounts from a file
-dot account import --file team-accounts.json
-dot account import --file accounts.json --dry-run
-dot account import --file accounts.json --overwrite
+dot account import team-accounts.json
+dot account import accounts.json --dry-run
+dot account import accounts.json --overwrite
 
 # Inspect an account — show public key and SS58 address
 dot account inspect alice
@@ -236,7 +260,7 @@ dot account add council 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684
 
 Watch-only accounts appear in `dot account list` with a `(watch-only)` badge and can be inspected and removed like any other account. They cannot be used with `--from` (signing) or as a source for `derive`.
 
-The `add` subcommand is context-sensitive: bare `add <name> <address>` creates a watch-only entry, while `add --secret` or `add --env` imports a keyed account (same as `import`).
+The `add` subcommand is context-sensitive: bare `add <name> <address>` creates a watch-only entry, while `add --secret` or `add --env` imports a keyed account. `dot account import` is reserved for file-based batch import.
 
 #### Named address resolution
 
@@ -302,16 +326,16 @@ dot account inspect alice --json
 For CI/CD and security-conscious workflows, store a reference to an environment variable instead of the secret itself:
 
 ```bash
-dot account import ci-signer --env MY_SECRET
+dot account add ci-signer --env MY_SECRET
 ```
 
-`--secret` and `--env` are mutually exclusive. `add` is an alias for `import`.
+`--secret` and `--env` are mutually exclusive. Use `dot account add` for single-account imports; `dot account import` is reserved for file-based batch import.
 
 The secret is never written to disk. At signing time, the CLI reads `$MY_SECRET` and derives the keypair. If the variable is not set, the CLI errors with a clear message. `account list` shows an `(env: MY_SECRET)` badge and resolves the address live when the variable is available.
 
 #### Derivation paths
 
-Use `--path` with `create`, `import`, or the `derive` action to derive child keys from the same secret. Different paths produce different keypairs, enabling key separation (e.g. staking vs. governance) without managing multiple mnemonics.
+Use `--path` with `create`, `add`, or the `derive` action to derive child keys from the same secret. Different paths produce different keypairs, enabling key separation (e.g. staking vs. governance) without managing multiple mnemonics.
 
 ```bash
 # Create with a derivation path
@@ -320,8 +344,8 @@ dot account create my-staking --path //staking
 # Multi-segment path (hard + soft junctions)
 dot account create multi --path //polkadot//0/wallet
 
-# Import with a path
-dot account import hot --secret "word1 word2 ..." --path //hot
+# Add with a path
+dot account add hot --secret "word1 word2 ..." --path //hot
 
 # Derive a child from an existing account
 dot account derive treasury treasury-staking --path //staking
@@ -362,20 +386,24 @@ dot account export --include-secrets --file backup.json
 # Export only watch-only accounts (always safe)
 dot account export --watch-only
 
-# Batch-import accounts from a file
-dot account import --file team-accounts.json
+# Batch-import accounts from a file (positional path, like `dot chain import`)
+dot account import team-accounts.json
 
 # Preview without applying
-dot account import --file accounts.json --dry-run
+dot account import accounts.json --dry-run
 
 # Overwrite existing accounts
-dot account import --file accounts.json --overwrite
+dot account import accounts.json --overwrite
 
 # Pipe from another machine
-ssh remote-dev "dot account export --watch-only" | dot account import --file /dev/stdin
+ssh remote-dev "dot account export --watch-only" | dot account import -
 ```
 
-Security: default export replaces mnemonic/seed with `"<redacted>"`. `--include-secrets` is required for actual secrets. Env-backed accounts export the variable *name* (e.g. `{"env": "MY_SECRET"}`), never the value. Redacted accounts import as watch-only (public key preserved, no signing capability). The existing single-account `import` (`--secret`/`--env`) is unchanged — batch import uses `--file` to distinguish.
+Output mirrors `dot chain import` — one line per account with a status glyph (`✓` added, `⟳` overwritten, `-` skipped) and a terse count summary at the end. Running `dot account import` with no file path prints the subcommand help instead of blocking on stdin.
+
+`dot account import` is file-only. For a single-account import from a mnemonic or env variable, use `dot account add <name> --secret "..."` or `dot account add <name> --env VAR`.
+
+Security: default export replaces mnemonic/seed with `"<redacted>"`. `--include-secrets` is required for actual secrets. Env-backed accounts export the variable *name* (e.g. `{"env": "MY_SECRET"}`), never the value. Redacted accounts import as watch-only (public key preserved, no signing capability).
 
 ### Chain prefix
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -160,7 +160,7 @@ Removing a chain that other chains reference as their `relay` prints a warning l
 
 ### Export chain configuration
 
-Export chain configurations to a JSON file or stdout for backup, sharing, or transfer to another machine. By default, only user-added chains and built-ins with modified RPCs are exported. Metadata is not included — re-fetch with `dot chain update --all` after importing.
+Export chain configurations to a JSON file or stdout for backup, sharing, or transfer to another machine. By default, only user-added chains and built-ins with modified RPCs are exported. Metadata is not included in the export — `dot chain import` re-fetches it automatically for each imported chain (see [Import chain configuration](#import-chain-configuration) below).
 
 ```
 # Export custom chains to stdout (pipe-friendly)
@@ -192,7 +192,7 @@ The export format is JSON with a `chains` field:
 
 ### Import chain configuration
 
-Import chain configurations from a JSON file or stdin:
+Import chain configurations from a JSON file or stdin. Running `dot chain import` with no file prints this section's help instead of blocking on stdin — there's no way to accidentally hang the CLI.
 
 ```
 # Import from a file
@@ -204,6 +204,9 @@ dot chain import my-chains.json --dry-run
 # Overwrite existing chains
 dot chain import my-chains.json --overwrite
 
+# Skip automatic metadata fetch (offline / CI bootstrap)
+dot chain import my-chains.json --no-metadata
+
 # Import from stdin (pipe from another machine)
 ssh remote-dev "dot chain export" | dot chain import -
 ```
@@ -212,7 +215,26 @@ Import behavior:
 
 - **Existing chains** are skipped with a warning unless `--overwrite` is passed
 - **Relay references** are validated — a warning is printed if a chain references a relay that doesn't exist in the import file or current config
-- After import, run `dot chain update --all` to fetch metadata for the new chains
+- **Metadata is fetched automatically** for every newly added or overwritten chain so tab completion and metadata-dependent commands (`dot <chain>.query.*`, `dot inspect`, …) work immediately. Partial fetch failures print `✗ <chain> — <error>` but do not fail the import. Pass `--no-metadata` to skip the fetch; you can always backfill later with `dot chain update --all`.
+
+Output prints one line per chain with a status glyph (`✓` added, `⟳` overwritten, `-` skipped) and a terse count summary at the end:
+
+```
+  ✓ preview
+  ✓ preview-people
+  ⟳ polkadot (overwritten)
+  - paseo (skipped)
+
+2 added, 1 overwritten, 1 skipped
+
+Updating metadata for 3 chain(s)...
+
+  ✓ preview
+  ✓ preview-people
+  ✓ polkadot
+```
+
+With `--json` the output is structured — `{ action, added, overwritten, skipped, warnings }` — and the metadata-fetch phase is skipped.
 
 ## Accounts
 
@@ -257,36 +279,38 @@ Watch-only accounts appear in `dot account list` with a `(watch-only)` badge. Th
 
 The `add` subcommand is context-sensitive:
 - `add <name> <address>` — creates a watch-only entry (no secret)
-- `add <name> --secret "..."` — imports a keyed account (same as `import`)
-- `add <name> --env VAR` — imports an env-backed account (same as `import`)
+- `add <name> --secret "..."` — adds a keyed account from a BIP39 mnemonic
+- `add <name> --env VAR` — adds an env-backed account
 
-### Import an account
+`dot account import` is reserved for file-based batch import only (see [Batch-import accounts](#batch-import-accounts) below).
 
-Import from a BIP39 mnemonic or raw hex seed:
+### Add a keyed account
 
-```
-dot account import treasury --secret "word1 word2 ... word12"
-dot account import raw-key --secret 0xabcdef...
-```
-
-Use `--path` to import with a derivation path:
+Add an account from a BIP39 mnemonic or raw hex seed:
 
 ```
-dot account import hot-wallet --secret "word1 word2 ... word12" --path //hot
+dot account add treasury --secret "word1 word2 ... word12"
+dot account add raw-key --secret 0xabcdef...
 ```
 
-### Import an env-var-backed account
+Use `--path` to add with a derivation path:
+
+```
+dot account add hot-wallet --secret "word1 word2 ... word12" --path //hot
+```
+
+### Add an env-var-backed account
 
 Store a reference to an environment variable instead of the secret itself. The secret never touches disk — ideal for CI/CD pipelines and security-conscious workflows:
 
 ```
-dot account import ci-signer --env MY_SECRET
+dot account add ci-signer --env MY_SECRET
 ```
 
 `--secret` and `--env` are mutually exclusive. Both `--secret` and `--env` can be combined with `--path`:
 
 ```
-dot account import ci-signer --env MY_SECRET --path //ci
+dot account add ci-signer --env MY_SECRET --path //ci
 ```
 
 At signing time, the CLI reads `$MY_SECRET` and derives the keypair. If the variable is not set, the CLI errors with a clear message.
@@ -316,14 +340,14 @@ dot account derive treasury treasury-staking --path //staking
 
 ### Derivation paths
 
-Use `--path` with `create`, `import`, or `derive` to derive child keys from the same secret. Different paths produce different keypairs, enabling key separation (e.g. staking vs. governance) without managing multiple mnemonics.
+Use `--path` with `create`, `add`, or `derive` to derive child keys from the same secret. Different paths produce different keypairs, enabling key separation (e.g. staking vs. governance) without managing multiple mnemonics.
 
 Derivation paths use the Substrate convention: `//hard` for hard derivation, `/soft` for soft derivation. Paths can have multiple segments:
 
 ```
 dot account create validator --path //staking
 dot account create multi --path //polkadot//0/wallet
-dot account import treasury --secret "..." --path //hot
+dot account add treasury --secret "..." --path //hot
 dot account derive treasury treasury-gov --path //governance
 ```
 
@@ -440,21 +464,23 @@ Security considerations:
 
 ### Batch-import accounts
 
-Import accounts from a previously exported JSON file. This is distinct from the existing `dot account import <name> --secret "..."` (single account from mnemonic) — batch import uses `--file`:
+Import accounts from a previously exported JSON file. `dot account import` is file-only — analog to `dot chain import`. The path is passed positionally (the legacy `--file` flag is still accepted). For single-account imports from a mnemonic or env variable, use [`dot account add`](#add-a-keyed-account) instead.
 
 ```
-# Import from a file
-dot account import --file team-accounts.json
+# Import from a file (positional path)
+dot account import team-accounts.json
 
 # Preview without applying changes
-dot account import --file accounts.json --dry-run
+dot account import accounts.json --dry-run
 
 # Overwrite existing accounts
-dot account import --file accounts.json --overwrite
+dot account import accounts.json --overwrite
 
 # Import from stdin
-ssh remote-dev "dot account export --watch-only" | dot account import --file /dev/stdin
+ssh remote-dev "dot account export --watch-only" | dot account import -
 ```
+
+Running `dot account import` with no file prints this section's help instead of blocking on stdin.
 
 Import behavior:
 
@@ -465,11 +491,26 @@ Import behavior:
 - **Bandersnatch keys** are preserved if present in the export
 - **Dev account names** (alice, bob, etc.) are skipped
 
-The existing single-account import is unchanged:
+Output prints one line per account with a status glyph (`✓` added, `⟳` overwritten, `-` skipped) and a terse count summary at the end:
 
 ```
-dot account import treasury --secret "word1 word2 ..."     # single account (unchanged)
-dot account import --file accounts.json                     # batch import (new)
+  ✓ treasury
+  ✓ council-member
+  - alice (skipped)
+
+2 added, 1 skipped
+```
+
+Migration from the pre-1.x single-account import form:
+
+```
+# Before
+dot account import treasury --secret "word1 word2 ..."     # removed
+dot account import --file accounts.json                     # still works
+
+# After
+dot account add treasury --secret "word1 word2 ..."        # canonical single-account
+dot account import accounts.json                           # positional batch import
 ```
 
 ### Inspect accounts

--- a/src/commands/account.test.ts
+++ b/src/commands/account.test.ts
@@ -79,10 +79,10 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stderr).toContain("already exists");
   });
 
-  test("import name --secret <mnemonic> succeeds", async () => {
+  test("add name --secret <mnemonic> succeeds", async () => {
     const { stdout, exitCode } = await runCli([
       "account",
-      "import",
+      "add",
       "my-imported",
       "--secret",
       TEST_MNEMONIC,
@@ -92,10 +92,10 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stdout).toContain("Address:");
   });
 
-  test("import with invalid secret errors", async () => {
+  test("add with invalid secret errors", async () => {
     const { stderr, exitCode } = await runCli([
       "account",
-      "import",
+      "add",
       "bad-key",
       "--secret",
       "not a valid mnemonic at all",
@@ -104,26 +104,13 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stderr).toContain("Invalid secret");
   });
 
-  test("import (no name) errors", async () => {
-    const { stderr, exitCode } = await runCli(["account", "import"]);
+  test("import (no file, no stdin) errors without hanging", async () => {
+    const { exitCode } = await runCli(["account", "import"]);
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("name is required");
   });
 
-  test("import name (no --secret or --env) errors", async () => {
-    const { stderr, exitCode } = await runCli(["account", "import", "my-key"]);
-    expect(exitCode).toBe(1);
-    expect(stderr).toContain("--secret or --env is required");
-  });
-
-  test("import bob (dev name) errors", async () => {
-    const { stderr, exitCode } = await runCli([
-      "account",
-      "import",
-      "bob",
-      "--secret",
-      TEST_MNEMONIC,
-    ]);
+  test("add bob (dev name) errors", async () => {
+    const { stderr, exitCode } = await runCli(["account", "add", "bob", "--secret", TEST_MNEMONIC]);
     expect(exitCode).toBe(1);
     expect(stderr).toContain("built-in dev account");
   });
@@ -186,32 +173,9 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stderr).toContain("not found");
   });
 
-  test("add is an alias for import (--secret)", async () => {
-    const { stdout, exitCode } = await runCli([
-      "account",
-      "add",
-      "my-imported",
-      "--secret",
-      TEST_MNEMONIC,
-    ]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("Account Imported");
-    expect(stdout).toContain("Address:");
-  });
-
-  test("add is an alias for import (--env)", async () => {
+  test("add name --env VAR (env set) succeeds with address", async () => {
     const { stdout, exitCode } = await runCli(
       ["account", "add", "env-test", "--env", "MY_SECRET"],
-      { env: { MY_SECRET: TEST_MNEMONIC } },
-    );
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("Account Imported");
-    expect(stdout).toContain("Address:");
-  });
-
-  test("import name --env VAR (env set) succeeds with address", async () => {
-    const { stdout, exitCode } = await runCli(
-      ["account", "import", "env-test", "--env", "MY_SECRET"],
       {
         env: { MY_SECRET: TEST_MNEMONIC },
       },
@@ -221,9 +185,9 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stdout).toContain("Address:");
   });
 
-  test("import name --env VAR (env not set) succeeds with deferred", async () => {
+  test("add name --env VAR (env not set) succeeds with deferred", async () => {
     const { stdout, exitCode } = await runCli(
-      ["account", "import", "env-test", "--env", "MY_SECRET"],
+      ["account", "add", "env-test", "--env", "MY_SECRET"],
       { env: { MY_SECRET: "" } },
     );
     expect(exitCode).toBe(0);
@@ -231,29 +195,26 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stdout).toContain("will resolve");
   });
 
-  test("import --secret and --env together errors", async () => {
+  test("add --secret and --env together errors", async () => {
     const { stderr, exitCode } = await runCli(
-      ["account", "import", "env-test", "--secret", TEST_MNEMONIC, "--env", "MY_SECRET"],
+      ["account", "add", "env-test", "--secret", TEST_MNEMONIC, "--env", "MY_SECRET"],
       { env: { MY_SECRET: TEST_MNEMONIC } },
     );
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Use --secret or --env, not both");
   });
 
-  test("import alice --env VAR (dev name) errors", async () => {
-    const { stderr, exitCode } = await runCli(
-      ["account", "import", "alice", "--env", "MY_SECRET"],
-      {
-        env: { MY_SECRET: TEST_MNEMONIC },
-      },
-    );
+  test("add alice --env VAR (dev name) errors", async () => {
+    const { stderr, exitCode } = await runCli(["account", "add", "alice", "--env", "MY_SECRET"], {
+      env: { MY_SECRET: TEST_MNEMONIC },
+    });
     expect(exitCode).toBe(1);
     expect(stderr).toContain("built-in dev account");
   });
 
-  test("import duplicate --env VAR errors", async () => {
+  test("add duplicate --env VAR errors", async () => {
     const { stderr, exitCode } = await runCli(
-      ["account", "import", "my-account", "--env", "MY_SECRET"],
+      ["account", "add", "my-account", "--env", "MY_SECRET"],
       {
         accounts: [STORED_ACCOUNT],
         env: { MY_SECRET: TEST_MNEMONIC },
@@ -368,10 +329,10 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stdout).toContain("Address:");
   });
 
-  test("import --secret with --path stores path", async () => {
+  test("add --secret with --path stores path", async () => {
     const { stdout, exitCode } = await runCli([
       "account",
-      "import",
+      "add",
       "my-derived",
       "--secret",
       TEST_MNEMONIC,
@@ -385,9 +346,9 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stdout).toContain("Address:");
   });
 
-  test("import --env with --path stores path", async () => {
+  test("add --env with --path stores path", async () => {
     const { stdout, exitCode } = await runCli(
-      ["account", "import", "env-derived", "--env", "MY_SECRET", "--path", "//ci"],
+      ["account", "add", "env-derived", "--env", "MY_SECRET", "--path", "//ci"],
       { env: { MY_SECRET: TEST_MNEMONIC } },
     );
     expect(exitCode).toBe(0);
@@ -502,10 +463,10 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stdout).toContain("Address:");
   });
 
-  test("import --secret with multi-segment --path //hard/soft//hard2", async () => {
+  test("add --secret with multi-segment --path //hard/soft//hard2", async () => {
     const { stdout, exitCode } = await runCli([
       "account",
-      "import",
+      "add",
       "multi-imported",
       "--secret",
       TEST_MNEMONIC,
@@ -519,11 +480,11 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(stdout).toContain("Address:");
   });
 
-  test("import with different multi-segment paths produces different addresses", async () => {
+  test("add with different multi-segment paths produces different addresses", async () => {
     const run = async (path: string) => {
       const { stdout, exitCode } = await runCli([
         "account",
-        "import",
+        "add",
         `acct-${path.replace(/\//g, "-")}`,
         "--secret",
         TEST_MNEMONIC,
@@ -961,7 +922,7 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(parsed.accounts[0].bandersnatch).toEqual({ "": "0xaabb", candidate: "0xccdd" });
   });
 
-  test("batch import adds new accounts", async () => {
+  test("batch import adds new accounts (positional file)", async () => {
     const importData = JSON.stringify({
       accounts: [
         {
@@ -971,12 +932,12 @@ describe("dot account", { timeout: 15_000 }, () => {
         },
       ],
     });
-    const { stdout, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/import.json"],
-      { files: { "import.json": importData } },
-    );
+    const { stdout, exitCode } = await runCli(["account", "import", "{{HOME}}/import.json"], {
+      files: { "import.json": importData },
+    });
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Added: imported-watch");
+    expect(stdout).toContain("imported-watch");
+    expect(stdout).toContain("1 added");
   });
 
   test("batch import skips existing accounts without --overwrite", async () => {
@@ -990,12 +951,13 @@ describe("dot account", { timeout: 15_000 }, () => {
       ],
     });
     const { stdout, stderr, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/import.json"],
+      ["account", "import", "{{HOME}}/import.json"],
       { accounts: [STORED_ACCOUNT], files: { "import.json": importData } },
     );
     expect(exitCode).toBe(0);
     expect(stderr).toContain("Skipped");
-    expect(stdout).toContain("Skipped: my-account");
+    expect(stdout).toContain("my-account (skipped)");
+    expect(stdout).toContain("1 skipped");
   });
 
   test("batch import --overwrite replaces existing accounts", async () => {
@@ -1009,11 +971,13 @@ describe("dot account", { timeout: 15_000 }, () => {
       ],
     });
     const { stdout, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/import.json", "--overwrite"],
+      ["account", "import", "{{HOME}}/import.json", "--overwrite"],
       { accounts: [STORED_ACCOUNT], files: { "import.json": importData } },
     );
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Overwritten: my-account");
+    expect(stdout).toContain("my-account");
+    expect(stdout).toContain("(overwritten)");
+    expect(stdout).toContain("1 overwritten");
   });
 
   test("batch import --dry-run does not persist", async () => {
@@ -1027,12 +991,13 @@ describe("dot account", { timeout: 15_000 }, () => {
       ],
     });
     const { stdout, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/import.json", "--dry-run"],
+      ["account", "import", "{{HOME}}/import.json", "--dry-run"],
       { files: { "import.json": importData } },
     );
     expect(exitCode).toBe(0);
     expect(stdout).toContain("(dry run)");
-    expect(stdout).toContain("Added: dry-run-acct");
+    expect(stdout).toContain("dry-run-acct");
+    expect(stdout).toContain("1 added");
   });
 
   test("batch import redacted account becomes watch-only", async () => {
@@ -1047,7 +1012,7 @@ describe("dot account", { timeout: 15_000 }, () => {
       ],
     });
     const { stdout, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/import.json", "--json"],
+      ["account", "import", "{{HOME}}/import.json", "--json"],
       { files: { "import.json": importData } },
     );
     expect(exitCode).toBe(0);
@@ -1067,7 +1032,7 @@ describe("dot account", { timeout: 15_000 }, () => {
       ],
     });
     const { stdout, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/import.json", "--json"],
+      ["account", "import", "{{HOME}}/import.json", "--json"],
       { files: { "import.json": importData } },
     );
     expect(exitCode).toBe(0);
@@ -1087,7 +1052,7 @@ describe("dot account", { timeout: 15_000 }, () => {
       ],
     });
     const { stdout, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/import.json", "--json"],
+      ["account", "import", "{{HOME}}/import.json", "--json"],
       { files: { "import.json": importData } },
     );
     expect(exitCode).toBe(0);
@@ -1099,25 +1064,23 @@ describe("dot account", { timeout: 15_000 }, () => {
     const importData = JSON.stringify({
       accounts: [{ name: "alice", publicKey: "0xaabb", derivationPath: "" }],
     });
-    const { stderr, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/import.json"],
-      { files: { "import.json": importData } },
-    );
+    const { stderr, exitCode } = await runCli(["account", "import", "{{HOME}}/import.json"], {
+      files: { "import.json": importData },
+    });
     expect(exitCode).toBe(0);
     expect(stderr).toContain("Skipped");
     expect(stderr).toContain("dev account");
   });
 
   test("batch import invalid JSON errors", async () => {
-    const { stderr, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/bad.json"],
-      { files: { "bad.json": "not valid json" } },
-    );
+    const { stderr, exitCode } = await runCli(["account", "import", "{{HOME}}/bad.json"], {
+      files: { "bad.json": "not valid json" },
+    });
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Invalid JSON");
   });
 
-  test("batch import from stdin via /dev/stdin", async () => {
+  test("batch import from stdin", async () => {
     const importData = JSON.stringify({
       accounts: [
         {
@@ -1127,11 +1090,12 @@ describe("dot account", { timeout: 15_000 }, () => {
         },
       ],
     });
-    const { stdout, exitCode } = await runCli(["account", "import", "--file", "/dev/stdin"], {
+    const { stdout, exitCode } = await runCli(["account", "import", "-"], {
       stdin: importData,
     });
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Added: stdin-acct");
+    expect(stdout).toContain("stdin-acct");
+    expect(stdout).toContain("1 added");
   });
 
   test("batch import --json returns structured output", async () => {
@@ -1145,7 +1109,7 @@ describe("dot account", { timeout: 15_000 }, () => {
       ],
     });
     const { stdout, exitCode } = await runCli(
-      ["account", "import", "--file", "{{HOME}}/import.json", "--json"],
+      ["account", "import", "{{HOME}}/import.json", "--json"],
       { files: { "import.json": importData } },
     );
     expect(exitCode).toBe(0);
@@ -1161,8 +1125,8 @@ describe("dot account", { timeout: 15_000 }, () => {
     });
     expect(exported.exitCode).toBe(0);
 
-    // Import into clean environment via /dev/stdin
-    const imported = await runCli(["account", "import", "--file", "/dev/stdin", "--json"], {
+    // Import into clean environment via stdin
+    const imported = await runCli(["account", "import", "-", "--json"], {
       stdin: exported.stdout,
     });
     expect(imported.exitCode).toBe(0);
@@ -1171,11 +1135,10 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(result.added).toContain("treasury");
   });
 
-  test("existing single import still works alongside batch import", async () => {
-    // Existing single-account import should still work
+  test("single-account add still works alongside batch import", async () => {
     const { stdout, exitCode } = await runCli([
       "account",
-      "import",
+      "add",
       "test-single",
       "--secret",
       TEST_MNEMONIC,
@@ -1183,5 +1146,65 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("Account Imported");
     expect(stdout).toContain("test-single");
+  });
+
+  test("batch import prints per-item lines, not comma-joined summary", async () => {
+    const importData = JSON.stringify({
+      accounts: [
+        {
+          name: "acct-a",
+          publicKey: "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+          derivationPath: "",
+        },
+        {
+          name: "acct-b",
+          publicKey: "0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48",
+          derivationPath: "",
+        },
+        {
+          name: "acct-c",
+          publicKey: "0x306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20",
+          derivationPath: "",
+        },
+      ],
+    });
+    const { stdout, exitCode } = await runCli(
+      ["account", "import", "{{HOME}}/import.json", "--dry-run"],
+      { files: { "import.json": importData } },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/✓ acct-a\b/);
+    expect(stdout).toMatch(/✓ acct-b\b/);
+    expect(stdout).toMatch(/✓ acct-c\b/);
+    expect(stdout).not.toContain("acct-a, acct-b, acct-c");
+    expect(stdout).not.toContain("Added: acct-a");
+    expect(stdout).toContain("3 added");
+  });
+
+  test("batch import empty file prints no-accounts message", async () => {
+    const importData = JSON.stringify({ accounts: [] });
+    const { stdout, exitCode } = await runCli(
+      ["account", "import", "{{HOME}}/import.json", "--dry-run"],
+      { files: { "import.json": importData } },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("No accounts imported");
+  });
+
+  test("account import no longer accepts --secret (single-import removed)", async () => {
+    // `dot account import <name> --secret ...` must NOT create an account anymore.
+    // The canonical path is `dot account add <name> --secret ...`.
+    const { exitCode } = await runCli(
+      ["account", "import", "should-not-work", "--secret", TEST_MNEMONIC],
+      {},
+    );
+    // Either errors or no-op, but MUST NOT create an account.
+    const list = await runCli(["account", "list", "--json"]);
+    const parsed = JSON.parse(list.stdout);
+    const match = parsed.accounts?.find?.((a: { name: string }) => a.name === "should-not-work");
+    expect(match).toBeUndefined();
+    // Exit code can be 0 (help shown) or 1 (invalid JSON when no stdin);
+    // either way, no account was created.
+    expect([0, 1]).toContain(exitCode);
   });
 });

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -24,6 +24,7 @@ import {
   formatJson,
   isJsonOutput,
   printHeading,
+  printImportResults,
   printItem,
   RESET,
   YELLOW,
@@ -35,9 +36,7 @@ ${BOLD}Usage:${RESET}
   $ dot account add <name> --secret <s> [--path <derivation>]        Import from BIP39 mnemonic
   $ dot account add <name> --env <VAR> [--path <derivation>]         Import account backed by env variable
   $ dot account create|new <name> [--path <derivation>]              Create a new account
-  $ dot account import <name> --secret <s> [--path <derivation>]     Import from BIP39 mnemonic
-  $ dot account import <name> --env <VAR> [--path <derivation>]      Import account backed by env variable
-  $ dot account import --file <path>                                 Batch-import accounts from a file
+  $ dot account import <file>                                        Batch-import accounts from a file
   $ dot account export [names...]                                    Export accounts to stdout
   $ dot account derive <source> <new-name> --path <derivation>       Derive a child account
   $ dot account inspect <input> [--prefix <N>]                       Inspect an account/address/key
@@ -46,14 +45,14 @@ ${BOLD}Usage:${RESET}
 
 ${BOLD}Examples:${RESET}
   $ dot account add treasury 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+  $ dot account add treasury --secret "word1 word2 ... word12"
+  $ dot account add ci-signer --env MY_SECRET --path //ci
   $ dot account create my-validator
   $ dot account create my-staking --path //staking
   $ dot account create multi --path //polkadot//0/wallet
-  $ dot account import treasury --secret "word1 word2 ... word12"
-  $ dot account import ci-signer --env MY_SECRET --path //ci
-  $ dot account import --file team-accounts.json
-  $ dot account import --file accounts.json --dry-run
-  $ dot account import --file accounts.json --overwrite
+  $ dot account import team-accounts.json
+  $ dot account import accounts.json --dry-run
+  $ dot account import accounts.json --overwrite
   $ dot account export
   $ dot account export treasury my-validator
   $ dot account export --include-secrets --file backup.json
@@ -117,8 +116,7 @@ export function registerAccountCommands(cli: CAC) {
             if (opts.secret || opts.env) return accountImport(names[0], opts);
             return accountAddWatchOnly(names[0], names[1], opts);
           case "import":
-            if (opts.file) return accountBatchImport(opts);
-            return accountImport(names[0], opts);
+            return accountBatchImport(names[0], opts);
           case "export":
             return accountExport(names, opts);
           case "derive":
@@ -780,18 +778,26 @@ async function accountExport(
   }
 }
 
-async function accountBatchImport(opts: {
-  file?: string;
-  overwrite?: boolean;
-  dryRun?: boolean;
-  output?: string;
-  json?: boolean;
-}) {
+async function accountBatchImport(
+  filePath: string | undefined,
+  opts: {
+    file?: string;
+    overwrite?: boolean;
+    dryRun?: boolean;
+    output?: string;
+    json?: boolean;
+  },
+) {
+  const inputPath = filePath ?? opts.file;
   let raw: string;
-  if (!opts.file || opts.file === "-") {
+  if (!inputPath || inputPath === "-") {
+    if (process.stdin.isTTY) {
+      console.log(ACCOUNT_HELP);
+      return;
+    }
     raw = await readStdin();
   } else {
-    raw = await readFile(opts.file, "utf-8");
+    raw = await readFile(inputPath, "utf-8");
   }
 
   let importData: AccountExportData;
@@ -894,12 +900,11 @@ async function accountBatchImport(opts: {
     return;
   }
 
-  const prefix = opts.dryRun ? "(dry run) " : "";
-  if (added.length > 0) console.log(`${prefix}Added: ${added.join(", ")}`);
-  if (overwritten.length > 0) console.log(`${prefix}Overwritten: ${overwritten.join(", ")}`);
-  if (skipped.length > 0) console.log(`${prefix}Skipped: ${skipped.join(", ")}`);
-
-  if (added.length === 0 && overwritten.length === 0) {
-    console.log(`${prefix}No accounts imported.`);
-  }
+  printImportResults({
+    added,
+    overwritten,
+    skipped,
+    dryRun: opts.dryRun ?? false,
+    noun: "account",
+  });
 }

--- a/src/commands/chain.test.ts
+++ b/src/commands/chain.test.ts
@@ -572,11 +572,15 @@ describe("dot chain", () => {
         kusama: { rpc: "wss://kusama-rpc.polkadot.io" },
       },
     });
-    const { stdout, exitCode } = await runCli(["chain", "import", "{{HOME}}/import.json"], {
-      files: { "import.json": importData },
-    });
+    const { stdout, exitCode } = await runCli(
+      ["chain", "import", "{{HOME}}/import.json", "--no-metadata"],
+      {
+        files: { "import.json": importData },
+      },
+    );
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Added: kusama");
+    expect(stdout).toContain("kusama");
+    expect(stdout).toContain("1 added");
 
     // Verify it was actually added
     const list = await runCli(["chain", "list", "--json"], {
@@ -596,15 +600,19 @@ describe("dot chain", () => {
         kusama: { rpc: "wss://new-endpoint.example" },
       },
     });
-    const { stdout, stderr, exitCode } = await runCli(["chain", "import", "{{HOME}}/import.json"], {
-      config: {
-        chains: { kusama: { rpc: "wss://kusama-rpc.polkadot.io" } },
+    const { stdout, stderr, exitCode } = await runCli(
+      ["chain", "import", "{{HOME}}/import.json", "--no-metadata"],
+      {
+        config: {
+          chains: { kusama: { rpc: "wss://kusama-rpc.polkadot.io" } },
+        },
+        files: { "import.json": importData },
       },
-      files: { "import.json": importData },
-    });
+    );
     expect(exitCode).toBe(0);
     expect(stderr).toContain("Skipped");
-    expect(stdout).toContain("Skipped: kusama");
+    expect(stdout).toContain("kusama (skipped)");
+    expect(stdout).toContain("1 skipped");
   });
 
   test("import --overwrite replaces existing chains", async () => {
@@ -615,7 +623,7 @@ describe("dot chain", () => {
       },
     });
     const { stdout, exitCode } = await runCli(
-      ["chain", "import", "{{HOME}}/import.json", "--overwrite"],
+      ["chain", "import", "{{HOME}}/import.json", "--overwrite", "--no-metadata"],
       {
         config: {
           chains: { kusama: { rpc: "wss://kusama-rpc.polkadot.io" } },
@@ -624,7 +632,9 @@ describe("dot chain", () => {
       },
     );
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Overwritten: kusama");
+    expect(stdout).toContain("kusama");
+    expect(stdout).toContain("(overwritten)");
+    expect(stdout).toContain("1 overwritten");
   });
 
   test("import --dry-run does not persist changes", async () => {
@@ -642,7 +652,13 @@ describe("dot chain", () => {
     );
     expect(exitCode).toBe(0);
     expect(stdout).toContain("(dry run)");
-    expect(stdout).toContain("Added: kusama");
+    expect(stdout).toContain("kusama");
+    expect(stdout).toContain("1 added");
+  });
+
+  test("import bare (no file, no stdin) errors without hanging", async () => {
+    const { exitCode } = await runCli(["chain", "import"]);
+    expect(exitCode).toBe(1);
   });
 
   test("import warns about missing relay reference", async () => {
@@ -656,9 +672,12 @@ describe("dot chain", () => {
         },
       },
     });
-    const { stderr, exitCode } = await runCli(["chain", "import", "{{HOME}}/import.json"], {
-      files: { "import.json": importData },
-    });
+    const { stderr, exitCode } = await runCli(
+      ["chain", "import", "{{HOME}}/import.json", "--no-metadata"],
+      {
+        files: { "import.json": importData },
+      },
+    );
     expect(exitCode).toBe(0);
     expect(stderr).toContain("nonexistent-relay");
     expect(stderr).toContain("does not exist");
@@ -706,9 +725,12 @@ describe("dot chain", () => {
         kusama: { rpc: "wss://kusama-rpc.polkadot.io" },
       },
     });
-    const { stdout, exitCode } = await runCli(["chain", "import", "-"], { stdin: importData });
+    const { stdout, exitCode } = await runCli(["chain", "import", "-", "--no-metadata"], {
+      stdin: importData,
+    });
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Added: kusama");
+    expect(stdout).toContain("kusama");
+    expect(stdout).toContain("1 added");
   });
 
   test("export round-trip: export then import is consistent", async () => {
@@ -740,17 +762,76 @@ describe("dot chain", () => {
     expect(result.added).toContain("local-para");
   });
 
-  test("import suggests running chain update", async () => {
+  test("import --no-metadata skips metadata fetch", async () => {
     const importData = JSON.stringify({
       defaultChain: "polkadot",
       chains: {
         kusama: { rpc: "wss://kusama-rpc.polkadot.io" },
       },
     });
-    const { stderr, exitCode } = await runCli(["chain", "import", "{{HOME}}/import.json"], {
-      files: { "import.json": importData },
-    });
+    const { stderr, exitCode } = await runCli(
+      ["chain", "import", "{{HOME}}/import.json", "--no-metadata"],
+      {
+        files: { "import.json": importData },
+      },
+    );
     expect(exitCode).toBe(0);
-    expect(stderr).toContain("dot chain update --all");
+    expect(stderr).not.toContain("Updating metadata");
+    expect(stderr).not.toContain("dot chain update --all");
+  });
+
+  test("import prints per-item lines, not comma-joined summary", async () => {
+    const importData = JSON.stringify({
+      chains: {
+        "new-a": { rpc: "wss://a.example" },
+        "new-b": { rpc: "wss://b.example" },
+        "new-c": { rpc: "wss://c.example" },
+      },
+    });
+    const { stdout, exitCode } = await runCli(
+      ["chain", "import", "{{HOME}}/import.json", "--dry-run"],
+      { files: { "import.json": importData } },
+    );
+    expect(exitCode).toBe(0);
+    // Each chain name appears on its own line prefixed by the ✓ tick
+    expect(stdout).toMatch(/✓ new-a\b/);
+    expect(stdout).toMatch(/✓ new-b\b/);
+    expect(stdout).toMatch(/✓ new-c\b/);
+    // The old comma-joined "Added: a, b, c" format should be gone
+    expect(stdout).not.toContain("new-a, new-b, new-c");
+    expect(stdout).not.toContain("Added: new-a");
+    // Count summary replaces the old format
+    expect(stdout).toContain("3 added");
+  });
+
+  test("import summary lists added, overwritten, and skipped counts", async () => {
+    const importData = JSON.stringify({
+      chains: {
+        kusama: { rpc: "wss://new-kusama.example" },
+        westend: { rpc: "wss://westend.example" },
+        polkadot: { rpc: "wss://existing.example" },
+      },
+    });
+    const { stdout, exitCode } = await runCli(
+      ["chain", "import", "{{HOME}}/import.json", "--overwrite", "--dry-run"],
+      {
+        config: { chains: { kusama: { rpc: "wss://old-kusama.example" } } },
+        files: { "import.json": importData },
+      },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("1 added");
+    expect(stdout).toContain("overwritten");
+    expect(stdout).toContain("(dry run)");
+  });
+
+  test("import empty file prints no-chains message", async () => {
+    const importData = JSON.stringify({ chains: {} });
+    const { stdout, exitCode } = await runCli(
+      ["chain", "import", "{{HOME}}/import.json", "--dry-run"],
+      { files: { "import.json": importData } },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("No chains imported");
   });
 });

--- a/src/commands/chain.ts
+++ b/src/commands/chain.ts
@@ -24,6 +24,7 @@ import {
   GREEN,
   isJsonOutput,
   printHeading,
+  printImportResults,
   RED,
   RESET,
   YELLOW,
@@ -54,6 +55,7 @@ ${BOLD}Examples:${RESET}
   $ dot chain import my-chains.json
   $ dot chain import my-chains.json --dry-run
   $ dot chain import my-chains.json --overwrite
+  $ dot chain import my-chains.json --no-metadata
 `.trimStart();
 
 export function registerChainCommands(cli: CAC) {
@@ -69,6 +71,7 @@ export function registerChainCommands(cli: CAC) {
     .option("--file <path>", "Output/input file for export/import")
     .option("--overwrite", "Overwrite existing chains on import")
     .option("--dry-run", "Preview import without applying changes")
+    .option("--no-metadata", "Skip automatic metadata fetch after import")
     .action(
       async (
         action: string | undefined,
@@ -81,6 +84,7 @@ export function registerChainCommands(cli: CAC) {
           file?: string;
           overwrite?: boolean;
           dryRun?: boolean;
+          metadata?: boolean;
           output?: string;
           json?: boolean;
         },
@@ -341,8 +345,20 @@ async function chainUpdateAll(config: {
   chains: Record<string, import("../config/types.ts").ChainConfig>;
 }) {
   const chainNames = Object.keys(config.chains).sort();
+  const failed = await updateChainsMetadata(config, chainNames);
+  if (failed > 0) {
+    console.error(`\n${failed} of ${chainNames.length} chains failed to update.`);
+    process.exit(1);
+  }
+}
 
-  process.stderr.write(`Updating metadata for ${chainNames.length} chains...\n\n`);
+async function updateChainsMetadata(
+  config: { chains: Record<string, import("../config/types.ts").ChainConfig> },
+  chainNames: string[],
+): Promise<number> {
+  if (chainNames.length === 0) return 0;
+
+  process.stderr.write(`Updating metadata for ${chainNames.length} chain(s)...\n\n`);
 
   const results = await Promise.allSettled(
     chainNames.map(async (chainName) => {
@@ -368,11 +384,7 @@ async function chainUpdateAll(config: {
     }
   }
 
-  const failed = results.filter((r) => r.status === "rejected").length;
-  if (failed > 0) {
-    console.error(`\n${failed} of ${chainNames.length} chains failed to update.`);
-    process.exit(1);
-  }
+  return results.filter((r) => r.status === "rejected").length;
 }
 
 function isBuiltinModified(name: string, config: Config): boolean {
@@ -455,17 +467,21 @@ async function chainImport(
     file?: string;
     overwrite?: boolean;
     dryRun?: boolean;
+    metadata?: boolean;
     output?: string;
     json?: boolean;
   },
 ) {
-  // Resolve input: positional arg, --file flag, or stdin
   const inputPath = filePath ?? opts.file;
   let raw: string;
-  if (inputPath && inputPath !== "-") {
-    raw = await readFile(inputPath, "utf-8");
-  } else {
+  if (!inputPath || inputPath === "-") {
+    if (process.stdin.isTTY) {
+      console.log(CHAIN_HELP);
+      return;
+    }
     raw = await readStdin();
+  } else {
+    raw = await readFile(inputPath, "utf-8");
   }
 
   let importData: ChainExportData;
@@ -496,7 +512,6 @@ async function chainImport(
       continue;
     }
 
-    // Validate relay reference
     if (chainConfig.relay) {
       const relayInImport = Object.keys(importData.chains).some(
         (n) => n.toLowerCase() === chainConfig.relay!.toLowerCase(),
@@ -538,14 +553,16 @@ async function chainImport(
     return;
   }
 
-  const prefix = opts.dryRun ? "(dry run) " : "";
-  if (added.length > 0) console.log(`${prefix}Added: ${added.join(", ")}`);
-  if (overwritten.length > 0) console.log(`${prefix}Overwritten: ${overwritten.join(", ")}`);
-  if (skipped.length > 0) console.log(`${prefix}Skipped: ${skipped.join(", ")}`);
+  printImportResults({
+    added,
+    overwritten,
+    skipped,
+    dryRun: opts.dryRun ?? false,
+    noun: "chain",
+  });
 
-  if (added.length === 0 && overwritten.length === 0) {
-    console.log(`${prefix}No chains imported.`);
-  } else if (!opts.dryRun) {
-    console.error(`\nRun "dot chain update --all" to fetch metadata for imported chains.`);
+  if (!opts.dryRun && opts.metadata !== false && (added.length > 0 || overwritten.length > 0)) {
+    console.log();
+    await updateChainsMetadata(config, [...added, ...overwritten]);
   }
 }

--- a/src/core/output.test.ts
+++ b/src/core/output.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { Binary } from "polkadot-api";
-import { firstSentence, formatJson, formatPretty, isJsonOutput, Spinner } from "./output.ts";
+import {
+  firstSentence,
+  formatJson,
+  formatPretty,
+  isJsonOutput,
+  printImportResults,
+  Spinner,
+} from "./output.ts";
 
 describe("formatJson", () => {
   test("formats object with 2-space indentation", () => {
@@ -249,6 +256,123 @@ describe("firstSentence", () => {
     expect(firstSentence(["Use e.g. this method. Then do something else."])).toBe(
       "Use e.g. this method.",
     );
+  });
+});
+
+describe("printImportResults", () => {
+  const capture = (fn: () => void): string => {
+    const lines: string[] = [];
+    const spy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    });
+    try {
+      fn();
+    } finally {
+      spy.mockRestore();
+    }
+    return lines.join("\n");
+  };
+
+  test("prints one line per added entry with a checkmark", () => {
+    const out = capture(() =>
+      printImportResults({
+        added: ["a", "b", "c"],
+        overwritten: [],
+        skipped: [],
+        dryRun: false,
+        noun: "chain",
+      }),
+    );
+    expect(out).toMatch(/✓ a/);
+    expect(out).toMatch(/✓ b/);
+    expect(out).toMatch(/✓ c/);
+    // No comma-joined list
+    expect(out).not.toContain("a, b, c");
+    expect(out).toContain("3 added");
+  });
+
+  test("prints overwritten entries with overwritten marker and count", () => {
+    const out = capture(() =>
+      printImportResults({
+        added: [],
+        overwritten: ["x", "y"],
+        skipped: [],
+        dryRun: false,
+        noun: "chain",
+      }),
+    );
+    expect(out).toContain("x");
+    expect(out).toContain("y");
+    expect(out).toContain("(overwritten)");
+    expect(out).toContain("2 overwritten");
+  });
+
+  test("prints skipped entries dimmed and counted", () => {
+    const out = capture(() =>
+      printImportResults({
+        added: [],
+        overwritten: [],
+        skipped: ["s1", "s2"],
+        dryRun: false,
+        noun: "account",
+      }),
+    );
+    expect(out).toContain("s1 (skipped)");
+    expect(out).toContain("s2 (skipped)");
+    expect(out).toContain("2 skipped");
+  });
+
+  test("summary combines multiple categories", () => {
+    const out = capture(() =>
+      printImportResults({
+        added: ["a"],
+        overwritten: ["b", "c"],
+        skipped: ["d"],
+        dryRun: false,
+        noun: "chain",
+      }),
+    );
+    expect(out).toContain("1 added, 2 overwritten, 1 skipped");
+  });
+
+  test("dry-run adds suffix to summary", () => {
+    const out = capture(() =>
+      printImportResults({
+        added: ["a"],
+        overwritten: [],
+        skipped: [],
+        dryRun: true,
+        noun: "chain",
+      }),
+    );
+    expect(out).toContain("1 added (dry run)");
+  });
+
+  test("no results prints 'No <noun>s imported' with dry-run prefix", () => {
+    const out = capture(() =>
+      printImportResults({
+        added: [],
+        overwritten: [],
+        skipped: [],
+        dryRun: true,
+        noun: "chain",
+      }),
+    );
+    expect(out).toContain("(dry run) No chains imported");
+  });
+
+  test("no results without dry-run still uses the noun", () => {
+    const out = capture(() =>
+      printImportResults({
+        added: [],
+        overwritten: [],
+        skipped: [],
+        dryRun: false,
+        noun: "account",
+      }),
+    );
+    expect(out).toContain("No accounts imported");
+    expect(out).not.toContain("(dry run)");
   });
 });
 

--- a/src/core/output.ts
+++ b/src/core/output.ts
@@ -75,6 +75,40 @@ export function printDocs(docs: string[]): void {
 
 const CHECK_MARK = "✓";
 
+export function printImportResults(params: {
+  added: string[];
+  overwritten: string[];
+  skipped: string[];
+  dryRun: boolean;
+  noun: string;
+}): void {
+  const { added, overwritten, skipped, dryRun, noun } = params;
+
+  for (const name of added) {
+    console.log(`  ${GREEN}${CHECK_MARK}${RESET} ${name}`);
+  }
+  for (const name of overwritten) {
+    console.log(`  ${YELLOW}⟳${RESET} ${name}${DIM} (overwritten)${RESET}`);
+  }
+  for (const name of skipped) {
+    console.log(`  ${DIM}- ${name} (skipped)${RESET}`);
+  }
+
+  if (added.length === 0 && overwritten.length === 0 && skipped.length === 0) {
+    const prefix = dryRun ? "(dry run) " : "";
+    console.log(`${prefix}No ${noun}s imported.`);
+    return;
+  }
+
+  const parts: string[] = [];
+  if (added.length > 0) parts.push(`${added.length} added`);
+  if (overwritten.length > 0) parts.push(`${overwritten.length} overwritten`);
+  if (skipped.length > 0) parts.push(`${skipped.length} skipped`);
+  const suffix = dryRun ? " (dry run)" : "";
+  console.log();
+  console.log(`${parts.join(", ")}${suffix}`);
+}
+
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 class Spinner {


### PR DESCRIPTION
## Summary

- Per-item status output (`✓` added, `⟳` overwritten, `-` skipped) with a terse count summary, replacing the unreadable comma-joined `Added: a, b, c, ...` line that could span hundreds of characters.
- `dot chain import` / `dot account import` with no file argument no longer hang on stdin in an interactive terminal — they print the subcommand help instead. Piped stdin (`cat file | dot … import` or `… import -`) still works.
- After a non-dry-run `dot chain import`, metadata is fetched automatically for newly added or overwritten chains so tab completion and metadata-dependent commands work immediately. Opt out with `--no-metadata` (useful for offline / CI bootstrap).
- `dot account import` is now file-only and takes the file path positionally, matching `dot chain import`. The previous single-account form (`dot account import <name> --secret …` / `--env …`) has been removed; `dot account add` is the canonical single-account path (and has always supported `--secret` / `--env`).

Example output:

```
  ✓ preview
  ✓ preview-people
  ⟳ polkadot (overwritten)
  - paseo (skipped)

2 added, 1 overwritten, 1 skipped

Updating metadata for 3 chain(s)...

  ✓ preview
  ✓ preview-people
  ✓ polkadot
```

Changeset: `.changeset/import-ux-improvements.md` (minor).

## Test plan

- [x] `bun test` — 1315 pass, 0 fail
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run build` succeeds
- [x] Coverage didn't regress — overall 68.71% → 68.91%; `src/core/output.ts` 91.57% → 93.46% (added 7 direct unit tests for the new `printImportResults` helper so it's tracked, since command modules run via subprocess and aren't picked up by lcov).
- [x] README and `docs/content/_index.md` updated with the new output, `--no-metadata`, auto-metadata, positional-file form, and migration note (`dot account import <name> --secret` → `dot account add <name> --secret`).
- [ ] Manual smoke: `dot chain import ./dot-chain-export.json --dry-run` shows per-item lines and count summary.
- [ ] Manual smoke: `dot chain import ./dot-chain-export.json` (non-dry-run) auto-fetches metadata for new chains.
- [ ] Manual smoke: `dot account import` with no args shows help instead of hanging.
- [ ] Manual smoke: `dot account import accounts.json` (positional) works; `dot account import --file accounts.json` still works for back-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)