### PR TITLE
fix(extensions): include chain in help, usage hints, and error suggestions

### DIFF
--- a/.changeset/fix-extensions-help-chain.md
+++ b/.changeset/fix-extensions-help-chain.md
@@ -1,0 +1,18 @@
+---
+"polkadot-cli": patch
+---
+
+Fix `extensions` help and docs that assumed the removed default chain.
+
+After the default-chain removal every chain-consuming command requires
+`--chain <name>` or a `<chain>.` dotpath prefix. A few surfaces introduced
+alongside `dot extensions` were still suggesting commands without either:
+
+- The custom-extension detail view's `--ext` Usage hint now includes the
+  resolved chain (`dot <chain>.tx.<Pallet>.<Call> --from <acc> --ext ...`).
+- The "transaction extensions have no sub-items" error now preserves the
+  chain the user supplied — prefix form when they used a `<chain>.` prefix,
+  `--chain <name>` when they used the flag, and a `<chain>` placeholder
+  when neither was set.
+- The top-of-file feature bullet in `README.md` and `docs/content/_index.md`
+  reads `dot <chain>.extensions` instead of `dot extensions`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Ships with Polkadot and all system parachains preconfigured with multiple fallba
 - ✅ zsh, bash, and fish autocompletion
 - ✅ Exposes all on-chain metadata documentation
 - ✅ Encode, dry-run, and submit extrinsics
-- ✅ Support for custom signed extensions — and a `dot extensions` inspector to discover them
+- ✅ Support for custom signed extensions — and a `dot <chain>.extensions` inspector to discover them
 - ✅ Built with agent use in mind — structured JSON output on every command (`--json`)
 - ✅ Fuzzy matching with typo suggestions
 - ✅ Account management — BIP39 mnemonics, derivation paths, env-backed secrets, watch-only, dev accounts

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -9,7 +9,7 @@ A command-line tool for interacting with Polkadot-ecosystem chains. Manage chain
 - ✅ zsh, bash, and fish autocompletion
 - ✅ Exposes all on-chain metadata documentation
 - ✅ Encode, dry-run, and submit extrinsics
-- ✅ Support for custom signed extensions — and a `dot extensions` inspector to discover them
+- ✅ Support for custom signed extensions — and a `dot <chain>.extensions` inspector to discover them
 - ✅ Built with agent use in mind — structured JSON output on every command (`--json`)
 - ✅ Fuzzy matching with typo suggestions
 - ✅ Account management — BIP39 mnemonics, derivation paths, env-backed secrets, watch-only, dev accounts

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -272,9 +272,12 @@ if (process.argv[2] === "__complete") {
             break;
           case "extensions": {
             if (parsed.item) {
-              throw new CliError(
-                `Transaction extensions have no sub-items. Try "dot extensions.${parsed.pallet}".`,
-              );
+              const suggestion = parsed.chain
+                ? `dot ${parsed.chain}.extensions.${parsed.pallet}`
+                : opts.chain
+                  ? `dot extensions.${parsed.pallet} --chain ${opts.chain}`
+                  : `dot extensions.${parsed.pallet} --chain <chain>`;
+              throw new CliError(`Transaction extensions have no sub-items. Try "${suggestion}".`);
             }
             await handleExtensions(parsed.pallet, handlerOpts);
             break;

--- a/src/commands/focused-inspect.ts
+++ b/src/commands/focused-inspect.ts
@@ -780,7 +780,7 @@ export async function handleExtensions(
     console.log();
     console.log(`${BOLD}Usage:${RESET}`);
     console.log(
-      `  dot tx.<Pallet>.<Call> --from <acc> --ext '{"${described.identifier}":{"value":<v>}}'`,
+      `  dot ${chainName}.tx.<Pallet>.<Call> --from <acc> --ext '{"${described.identifier}":{"value":<v>}}'`,
     );
   }
   console.log();


### PR DESCRIPTION
## Summary

- After the default-chain removal (`efd2e56`), every chain-consuming command requires `--chain <name>` or a `<chain>.` dotpath prefix. Three surfaces introduced alongside `dot extensions` still suggested commands without either — this PR brings them in line.
- `src/commands/focused-inspect.ts`: the custom-extension detail view's `--ext` Usage hint now prints `dot <chain>.tx.<Pallet>.<Call> ...` using the resolved `chainName`.
- `src/cli.ts`: the "transaction extensions have no sub-items" error now preserves the chain the user supplied — prefix form when they used a `<chain>.` prefix, `--chain <name>` form when they used the flag, or a `<chain>` placeholder otherwise.
- `README.md` / `docs/content/_index.md`: top-of-file feature bullet now reads `dot <chain>.extensions` instead of `dot extensions`.

## Test plan

- [x] `bun test` — all 1304 tests pass, including the `dot extensions` sub-item rejection test.
- [x] Manually exercised both error paths:
  - `dot polkadot.extensions.CheckMortality.value` → `Try "dot polkadot.extensions.CheckMortality"`
  - `dot extensions.CheckMortality.value --chain polkadot` → `Try "dot extensions.CheckMortality --chain polkadot"`
- [x] Repo-wide grep confirms no remaining `dot extensions` / `dot ext ` invocations without `--chain` or a chain prefix.

Includes a `patch` changeset.