### PR TITLE
feat(account): add --show-secret to reveal sr25519 expanded private key

### DIFF
--- a/.changeset/show-secret-private-key.md
+++ b/.changeset/show-secret-private-key.md
@@ -1,0 +1,16 @@
+---
+"polkadot-cli": minor
+---
+
+Add `--show-secret` to `dot account inspect`.
+
+Prints the **64-byte sr25519 expanded secret key** as `0x`-prefixed hex
+alongside the public key and SS58 address. Works for dev accounts
+(Alice/Bob/Charlie/Dave/Eve/Ferdie, derived on-the-fly) and for stored
+accounts that have a resolvable secret (mnemonic or hex seed). Refuses on
+watch-only accounts, bare SS58 addresses, or hex public keys.
+
+The emitted hex is the final secret after any derivation path is applied, so
+it can be pasted directly into signers that don't accept a mnemonic+path
+combination (e.g. services that expect a raw `PRIVATE_KEY` env var). In
+`--json` mode the value is surfaced under the `privateKey` field.

--- a/README.md
+++ b/README.md
@@ -321,6 +321,17 @@ dot account inspect alice --json
 # {"publicKey":"0xd435...a27d","ss58":"5Grw...utQY","prefix":42,"name":"Alice"}
 ```
 
+#### Reveal the sr25519 private key
+
+For provisioning another signer (e.g. a server that expects a raw hex private key in an env var), add `--show-secret` to print the **64-byte sr25519 expanded secret** as `0x`-prefixed hex:
+
+```bash
+dot account inspect dave --show-secret
+# Private Key: 0x<128 hex chars>   (sr25519 expanded, 64 bytes — never share)
+```
+
+Works for dev accounts (derived on-the-fly from the standard dev mnemonic) and for stored accounts that have a secret (mnemonic or hex seed). Refuses on watch-only accounts, bare SS58 addresses, or hex public keys. The hex is the final secret after any derivation path is applied, so it can be fed directly to signers that don't accept a mnemonic+path (e.g. `@scure/sr25519`'s `sign`, or services like identity-backend that read a `PROXY_PRIVATE_KEY`). Combine with `--json` to include it under the `privateKey` field.
+
 #### Env-var-backed accounts
 
 For CI/CD and security-conscious workflows, store a reference to an environment variable instead of the secret itself:

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@polkadot-api/view-builder": "^0.5.1",
         "@polkadot-labs/hdkd": "^0.0.28",
         "@polkadot-labs/hdkd-helpers": "^0.0.29",
+        "@scure/sr25519": "^1.0.0",
         "cac": "^6.7.14",
         "polkadot-api": "^2.0.1",
         "verifiablejs": "^1.2.0",

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -555,6 +555,17 @@ dot account inspect alice --json
 # {"publicKey":"0xd435...a27d","ss58":"5Grw...utQY","prefix":42,"name":"Alice"}
 ```
 
+### Reveal the sr25519 private key
+
+Add `--show-secret` to print the **64-byte sr25519 expanded secret** as `0x`-prefixed hex — useful for provisioning another signer (e.g. a server that expects a raw hex private key in an env var):
+
+```
+dot account inspect dave --show-secret
+# Private Key: 0x<128 hex chars>   (sr25519 expanded, 64 bytes — never share)
+```
+
+Works for dev accounts (derived on-the-fly from the standard dev mnemonic) and for stored accounts that have a secret (mnemonic or hex seed). Refuses on watch-only accounts, bare SS58 addresses, or hex public keys. The hex is the final secret after any derivation path is applied, so it can be fed directly to signers that don't accept a mnemonic+path. Combine with `--json` to include it under the `privateKey` field.
+
 ## Chain Prefix
 
 Prefix the dot-path with a chain name to target a specific chain instead of using the `--chain` flag. The prefix becomes the first segment of the dot-path:

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@polkadot-api/view-builder": "^0.5.1",
     "@polkadot-labs/hdkd": "^0.0.28",
     "@polkadot-labs/hdkd-helpers": "^0.0.29",
+    "@scure/sr25519": "^1.0.0",
     "cac": "^6.7.14",
     "polkadot-api": "^2.0.1",
     "verifiablejs": "^1.2.0",

--- a/src/commands/account.test.ts
+++ b/src/commands/account.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { StoredAccount } from "../config/accounts-types.ts";
+import { importAccount, publicKeyToHex } from "../core/accounts.ts";
 import { runCli, TEST_MNEMONIC } from "./__fixtures__/run-cli.ts";
 
 const STORED_ACCOUNT: StoredAccount = {
@@ -800,6 +801,113 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(parsed.publicKey).toMatch(/^0x/);
     expect(parsed.ss58).toBeDefined();
     expect(parsed.prefix).toBe(42);
+  });
+
+  // --show-secret tests
+  test("inspect dev account --show-secret prints 64-byte hex", async () => {
+    const { stdout, exitCode } = await runCli(["account", "inspect", "dave", "--show-secret"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Private Key:");
+    expect(stdout).toContain("sr25519 expanded, 64 bytes");
+    const match = stdout.match(/Private Key:\s+(0x[0-9a-f]+)/);
+    expect(match?.[1]).toMatch(/^0x[0-9a-f]{128}$/);
+  });
+
+  test("inspect --show-secret --json surfaces privateKey field", async () => {
+    const { stdout, exitCode } = await runCli([
+      "account",
+      "inspect",
+      "alice",
+      "--show-secret",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.privateKey).toMatch(/^0x[0-9a-f]{128}$/);
+  });
+
+  test("inspect --show-secret on stored account with mnemonic", async () => {
+    const { stdout, exitCode } = await runCli(
+      ["account", "inspect", "my-account", "--show-secret"],
+      { accounts: [STORED_ACCOUNT] },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/Private Key:\s+0x[0-9a-f]{128}/);
+  });
+
+  test("inspect --show-secret on stored account with hex-seed secret and soft path", async () => {
+    const hexSeed = `0x${"11".repeat(32)}`;
+    const softPath = "/soft";
+    const hexAcct: StoredAccount = {
+      name: "hex-acct",
+      secret: hexSeed,
+      publicKey: publicKeyToHex(importAccount(hexSeed, softPath).publicKey),
+      derivationPath: softPath,
+    };
+    const { stdout, exitCode } = await runCli(
+      ["account", "inspect", "hex-acct", "--show-secret", "--json"],
+      { accounts: [hexAcct] },
+    );
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.privateKey).toMatch(/^0x[0-9a-f]{128}$/);
+  });
+
+  test("inspect --show-secret exercises numeric //0 derivation", async () => {
+    const numericPath = "//0";
+    const hexAcct: StoredAccount = {
+      name: "numeric-acct",
+      secret: TEST_MNEMONIC,
+      publicKey: publicKeyToHex(importAccount(TEST_MNEMONIC, numericPath).publicKey),
+      derivationPath: numericPath,
+    };
+    const { stdout, exitCode } = await runCli(
+      ["account", "inspect", "numeric-acct", "--show-secret", "--json"],
+      { accounts: [hexAcct] },
+    );
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.privateKey).toMatch(/^0x[0-9a-f]{128}$/);
+  });
+
+  test("inspect --show-secret on watch-only account errors", async () => {
+    const watchOnly: StoredAccount = {
+      name: "treasury",
+      publicKey: "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+      derivationPath: "",
+    };
+    const { stderr, exitCode } = await runCli(["account", "inspect", "treasury", "--show-secret"], {
+      accounts: [watchOnly],
+    });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("watch-only");
+  });
+
+  test("inspect --show-secret on raw SS58 address errors", async () => {
+    const { stderr, exitCode } = await runCli([
+      "account",
+      "inspect",
+      "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      "--show-secret",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--show-secret requires an account name");
+  });
+
+  test("inspect --show-secret on env-backed account uses resolved env", async () => {
+    const envAcct: StoredAccount = {
+      name: "env-acct",
+      secret: { env: "MY_SECRET" },
+      publicKey: "",
+      derivationPath: "",
+    };
+    const { stdout, exitCode } = await runCli(
+      ["account", "inspect", "env-acct", "--show-secret", "--json"],
+      { accounts: [envAcct], env: { MY_SECRET: TEST_MNEMONIC } },
+    );
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.privateKey).toMatch(/^0x[0-9a-f]{128}$/);
   });
 
   test("remove --json returns removed names", async () => {

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -8,6 +8,7 @@ import {
   type StoredAccount,
 } from "../config/accounts-types.ts";
 import {
+  bytesToHex,
   createNewAccount,
   DEV_NAMES,
   fromSs58,
@@ -16,6 +17,7 @@ import {
   isDevAccount,
   isHexPublicKey,
   publicKeyToHex,
+  resolveAccountExpandedSecret,
   toSs58,
   tryDerivePublicKey,
 } from "../core/accounts.ts";
@@ -39,7 +41,7 @@ ${BOLD}Usage:${RESET}
   $ dot account import <file>                                        Batch-import accounts from a file
   $ dot account export [names...]                                    Export accounts to stdout
   $ dot account derive <source> <new-name> --path <derivation>       Derive a child account
-  $ dot account inspect <input> [--prefix <N>]                       Inspect an account/address/key
+  $ dot account inspect <input> [--prefix <N>] [--show-secret]       Inspect an account/address/key
   $ dot account list                                                 List all accounts
   $ dot account remove|delete <name> [name2] ...                     Remove stored account(s)
 
@@ -59,6 +61,7 @@ ${BOLD}Examples:${RESET}
   $ dot account export --watch-only
   $ dot account derive treasury treasury-staking --path //staking
   $ dot account inspect alice
+  $ dot account inspect dave --show-secret
   $ dot account inspect 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
   $ dot account inspect 0xd435...a27d --prefix 0
   $ dot account list
@@ -85,6 +88,7 @@ export function registerAccountCommands(cli: CAC) {
     .option("--dry-run", "Preview batch import without applying changes")
     .option("--include-secrets", "Include secrets in export (redacted by default)")
     .option("--watch-only", "Export only watch-only accounts")
+    .option("--show-secret", "Reveal the 64-byte sr25519 expanded private key (inspect only)")
     .action(
       async (
         action: string | undefined,
@@ -99,6 +103,7 @@ export function registerAccountCommands(cli: CAC) {
           dryRun?: boolean;
           includeSecrets?: boolean;
           watchOnly?: boolean;
+          showSecret?: boolean;
           output?: string;
           json?: boolean;
         },
@@ -587,7 +592,7 @@ async function accountRemove(names: string[], opts: { output?: string; json?: bo
 
 async function accountInspect(
   input: string | undefined,
-  opts: { prefix?: string; output?: string },
+  opts: { prefix?: string; showSecret?: boolean; output?: string; json?: boolean },
 ) {
   if (!input) {
     console.error("Input is required.\n");
@@ -604,12 +609,14 @@ async function accountInspect(
   let name: string | undefined;
   let publicKeyHex: string;
   let bandersnatch: Record<string, string> | undefined;
+  let hasSecret = false;
 
   // 1. Dev account name
   if (isDevAccount(input)) {
     name = input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
     const devAddr = getDevAddress(input);
     publicKeyHex = publicKeyToHex(fromSs58(devAddr));
+    hasSecret = true;
   }
   // 2. Stored account name
   else {
@@ -618,6 +625,7 @@ async function accountInspect(
     if (account) {
       name = account.name;
       bandersnatch = account.bandersnatch;
+      hasSecret = account.secret !== undefined;
       if (account.publicKey) {
         publicKeyHex = account.publicKey;
       } else if (account.secret !== undefined && isEnvSecret(account.secret)) {
@@ -655,10 +663,31 @@ async function accountInspect(
 
   const ss58 = toSs58(publicKeyHex!, prefix);
 
+  let privateKeyHex: string | undefined;
+  if (opts.showSecret) {
+    if (!name) {
+      console.error(
+        "--show-secret requires an account name; raw addresses and hex keys have no secret to reveal.",
+      );
+      process.exit(1);
+    }
+    if (!hasSecret) {
+      console.error(`Account "${name}" is watch-only (no secret). Cannot reveal private key.`);
+      process.exit(1);
+    }
+    try {
+      privateKeyHex = bytesToHex(await resolveAccountExpandedSecret(input));
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  }
+
   if (isJsonOutput(opts)) {
     const result: Record<string, unknown> = { publicKey: publicKeyHex!, ss58, prefix };
     if (name) result.name = name;
     if (bandersnatch && Object.keys(bandersnatch).length > 0) result.bandersnatch = bandersnatch;
+    if (privateKeyHex) result.privateKey = privateKeyHex;
     console.log(formatJson(result));
   } else {
     printHeading("Account Info");
@@ -678,6 +707,10 @@ async function accountInspect(
       }
     }
     console.log(`  ${BOLD}Prefix:${RESET}      ${prefix}`);
+    if (privateKeyHex) {
+      console.log(`  ${BOLD}Private Key:${RESET} ${privateKeyHex}`);
+      console.log(`               ${YELLOW}(sr25519 expanded, 64 bytes — never share)${RESET}`);
+    }
     console.log();
   }
 }

--- a/src/core/accounts.test.ts
+++ b/src/core/accounts.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { getPublicKey, sign, verify } from "@scure/sr25519";
 import { TEST_MNEMONIC } from "../commands/__fixtures__/run-cli.ts";
 import type { StoredAccount } from "../config/accounts-types.ts";
 import { isEnvSecret, isWatchOnly } from "../config/accounts-types.ts";
 import {
+  bytesToHex,
   createNewAccount,
+  deriveExpandedSecret,
   fromSs58,
   getDevAddress,
   importAccount,
   isDevAccount,
   isHexPublicKey,
+  miniSecretFromSecret,
   publicKeyToHex,
+  resolveAccountExpandedSecret,
   resolveAccountKeypair,
   resolveAccountSigner,
   resolveSecret,
@@ -401,6 +406,118 @@ describe("isWatchOnly", () => {
       derivationPath: "",
     };
     expect(isWatchOnly(account)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAccountExpandedSecret — sr25519 expanded 64-byte private key
+// ---------------------------------------------------------------------------
+
+describe("resolveAccountExpandedSecret", () => {
+  test("dev account returns 64-byte expanded secret", async () => {
+    const secret = await resolveAccountExpandedSecret("dave");
+    expect(secret).toBeInstanceOf(Uint8Array);
+    expect(secret).toHaveLength(64);
+  });
+
+  test("getPublicKey(expandedSecret) matches the keypair's public key for all dev accounts", async () => {
+    for (const name of ["alice", "bob", "charlie", "dave", "eve", "ferdie"]) {
+      const secret = await resolveAccountExpandedSecret(name);
+      const keypair = await resolveAccountKeypair(name);
+      expect(publicKeyToHex(getPublicKey(secret))).toBe(publicKeyToHex(keypair.publicKey));
+    }
+  });
+
+  test("signatures made with expanded secret verify against the account's public key", async () => {
+    const secret = await resolveAccountExpandedSecret("dave");
+    const pub = getPublicKey(secret);
+    const message = new TextEncoder().encode("hello dave");
+    const sig = sign(secret, message);
+    expect(verify(message, sig, pub)).toBe(true);
+  });
+
+  test("all dev accounts produce distinct 64-byte expanded secrets", async () => {
+    const hexes = new Set<string>();
+    for (const name of ["alice", "bob", "charlie", "dave", "eve", "ferdie"]) {
+      const s = await resolveAccountExpandedSecret(name);
+      expect(s).toHaveLength(64);
+      hexes.add(bytesToHex(s));
+    }
+    expect(hexes.size).toBe(6);
+  });
+
+  test("unknown account throws", async () => {
+    await expect(resolveAccountExpandedSecret("nonexistent_xyz_42")).rejects.toThrow(
+      /Unknown account/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveExpandedSecret / miniSecretFromSecret
+// ---------------------------------------------------------------------------
+
+describe("miniSecretFromSecret", () => {
+  test("returns 32 bytes for a valid BIP39 mnemonic", () => {
+    const bytes = miniSecretFromSecret(TEST_MNEMONIC);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes).toHaveLength(32);
+  });
+
+  test("returns 32 bytes for a 0x-prefixed hex seed", () => {
+    const hexSeed = `0x${"11".repeat(32)}`;
+    const bytes = miniSecretFromSecret(hexSeed);
+    expect(bytes).toHaveLength(32);
+    // All-0x11 seed round-trips exactly
+    expect(bytesToHex(bytes)).toBe(hexSeed);
+  });
+
+  test("throws on garbage input", () => {
+    expect(() => miniSecretFromSecret("not-a-valid-secret")).toThrow("Invalid secret");
+  });
+});
+
+describe("deriveExpandedSecret", () => {
+  const rootSeed = miniSecretFromSecret(TEST_MNEMONIC);
+
+  test("root path returns a 64-byte expanded secret", () => {
+    const sk = deriveExpandedSecret(rootSeed, "");
+    expect(sk).toBeInstanceOf(Uint8Array);
+    expect(sk).toHaveLength(64);
+    // getPublicKey(sk) must match what importAccount derives at root
+    const expectedPub = importAccount(TEST_MNEMONIC, "").publicKey;
+    expect(publicKeyToHex(getPublicKey(sk))).toBe(publicKeyToHex(expectedPub));
+  });
+
+  test("hard path //a produces a different secret than root and matches importAccount's public key", () => {
+    const root = deriveExpandedSecret(rootSeed, "");
+    const hard = deriveExpandedSecret(rootSeed, "//a");
+    expect(bytesToHex(root)).not.toBe(bytesToHex(hard));
+    const expectedPub = importAccount(TEST_MNEMONIC, "//a").publicKey;
+    expect(publicKeyToHex(getPublicKey(hard))).toBe(publicKeyToHex(expectedPub));
+  });
+
+  test("soft path /a exercises the soft branch of the derivation", () => {
+    const soft = deriveExpandedSecret(rootSeed, "/a");
+    expect(soft).toHaveLength(64);
+    const expectedPub = importAccount(TEST_MNEMONIC, "/a").publicKey;
+    expect(publicKeyToHex(getPublicKey(soft))).toBe(publicKeyToHex(expectedPub));
+  });
+
+  test("numeric junction //0 exercises the u32 branch of createChainCode", () => {
+    const sk = deriveExpandedSecret(rootSeed, "//0");
+    expect(sk).toHaveLength(64);
+    // Numeric and string components produce different secrets
+    const viaString = deriveExpandedSecret(rootSeed, "//zero");
+    expect(bytesToHex(sk)).not.toBe(bytesToHex(viaString));
+    // And matches importAccount at the same path
+    const expectedPub = importAccount(TEST_MNEMONIC, "//0").publicKey;
+    expect(publicKeyToHex(getPublicKey(sk))).toBe(publicKeyToHex(expectedPub));
+  });
+
+  test("throws when a junction component exceeds 31 bytes", () => {
+    const tooLong = "x".repeat(32);
+    expect(() => deriveExpandedSecret(rootSeed, `//${tooLong}`)).toThrow(/too long/);
   });
 });
 

--- a/src/core/accounts.ts
+++ b/src/core/accounts.ts
@@ -8,6 +8,7 @@ import {
   ss58Decode,
   validateMnemonic,
 } from "@polkadot-labs/hdkd-helpers";
+import { HDKD, secretFromSeed } from "@scure/sr25519";
 import type { PolkadotSigner } from "polkadot-api/signer";
 import { getPolkadotSigner } from "polkadot-api/signer";
 import { findAccount, loadAccounts } from "../config/accounts-store.ts";
@@ -50,6 +51,69 @@ function deriveFromHexSeed(
 function getDevKeypair(name: string) {
   const path = devDerivationPath(name);
   return deriveFromMnemonic(DEV_PHRASE, path);
+}
+
+// Mirrors @polkadot-labs/hdkd-helpers internals (parseDerivations.ts, createChainCode.ts)
+// which are not re-exported from its barrel.
+const DERIVATION_RE = /(\/{1,2})([^/]+)/g;
+
+function parseDerivations(path: string): Array<["hard" | "soft", string]> {
+  const out: Array<["hard" | "soft", string]> = [];
+  for (const [, type, code] of path.matchAll(DERIVATION_RE)) {
+    out.push([type === "//" ? "hard" : "soft", code!]);
+  }
+  return out;
+}
+
+function createChainCode(code: string): Uint8Array {
+  const chainCode = new Uint8Array(32);
+  const asNumber = +code;
+  if (Number.isNaN(asNumber)) {
+    // SCALE str.enc: compact length prefix + UTF-8 bytes. For length < 64 (all realistic
+    // junction names) the compact prefix is a single byte of (length << 2).
+    const bytes = new TextEncoder().encode(code);
+    if (bytes.length >= 32) {
+      throw new Error(`Derivation component "${code}" is too long (max 31 bytes)`);
+    }
+    chainCode[0] = bytes.length << 2;
+    chainCode.set(bytes, 1);
+  } else {
+    // SCALE u32.enc: little-endian 4 bytes
+    const n = asNumber >>> 0;
+    chainCode[0] = n & 0xff;
+    chainCode[1] = (n >>> 8) & 0xff;
+    chainCode[2] = (n >>> 16) & 0xff;
+    chainCode[3] = (n >>> 24) & 0xff;
+  }
+  return chainCode;
+}
+
+export function deriveExpandedSecret(miniSecret: Uint8Array, path: string): Uint8Array {
+  return parseDerivations(path).reduce(
+    (sk, [type, code]) =>
+      type === "hard"
+        ? HDKD.secretHard(sk, createChainCode(code))
+        : HDKD.secretSoft(sk, createChainCode(code)),
+    secretFromSeed(miniSecret),
+  );
+}
+
+export function miniSecretFromSecret(secret: string): Uint8Array {
+  const isHexSeed = /^0x[0-9a-fA-F]{64}$/.test(secret);
+  if (isHexSeed) {
+    const clean = secret.slice(2);
+    const bytes = new Uint8Array(32);
+    for (let i = 0; i < clean.length; i += 2) {
+      bytes[i / 2] = parseInt(clean.substring(i, i + 2), 16);
+    }
+    return bytes;
+  }
+  if (!validateMnemonic(secret)) {
+    throw new Error(
+      "Invalid secret. Expected a 0x-prefixed 32-byte hex seed or a valid BIP39 mnemonic.",
+    );
+  }
+  return entropyToMiniSecret(mnemonicToEntropy(secret));
 }
 
 export function getDevAddress(name: string, prefix = 42): string {
@@ -176,4 +240,41 @@ export async function resolveAccountKeypair(
 export async function resolveAccountSigner(name: string): Promise<PolkadotSigner> {
   const keypair = await resolveAccountKeypair(name);
   return getPolkadotSigner(keypair.publicKey, "Sr25519", keypair.sign);
+}
+
+export async function resolveAccountExpandedSecret(name: string): Promise<Uint8Array> {
+  if (isDevAccount(name)) {
+    const miniSecret = entropyToMiniSecret(mnemonicToEntropy(DEV_PHRASE));
+    return deriveExpandedSecret(miniSecret, devDerivationPath(name));
+  }
+
+  const accountsFile = await loadAccounts();
+  const account = findAccount(accountsFile, name);
+  if (!account) {
+    const available = [...DEV_NAMES, ...accountsFile.accounts.map((a) => a.name)].sort((a, b) =>
+      a.localeCompare(b),
+    );
+    const suggestions = findClosest(name, available);
+    const hint = suggestions.length > 0 ? `\n  Did you mean: ${suggestions.join(", ")}?` : "";
+    const list = available.map((a) => `\n    - ${a}`).join("");
+    throw new Error(`Unknown account "${name}".${hint}\n  Available accounts:${list}`);
+  }
+
+  if (account.secret === undefined) {
+    throw new Error(
+      `Account "${name}" is watch-only (no secret). Cannot derive private key. Import with --secret or --env.`,
+    );
+  }
+
+  const miniSecret = miniSecretFromSecret(resolveSecret(account.secret));
+  return deriveExpandedSecret(miniSecret, account.derivationPath);
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return (
+    "0x" +
+    Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+  );
 }


### PR DESCRIPTION
## Summary

- Adds `--show-secret` to `dot account inspect` that prints the **64-byte sr25519 expanded secret key** as `0x`-prefixed hex next to the public key and SS58 address.
- Works for dev accounts (Alice/Bob/Charlie/Dave/Eve/Ferdie, derived on-the-fly from the standard dev mnemonic) and for stored accounts with a resolvable secret (mnemonic, hex seed, or env-var–backed). Refuses on watch-only accounts, bare SS58 addresses, and hex public keys.
- The emitted hex is the secret **after** any derivation path is applied — so it can be pasted directly into signers that only accept a raw private key (e.g. a backend service reading a `PRIVATE_KEY` env var), no mnemonic+path required.
- Added `@scure/sr25519` as a direct dep (the underlying primitives `secretFromSeed`, `HDKD.secretHard/Soft`, `getPublicKey` are what `@polkadot-labs/hdkd` uses internally — it just doesn't expose the derived secret). `parseDerivations` and `createChainCode` are reimplemented locally (5 lines each) since hdkd-helpers doesn't re-export them.

Example:
```sh
$ dot account inspect dave --show-secret
Account Info

  Name:        Dave
  Public Key:  0x306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20
  SS58:        5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy
  Prefix:      42
  Private Key: 0x20e05482…b25568
               (sr25519 expanded, 64 bytes — never share)
```

With `--json`, the value is surfaced under the `privateKey` field.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` — 1336 pass, 0 fail (+16 new tests across `src/core/accounts.test.ts` and `src/commands/account.test.ts`)
- [x] Coverage of `src/core/accounts.ts`: 81.28% → **91.63%** lines, 97.06% → **100%** functions
- [x] Live CLI check: `bun src/cli.ts account inspect dave --show-secret` (human + `--json` output)
- [x] Error paths verified: watch-only account, raw SS58 address, hex public key
- [x] Stored-account paths verified: mnemonic + hard path, hex seed + soft path, mnemonic + numeric `//0` junction, env-backed secret
- [x] Cross-check: `getPublicKey(expandedSecret)` matches `resolveAccountKeypair(name).publicKey` for all 6 dev accounts
- [x] Signing with the printed secret verifies against the account's public key via `@scure/sr25519`'s `sign`/`verify`
- [x] Documented in README and `docs/content/_index.md`
- [x] Changeset added (`minor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)