### PR TITLE
feat(config): add DOT_HOME env var to redirect the config directory

### DIFF
--- a/.changeset/dot-home-env.md
+++ b/.changeset/dot-home-env.md
@@ -1,0 +1,23 @@
+---
+"polkadot-cli": minor
+---
+
+Add `DOT_HOME` environment variable to redirect the CLI's config directory.
+
+When `DOT_HOME` is set, the CLI reads and writes all state — `config.json`,
+`accounts.json`, `update-check.json`, and `chains/*/metadata.bin` — under that
+directory instead of the default `$HOME/.polkadot`. No `.polkadot` suffix is
+appended to the override.
+
+This lets you run experiments, CI jobs, or secondary profiles without touching
+your real config directory:
+
+```bash
+DOT_HOME=/tmp/dot-scratch dot account create throwaway
+```
+
+Empty-string `DOT_HOME=""` is treated as unset and falls back to
+`$HOME/.polkadot`, so a shell-quoting slip cannot accidentally target `/`.
+
+The project's own `runCli` test fixture now sets `DOT_HOME` to an isolated
+tmpdir for every subprocess it spawns.

--- a/README.md
+++ b/README.md
@@ -1410,7 +1410,7 @@ The notification is automatically suppressed when:
 
 ## Configuration
 
-Config and metadata caches live in `~/.polkadot/`:
+Config and metadata caches live in `~/.polkadot/` by default:
 
 ```
 ~/.polkadot/
@@ -1423,6 +1423,29 @@ Config and metadata caches live in `~/.polkadot/`:
 ```
 
 > **Warning:** `accounts.json` stores secrets (mnemonics and seeds) in **plain text**. Encrypted-at-rest storage is planned but not yet implemented. Keep appropriate file permissions (`chmod 600 ~/.polkadot/accounts.json`) and do not use this for high-value mainnet accounts.
+
+### `DOT_HOME` — redirect the config directory
+
+Set the `DOT_HOME` environment variable to point at a different directory. When set, the CLI reads and writes **everything** (config, accounts, metadata, update cache) under that path — no `.polkadot` suffix is appended.
+
+```bash
+# Use a scratch directory for experimentation
+DOT_HOME=/tmp/dot-scratch dot account create throwaway
+
+# Isolated per-project state (e.g. in a repo-local shell)
+export DOT_HOME="$PWD/.dot"
+dot chain add local --rpc ws://localhost:9944
+
+# Unset or empty DOT_HOME falls back to $HOME/.polkadot
+```
+
+Typical uses:
+
+- **Run throwaway commands without touching your real accounts.** Point `DOT_HOME` at a tmpdir so `dot account create`, `dot chain add`, and similar never modify `~/.polkadot/`.
+- **CI and test harnesses.** Give each job its own `DOT_HOME` so parallel runs don't share state. The project's own test fixture (`runCli`) uses this mechanism.
+- **Multiple profiles on one machine.** Switch between environments (e.g. a mainnet profile and a local-dev profile) by changing `DOT_HOME`.
+
+Empty-string `DOT_HOME=""` is treated as unset and falls back to `$HOME/.polkadot` — so a shell-quoting slip can't accidentally send writes to `/`.
 
 ## Environment compatibility
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -2024,7 +2024,7 @@ The CLI works in Node.js (v22+), Bun, and sandboxed runtimes (e.g. LLM tool-use 
 
 ## Configuration
 
-Config and metadata caches live in `~/.polkadot/`:
+Config and metadata caches live in `~/.polkadot/` by default:
 
 ```
 ~/.polkadot/
@@ -2035,3 +2035,20 @@ Config and metadata caches live in `~/.polkadot/`:
     └── polkadot/
         └── metadata.bin # cached SCALE-encoded metadata
 ```
+
+### `DOT_HOME` — redirect the config directory
+
+Set the `DOT_HOME` environment variable to point at a different directory. When set, the CLI reads and writes **everything** (config, accounts, metadata, update cache) under that path — no `.polkadot` suffix is appended.
+
+```bash
+# Scratch directory for experimentation — never touches ~/.polkadot
+DOT_HOME=/tmp/dot-scratch dot account create throwaway
+
+# Repo-local state
+export DOT_HOME="$PWD/.dot"
+dot chain add local --rpc ws://localhost:9944
+```
+
+Typical uses: throwaway commands that shouldn't touch real accounts, CI jobs that need isolated state, and switching between profiles (mainnet vs. local-dev) by changing one env var. The project's own test fixture (`runCli`) uses this mechanism.
+
+Empty-string `DOT_HOME=""` is treated as unset and falls back to `$HOME/.polkadot` — a shell-quoting slip can't send writes to `/`.

--- a/src/commands/__fixtures__/run-cli.ts
+++ b/src/commands/__fixtures__/run-cli.ts
@@ -102,7 +102,7 @@ export async function runCli(
 
   try {
     const spawnOpts: Parameters<typeof Bun.spawn>[1] = {
-      env: { ...process.env, HOME: tmpHome, ...options?.env },
+      env: { ...process.env, HOME: tmpHome, DOT_HOME: dotDir, ...options?.env },
       stdout: "pipe",
       stderr: "pipe",
     };

--- a/src/config/accounts-store.test.ts
+++ b/src/config/accounts-store.test.ts
@@ -25,3 +25,9 @@ describe("findAccount", () => {
     expect(result).toBeUndefined();
   });
 });
+
+// DOT_HOME save/load is covered end-to-end by every subprocess test that
+// goes through the runCli fixture (src/commands/__fixtures__/run-cli.ts)
+// — that fixture sets DOT_HOME on each spawn so writes land in a per-test
+// tmpdir. In-process mutation of process.env.DOT_HOME races against other
+// concurrent tests (bun test --concurrent), so we don't do it here.

--- a/src/config/accounts-store.ts
+++ b/src/config/accounts-store.ts
@@ -3,7 +3,9 @@ import { join } from "node:path";
 import type { AccountsFile, StoredAccount } from "./accounts-types.ts";
 import { getConfigDir } from "./store.ts";
 
-const ACCOUNTS_PATH = join(getConfigDir(), "accounts.json");
+export function getAccountsPath(): string {
+  return join(getConfigDir(), "accounts.json");
+}
 
 async function ensureDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true });
@@ -20,8 +22,9 @@ async function fileExists(path: string): Promise<boolean> {
 
 export async function loadAccounts(): Promise<AccountsFile> {
   await ensureDir(getConfigDir());
-  if (await fileExists(ACCOUNTS_PATH)) {
-    const data = await readFile(ACCOUNTS_PATH, "utf-8");
+  const path = getAccountsPath();
+  if (await fileExists(path)) {
+    const data = await readFile(path, "utf-8");
     return JSON.parse(data) as AccountsFile;
   }
   return { accounts: [] };
@@ -29,7 +32,7 @@ export async function loadAccounts(): Promise<AccountsFile> {
 
 export async function saveAccounts(file: AccountsFile): Promise<void> {
   await ensureDir(getConfigDir());
-  await writeFile(ACCOUNTS_PATH, `${JSON.stringify(file, null, 2)}\n`);
+  await writeFile(getAccountsPath(), `${JSON.stringify(file, null, 2)}\n`);
 }
 
 export function findAccount(file: AccountsFile, name: string): StoredAccount | undefined {

--- a/src/config/dot-home.test.ts
+++ b/src/config/dot-home.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+// DOT_HOME integration tests. These run user-code in a SUBPROCESS so env
+// mutation cannot leak into other tests under `bun test --concurrent`.
+// Each test gets its own fresh Bun process with its own env.
+
+const CLI_PATH = join(import.meta.dir, "../cli.ts");
+
+async function runWithEnv(
+  args: string[],
+  env: Record<string, string | undefined>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", CLI_PATH, ...args, "--chain", "polkadot"], {
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout as ReadableStream).text(),
+    new Response(proc.stderr as ReadableStream).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+// @ts-expect-error Bun supports describe(label, options, fn) at runtime
+describe("DOT_HOME", { timeout: 15_000 }, () => {
+  test("writes account state to $DOT_HOME, not $HOME/.polkadot", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "dot-home-fake-home-"));
+    const dotHome = mkdtempSync(join(tmpdir(), "dot-home-override-"));
+    try {
+      const { exitCode } = await runWithEnv(["account", "create", "scratch-acct", "--json"], {
+        HOME: fakeHome,
+        DOT_HOME: dotHome,
+      });
+      expect(exitCode).toBe(0);
+
+      // Write landed under DOT_HOME
+      expect(existsSync(join(dotHome, "accounts.json"))).toBe(true);
+      const saved = JSON.parse(readFileSync(join(dotHome, "accounts.json"), "utf-8"));
+      expect(saved.accounts).toHaveLength(1);
+      expect(saved.accounts[0].name).toBe("scratch-acct");
+
+      // And absolutely NOT under HOME/.polkadot (the original bug)
+      expect(existsSync(join(fakeHome, ".polkadot", "accounts.json"))).toBe(false);
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      rmSync(dotHome, { recursive: true, force: true });
+    }
+  });
+
+  test("empty-string DOT_HOME falls back to $HOME/.polkadot (does not target /)", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "dot-home-empty-"));
+    try {
+      const { exitCode } = await runWithEnv(["account", "create", "fallback-acct", "--json"], {
+        HOME: fakeHome,
+        DOT_HOME: "",
+      });
+      expect(exitCode).toBe(0);
+      // Fell back to HOME/.polkadot, NOT to / (which would error with EACCES
+      // or scatter files in the filesystem root).
+      expect(existsSync(join(fakeHome, ".polkadot", "accounts.json"))).toBe(true);
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("unset DOT_HOME falls back to $HOME/.polkadot", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "dot-home-unset-"));
+    try {
+      const { exitCode } = await runWithEnv(["account", "create", "default-acct", "--json"], {
+        HOME: fakeHome,
+        DOT_HOME: undefined,
+      });
+      expect(exitCode).toBe(0);
+      expect(existsSync(join(fakeHome, ".polkadot", "accounts.json"))).toBe(true);
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("a default-HOME run leaves the real ~/.polkadot/accounts.json untouched when DOT_HOME is set", async () => {
+    // Proves the "don't clobber the real file" guarantee users care about.
+    const dotHome = mkdtempSync(join(tmpdir(), "dot-home-guard-"));
+    const realAccountsPath = join(homedir(), ".polkadot", "accounts.json");
+    const before = existsSync(realAccountsPath) ? readFileSync(realAccountsPath, "utf-8") : null;
+    try {
+      const { exitCode } = await runWithEnv(["account", "create", "guard-acct", "--json"], {
+        DOT_HOME: dotHome,
+      });
+      expect(exitCode).toBe(0);
+      const after = existsSync(realAccountsPath) ? readFileSync(realAccountsPath, "utf-8") : null;
+      expect(after).toBe(before);
+      // And the account did land under DOT_HOME.
+      expect(existsSync(join(dotHome, "accounts.json"))).toBe(true);
+    } finally {
+      rmSync(dotHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config/store.test.ts
+++ b/src/config/store.test.ts
@@ -184,3 +184,14 @@ describe("loadConfig merge behavior", () => {
     expect(merged.chains["polkadot-asset-hub"]!.rpc).toBe("wss://custom.example");
   });
 });
+
+// DOT_HOME env var behavior is exercised end-to-end by every subprocess
+// test via the runCli fixture (src/commands/__fixtures__/run-cli.ts), which
+// sets DOT_HOME to a per-test tmpdir. In-process mutation of
+// process.env.DOT_HOME races against other tests under `bun test
+// --concurrent` (other tests in the suite read DOT_HOME via getConfigDir
+// from real production code paths), so we verify the behavior via
+// subprocess tests rather than in-process env mutation.
+//
+// A dedicated subprocess-based DOT_HOME test lives in
+// src/config/dot-home.test.ts.

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -5,24 +5,25 @@ import { CliError } from "../utils/errors.ts";
 import type { ChainConfig, Config } from "./types.ts";
 import { DEFAULT_CONFIG } from "./types.ts";
 
-const DOT_DIR = join(homedir(), ".polkadot");
-const CONFIG_PATH = join(DOT_DIR, "config.json");
-const CHAINS_DIR = join(DOT_DIR, "chains");
-
 export function getConfigDir(): string {
-  return DOT_DIR;
+  const override = process.env.DOT_HOME;
+  return override && override.length > 0 ? override : join(homedir(), ".polkadot");
 }
 
 export function getChainsDir(): string {
-  return CHAINS_DIR;
+  return join(getConfigDir(), "chains");
 }
 
 export function getChainDir(chainName: string): string {
-  return join(CHAINS_DIR, chainName);
+  return join(getChainsDir(), chainName);
 }
 
 export function getMetadataPath(chainName: string): string {
-  return join(CHAINS_DIR, chainName, "metadata.bin");
+  return join(getChainDir(chainName), "metadata.bin");
+}
+
+function getConfigPath(): string {
+  return join(getConfigDir(), "config.json");
 }
 
 async function ensureDir(dir: string): Promise<void> {
@@ -39,9 +40,10 @@ async function fileExists(path: string): Promise<boolean> {
 }
 
 export async function loadConfig(): Promise<Config> {
-  await ensureDir(DOT_DIR);
-  if (await fileExists(CONFIG_PATH)) {
-    const saved = JSON.parse(await readFile(CONFIG_PATH, "utf-8")) as Config;
+  await ensureDir(getConfigDir());
+  const configPath = getConfigPath();
+  if (await fileExists(configPath)) {
+    const saved = JSON.parse(await readFile(configPath, "utf-8")) as Config;
     const chains: Record<string, ChainConfig> = {};
     for (const [name, defaultConfig] of Object.entries(DEFAULT_CONFIG.chains)) {
       chains[name] = saved.chains[name]
@@ -60,8 +62,8 @@ export async function loadConfig(): Promise<Config> {
 }
 
 export async function saveConfig(config: Config): Promise<void> {
-  await ensureDir(DOT_DIR);
-  await writeFile(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+  await ensureDir(getConfigDir());
+  await writeFile(getConfigPath(), `${JSON.stringify(config, null, 2)}\n`);
 }
 
 export async function loadMetadata(chainName: string): Promise<Uint8Array | null> {


### PR DESCRIPTION
## Summary

- Adds a `DOT_HOME` environment variable that redirects the CLI's config directory. When set, the CLI reads and writes **all state** (`config.json`, `accounts.json`, `update-check.json`, `chains/*/metadata.bin`) under `$DOT_HOME` instead of `$HOME/.polkadot`. No `.polkadot` suffix is appended to the override.
- **Primary motivation:** make it safe to run throwaway commands, CI jobs, and secondary profiles without risking a write to the user's real `~/.polkadot/`. The trigger for this PR was an incident where a misplaced shell env-var scoping (`HOME=$(mktemp -d) mkdir ... && echo > $HOME/...`) clobbered the real `~/.polkadot/accounts.json` — `DOT_HOME=/tmp/scratch` eliminates that class of bug.
- **Safety:** empty-string `DOT_HOME=""` is treated as unset and falls back to `$HOME/.polkadot` — so a shell-quoting slip cannot cause writes to target `/`.

```sh
DOT_HOME=/tmp/dot-scratch dot account create throwaway
# reads/writes under /tmp/dot-scratch, never touches ~/.polkadot/
```

## Implementation

- `src/config/store.ts` — `getConfigDir()` is now lazy and re-reads `process.env.DOT_HOME` on every call. The module-level `DOT_DIR` / `CONFIG_PATH` / `CHAINS_DIR` constants are replaced by getters.
- `src/config/accounts-store.ts` — exposes `getAccountsPath()` instead of a cached `ACCOUNTS_PATH` constant, for the same reason.
- `src/commands/__fixtures__/run-cli.ts` — sets `DOT_HOME` on spawned subprocesses in addition to `HOME`, so every one of the 1300+ existing subprocess tests now also exercises the `DOT_HOME` code path.
- `src/config/dot-home.test.ts` — dedicated subprocess-based test suite covering:
  - writes land under `DOT_HOME`, not under `$HOME/.polkadot`
  - empty `DOT_HOME` falls back to `$HOME/.polkadot` (never `/`)
  - unset `DOT_HOME` falls back to `$HOME/.polkadot`
  - setting `DOT_HOME` while leaving `HOME` at the user's real home leaves `~/.polkadot/accounts.json` untouched (the guardrail the user explicitly asked for)

These tests run in spawned subprocesses because in-process mutation of `process.env.DOT_HOME` races against other tests under `bun test --concurrent` (other tests call `getConfigDir()` from production code paths).

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` — 1319 pass, 0 fail
- [x] `bun test --concurrent` — 1319 pass, 0 fail (verified race-free)
- [x] Live: `DOT_HOME=$(mktemp -d) bun src/cli.ts accounts` → \"Stored Accounts (none)\" while the real `~/.polkadot/accounts.json` is untouched
- [x] Documented in README (new section under \"Configuration\") and `docs/content/_index.md`
- [x] Changeset added (`minor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)