### PR TITLE
test: fix flaky client/loadMeta tests by using DI instead of mock.module

### DIFF
--- a/src/commands/focused-inspect.ts
+++ b/src/commands/focused-inspect.ts
@@ -34,16 +34,24 @@ import {
 import { suggestMessage } from "../utils/fuzzy-match.ts";
 import type { DotCategory } from "../utils/parse-dot-path.ts";
 
+export interface LoadMetaDeps {
+  createChainClient?: typeof createChainClient;
+  fetchMetadataFromChain?: typeof fetchMetadataFromChain;
+}
+
 export async function loadMeta(
   chainName: string,
   chainConfig: any,
   rpcOverride?: string,
+  deps: LoadMetaDeps = {},
 ): Promise<MetadataBundle> {
+  const _createChainClient = deps.createChainClient ?? createChainClient;
+  const _fetchMetadataFromChain = deps.fetchMetadataFromChain ?? fetchMetadataFromChain;
   if (rpcOverride) {
     process.stderr.write(`Fetching metadata from ${chainName}...\n`);
-    const clientHandle = await createChainClient(chainName, chainConfig, rpcOverride);
+    const clientHandle = await _createChainClient(chainName, chainConfig, rpcOverride);
     try {
-      const raw = await fetchMetadataFromChain(clientHandle, chainName);
+      const raw = await _fetchMetadataFromChain(clientHandle, chainName);
       return parseMetadata(raw);
     } finally {
       clientHandle.destroy();
@@ -53,7 +61,7 @@ export async function loadMeta(
     return await getOrFetchMetadata(chainName);
   } catch {
     process.stderr.write(`Fetching metadata from ${chainName}...\n`);
-    const clientHandle = await createChainClient(chainName, chainConfig);
+    const clientHandle = await _createChainClient(chainName, chainConfig);
     try {
       return await getOrFetchMetadata(chainName, clientHandle);
     } finally {

--- a/src/commands/load-meta.test.ts
+++ b/src/commands/load-meta.test.ts
@@ -1,19 +1,16 @@
 import { describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { loadMeta } from "./focused-inspect.ts";
 
 // ---------------------------------------------------------------------------
-// Load fixture metadata and actual metadata functions before mocking.
-// We only mock fetchMetadataFromChain and createChainClient — everything
-// else (parseMetadata, getOrFetchMetadata, etc.) uses real implementations.
+// Use dependency injection to substitute createChainClient and
+// fetchMetadataFromChain in isolation — avoids mock.module, which replaces
+// modules globally for the whole `bun test` process and breaks other tests.
 // ---------------------------------------------------------------------------
 const FIXTURE_METADATA = new Uint8Array(
   readFileSync(join(import.meta.dir, "__fixtures__/polkadot-metadata.bin")),
 );
-
-// Import actual metadata module BEFORE mock.module so we can re-export
-// real implementations alongside the mock.
-const actualMetadata = await import("../core/metadata.ts");
 
 const mockDestroy = mock(() => {});
 const mockCreateChainClient = mock(async () => ({
@@ -22,28 +19,10 @@ const mockCreateChainClient = mock(async () => ({
 }));
 const mockFetchMetadataFromChain = mock(async () => FIXTURE_METADATA);
 
-mock.module("../core/client.ts", () => ({
-  createChainClient: mockCreateChainClient,
-}));
-
-mock.module("../core/metadata.ts", () => ({
-  describeCallArgs: actualMetadata.describeCallArgs,
-  describeEventFields: actualMetadata.describeEventFields,
-  describeRuntimeApiMethodArgs: actualMetadata.describeRuntimeApiMethodArgs,
-  describeType: actualMetadata.describeType,
-  fetchMetadataFromChain: mockFetchMetadataFromChain,
-  findPallet: actualMetadata.findPallet,
-  findRuntimeApi: actualMetadata.findRuntimeApi,
-  getOrFetchMetadata: actualMetadata.getOrFetchMetadata,
-  getPalletNames: actualMetadata.getPalletNames,
-  getRuntimeApiNames: actualMetadata.getRuntimeApiNames,
-  listPallets: actualMetadata.listPallets,
-  listRuntimeApis: actualMetadata.listRuntimeApis,
-  parseMetadata: actualMetadata.parseMetadata,
-}));
-
-// Import loadMeta AFTER mocks are set up
-const { loadMeta } = await import("./focused-inspect.ts");
+const deps = {
+  createChainClient: mockCreateChainClient as any,
+  fetchMetadataFromChain: mockFetchMetadataFromChain as any,
+};
 
 // ---------------------------------------------------------------------------
 // loadMeta — --rpc override bypasses metadata cache
@@ -56,7 +35,7 @@ describe("loadMeta", () => {
     mockFetchMetadataFromChain.mockClear();
     mockDestroy.mockClear();
 
-    const meta = await loadMeta("polkadot", chainConfig, "wss://override.example.com");
+    const meta = await loadMeta("polkadot", chainConfig, "wss://override.example.com", deps);
 
     expect(meta).toBeDefined();
     expect(meta.unified).toBeDefined();
@@ -70,7 +49,7 @@ describe("loadMeta", () => {
   test("destroys client handle after fetching with rpcOverride", async () => {
     mockDestroy.mockClear();
 
-    await loadMeta("polkadot", chainConfig, "wss://override.example.com");
+    await loadMeta("polkadot", chainConfig, "wss://override.example.com", deps);
 
     expect(mockDestroy).toHaveBeenCalledTimes(1);
   });
@@ -82,7 +61,7 @@ describe("loadMeta", () => {
     // Without rpcOverride, loadMeta calls getOrFetchMetadata(chainName) which
     // reads from cache. The real getOrFetchMetadata calls the real loadMetadata
     // from store.ts — if cached metadata exists on disk, no client is created.
-    const meta = await loadMeta("polkadot", chainConfig);
+    const meta = await loadMeta("polkadot", chainConfig, undefined, deps);
 
     expect(meta).toBeDefined();
     expect(meta.unified).toBeDefined();

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { ChainConfig } from "../config/types.ts";
 import { ConnectionError } from "../utils/errors.ts";
+import { createChainClient } from "./client.ts";
 
-// Capture calls to getWsProvider so we can inspect the config it receives
+// Inject fakes via the `deps` argument so we don't replace the real
+// polkadot-api module (which other tests depend on for `Binary`, etc.).
 const mockGetWsProvider = mock((_endpoints: any, _config?: any) => (() => {}) as any);
 const mockCreateClient = mock(
   () =>
@@ -10,16 +12,10 @@ const mockCreateClient = mock(
       destroy: () => {},
     }) as any,
 );
-
-mock.module("polkadot-api/ws", () => ({
-  getWsProvider: mockGetWsProvider,
-}));
-mock.module("polkadot-api", () => ({
-  createClient: mockCreateClient,
-}));
-
-// Import after mocking so the mocks take effect
-const { createChainClient } = await import("./client.ts");
+const deps = {
+  getWsProvider: mockGetWsProvider as any,
+  createClient: mockCreateClient as any,
+};
 
 describe("createChainClient", () => {
   test("passes timeout config to getWsProvider", async () => {
@@ -29,6 +25,7 @@ describe("createChainClient", () => {
       "test-chain",
       { rpc: "wss://example.com" },
       "wss://example.com",
+      deps,
     );
 
     expect(mockGetWsProvider).toHaveBeenCalledTimes(1);
@@ -46,6 +43,7 @@ describe("createChainClient", () => {
       "test-chain",
       { rpc: "wss://example.com" },
       "wss://example.com",
+      deps,
     );
 
     const [, config] = mockGetWsProvider.mock.calls[0]!;
@@ -61,6 +59,7 @@ describe("createChainClient", () => {
       "test-chain",
       { rpc: "wss://example.com" },
       "wss://example.com",
+      deps,
     );
 
     // createClient should receive the raw provider, not a compat-wrapped one
@@ -76,7 +75,7 @@ describe("createChainClient", () => {
     mockGetWsProvider.mockClear();
 
     const rpcs = ["wss://a.example.com", "wss://b.example.com"];
-    const handle = await createChainClient("test-chain", { rpc: rpcs[0]! }, rpcs);
+    const handle = await createChainClient("test-chain", { rpc: rpcs[0]! }, rpcs, deps);
 
     const [endpoints] = mockGetWsProvider.mock.calls[0]!;
     expect(endpoints).toEqual(rpcs);
@@ -87,9 +86,12 @@ describe("createChainClient", () => {
   test("uses chainConfig.rpc when no rpcOverride is given", async () => {
     mockGetWsProvider.mockClear();
 
-    const handle = await createChainClient("test-chain", {
-      rpc: "wss://config.example.com",
-    });
+    const handle = await createChainClient(
+      "test-chain",
+      { rpc: "wss://config.example.com" },
+      undefined,
+      deps,
+    );
 
     const [endpoints] = mockGetWsProvider.mock.calls[0]!;
     expect(endpoints).toBe("wss://config.example.com");
@@ -99,12 +101,14 @@ describe("createChainClient", () => {
 
   test("throws ConnectionError when no RPC is configured", async () => {
     const noRpc = {} as ChainConfig;
-    expect(createChainClient("unknown-chain", noRpc)).rejects.toThrow(ConnectionError);
+    expect(createChainClient("unknown-chain", noRpc, undefined, deps)).rejects.toThrow(
+      ConnectionError,
+    );
   });
 
   test("throws ConnectionError with helpful message", async () => {
     const noRpc = {} as ChainConfig;
-    expect(createChainClient("my-chain", noRpc)).rejects.toThrow(
+    expect(createChainClient("my-chain", noRpc, undefined, deps)).rejects.toThrow(
       /No RPC endpoint configured.*"my-chain"/,
     );
   });
@@ -115,7 +119,7 @@ describe("createChainClient", () => {
     // Old configs may have lightClient: true — the field is no longer in the
     // ChainConfig interface but could still exist in user config files on disk.
     const legacyConfig = { rpc: "wss://example.com", lightClient: true } as ChainConfig;
-    const handle = await createChainClient("polkadot", legacyConfig);
+    const handle = await createChainClient("polkadot", legacyConfig, undefined, deps);
 
     expect(mockGetWsProvider).toHaveBeenCalledTimes(1);
     const [endpoints] = mockGetWsProvider.mock.calls[0]!;
@@ -137,6 +141,7 @@ describe("createChainClient", () => {
       "test-chain",
       { rpc: "wss://example.com" },
       "wss://example.com",
+      deps,
     );
 
     expect(destroySpy).not.toHaveBeenCalled();

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -9,6 +9,11 @@ export interface ClientHandle {
   destroy: () => void;
 }
 
+export interface CreateChainClientDeps {
+  createClient?: typeof createClient;
+  getWsProvider?: typeof getWsProvider;
+}
+
 // Suppress noisy retry/teardown logs from polkadot-api internals.
 // The WS provider logs "Unable to connect" via console.error, and the
 // observable-client logs "ChainHead … request failed" via console.warn
@@ -34,7 +39,10 @@ export async function createChainClient(
   chainName: string,
   chainConfig: ChainConfig,
   rpcOverride?: string | string[],
+  deps: CreateChainClientDeps = {},
 ): Promise<ClientHandle> {
+  const _createClient = deps.createClient ?? createClient;
+  const _getWsProvider = deps.getWsProvider ?? getWsProvider;
   const restoreConsole = suppressProviderNoise();
 
   const rpc = rpcOverride ?? chainConfig.rpc;
@@ -44,9 +52,9 @@ export async function createChainClient(
       `No RPC endpoint configured for chain "${chainName}". Use --rpc or configure one with: dot chain add ${chainName} --rpc <url>`,
     );
   }
-  const provider = getWsProvider(rpc, { timeout: 10_000 });
+  const provider = _getWsProvider(rpc, { timeout: 10_000 });
 
-  const client = createClient(provider, {
+  const client = _createClient(provider, {
     getMetadata: async () => loadMetadata(chainName),
     setMetadata: async (_codeHash, metadata) => {
       await saveMetadata(chainName, metadata);


### PR DESCRIPTION
## Summary

Two test files (`src/core/client.test.ts`, `src/commands/load-meta.test.ts`) use `mock.module()` on first-party source files. Because `mock.module()` replaces modules globally for the whole `bun test` process, their mocks leak into each other depending on bun's test-file discovery order. When `load-meta.test.ts` runs first (typical on Linux CI, alphabetical: `commands/...` < `core/...`), its `mock.module("../core/client.ts", ...)` replaces `createChainClient` with a stub that never calls `getWsProvider` and never throws `ConnectionError` — so every test in `client.test.ts` then fails with `Received number of calls: 0` or `Received promise that resolved`.

This is what caused the 9 failures on #184's CI run (a7536d4); the subsequent rerun passed because file-discovery order happened to shift.

## Fix

Thread an optional `deps` parameter through the two production functions so tests pass fakes directly instead of mutating module state:

- `createChainClient(..., deps?: { createClient?, getWsProvider? })`
- `loadMeta(..., deps?: { createChainClient?, fetchMetadataFromChain? })`

Defaults preserve existing behavior — no call sites change. Both test files now inject fakes via `deps`, with no `mock.module()` calls remaining.

## Why this is worth considering (and why it's optional)

- **For**: removes a real latent flake that will intermittently burn CI time, and deletes a cross-test-file footgun (`mock.module` on a first-party path).
- **Against**: reruns already work; the production change adds a small amount of API surface (one optional param on each function) that exists only for testability.

Not urgent — opening this for visibility so it can be merged later if the flake reappears.

## Test plan

- [x] `bun test src/core/client.test.ts` — 9 pass in isolation
- [x] `bun test src/commands/load-meta.test.ts` — 3 pass in isolation
- [x] `bun test` — 1346 pass, 0 fail
- [x] `bun test --randomize --seed=1` — 1346 pass (previously: 852 pass / 6 fail / link errors)
- [x] `bun test --randomize --seed=7` — 1346 pass
- [x] `bun test --randomize --seed=42` — 1346 pass (previously: 1337 pass / 9 fail)
- [x] `bun test --randomize --seed=100` — 1346 pass
- [x] `bun run lint` / `bun run typecheck` / `bun run build` — all clean
- [ ] GitHub Actions CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)