### PR TITLE
docs(skill): incorporate dot-cli skill evaluation feedback

### DIFF
--- a/.changeset/dot-cli-skill-feedback.md
+++ b/.changeset/dot-cli-skill-feedback.md
@@ -1,0 +1,17 @@
+---
+"polkadot-cli": patch
+---
+
+Polish the `dot-cli` Claude Code skill based on first-contact evaluation feedback. No CLI behavior changes.
+
+**SKILL.md**
+
+- Fix the `Inspect / Explore` section: the old `dot <chain>.inspect` dotpath form does not parse; show the two valid forms (`dot inspect <Pallet> --chain <name>` and chain-prefixed target `dot inspect <chain>.<Pallet>`), and call out that a bare `dot inspect <chain>` is parsed as a pallet name.
+- Add a `Complex Arguments` subsection under `Runtime APIs` with a worked `Location` example showing the `{type, value}` enum shape, so first-time users don't have to reverse-engineer XCM location JSON from `--dump` output.
+- Document that `--at <block>` is a tx flag only; queries always read the latest finalized head. Add `--at` to the Key Flags table.
+- Add a short `Common Errors` appendix (`Incompatible runtime entry`, unknown account, `undefined` piped into `jq`, metadata decode drift after runtime upgrades).
+- Replace the one-line pointer to `references/scripting-patterns.md` with three inline highlights so users know whether to click through.
+
+**Tests**
+
+- Extend `src/skill-marketplace.test.ts` with a regression test that asserts SKILL.md no longer contains the stale `<chain>.inspect` dotpath form, plus positive checks for the new content areas.

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -51,7 +51,7 @@ dot inspect --chain polkadot --rpc wss://kusama-rpc.polkadot.io
 
 # CORRECT
 dot chain add my-ah --rpc wss://example.com/asset-hub
-dot my-ah.inspect
+dot inspect --chain my-ah
 ```
 
 ## Querying Storage
@@ -63,6 +63,8 @@ dot chain.query.AssetConversion.Pools --dump               # all map entries
 dot chain.query.Assets.Metadata '{"parents":1,...}'        # complex key (JSON)
 dot chain.query.System.Number --json                       # JSON output
 ```
+
+Queries always read the latest finalized head — **historical state reads are not supported**. `--at <block>` is a tx-submission flag, not a query flag.
 
 ### Handling `undefined` — Critical for Scripting
 
@@ -120,11 +122,42 @@ dot chain.apis.Core.version --json
 
 Call without args to see the method signature.
 
-## Inspect / Explore
+### Complex Arguments (Location, enums)
+
+Enum-shaped args — including XCM `Location` / `VersionedLocation` and most pallet enums — are passed as JSON with `{type, value}` shape. `type` names the variant; `value` is the inner data (may be another `{type, value}`, an array, or a primitive):
 
 ```bash
-dot chain.inspect     # list all pallets with storage/call/event/error counts
+# Location for a local asset on Asset Hub (PalletInstance 50 = Assets, GeneralIndex = asset id)
+LOC_A='{"parents":1,"interior":{"type":"Here"}}'
+LOC_B='{"parents":0,"interior":{"type":"X2","value":[{"type":"PalletInstance","value":50},{"type":"GeneralIndex","value":"1984"}]}}'
+dot polkadot-asset-hub.apis.AssetConversionApi.get_reserves "$LOC_A" "$LOC_B" --json
 ```
+
+Tips for discovering the exact shape a runtime expects:
+
+- Run `--dump` on a related storage map that uses the same type and read back an existing entry.
+- `dot inspect <Pallet>.<Item> --chain <name>` prints the full type for a storage item.
+
+See [references/scripting-patterns.md](references/scripting-patterns.md) for more Location examples and the bash string-escaping pattern (`'"$VAR"'`).
+
+## Inspect / Explore
+
+`inspect` is a top-level command, **not** a dotpath category. `dot <chain>.inspect...` does not parse. Two valid forms:
+
+```bash
+# --chain flag with an optional positional target
+dot inspect --chain polkadot                      # list all pallets (with storage/call/event/error counts)
+dot inspect System --chain polkadot               # list items in one pallet
+dot inspect System.Account --chain polkadot       # show one storage item's type
+
+# Chain prefix on the inspect target (two or three dot-separated segments, chain first)
+dot inspect polkadot.System
+dot inspect polkadot.System.Account
+```
+
+A single positional arg is always treated as a pallet name, so `dot inspect polkadot` does **not** list pallets on the `polkadot` chain — use `--chain polkadot` for that.
+
+Useful for discovering enum variants: when a method signature shows `enum(N variants)`, run `dot inspect <Pallet>.<Item> --chain <name>` on a storage item that uses the same type, or `--dump` a storage map and read back the shape from a real entry.
 
 ## Account Management
 
@@ -159,7 +192,21 @@ dot tx.System.remark 0xdead --to-yaml                   # encode call → YAML
 | `--dry-run` | tx | Estimate fees without submitting |
 | `--dump` | query | Dump all entries of a storage map |
 | `--ext <json>` | tx | Custom signed extension values |
+| `--at <block>` | tx | Submit at a specific block hash (32-byte `0x…`); defaults to finalized. Not supported on queries. |
+
+## Common Errors
+
+- **`Incompatible runtime entry RuntimeCall(...)`** — usually a runtime API arg shape mismatch: wrong enum `{type, value}`, or a sized-binary `[u8; N]` passed as something other than `0x`-hex. Re-check the signature by calling `dot <chain>.apis.<Api>.<method>` with no args.
+- **`Unknown account or address "X"`** / account has no public key resolved yet — the `--from` name isn't registered. Check `dot account list`, or import with `dot account import <name> ...`.
+- **`undefined` piped into `jq`** — the literal string `undefined` is not JSON. Guard with `[ "$X" == "undefined" ]` before piping.
+- **Decode errors after a runtime upgrade** — metadata cache is keyed by chain name; register a fresh `dot chain add` alias for the upgraded chain rather than reusing the old one.
 
 ## Scripting Patterns
 
-For idempotent bash scripting patterns, big number handling, multi-environment config, and XCM composition, see [references/scripting-patterns.md](references/scripting-patterns.md).
+Highlights from [references/scripting-patterns.md](references/scripting-patterns.md):
+
+- `undefined`-guarded check-then-act for idempotent scripts.
+- XCM `Location` JSON shape and the bash escaping gotcha (`'"$VAR"'` breaks out of single-quoted JSON to interpolate).
+- FixedU128 rate math and u128 arithmetic via `python3` when bash overflows past 2^63.
+
+See the full reference for multi-environment config loaders and batch/sudo composition patterns.

--- a/dot-cli/references/scripting-patterns.md
+++ b/dot-cli/references/scripting-patterns.md
@@ -202,7 +202,7 @@ dot chain.apis.AssetConversionApi.get_reserves "$NATIVE" "$ASSET" --json
 
 2. **`--rpc` uses wrong metadata.** Always register chains with `dot chain add`, never rely on `--rpc` alone. Metadata cache is keyed by chain name, not RPC URL, so `--rpc` can pick up stale metadata from a previous chain with the same alias.
 
-3. **Every command needs an explicit chain.** No default chain — use a `<chain>.` dotpath prefix (`dot polkadot.inspect`) or `--chain <name>`. Commands without either error out.
+3. **Every command needs an explicit chain.** No default chain — use a `<chain>.` dotpath prefix (`dot polkadot.query.System.Number`) or `--chain <name>`. Commands without either error out. Note `inspect` is a top-level command; only `--chain` works for it.
 
 4. **u128 returned as quoted strings.** `"1000000000000"` not `1000000000000`. Strip quotes for comparison: `tr -d '"'`
 

--- a/src/skill-marketplace.test.ts
+++ b/src/skill-marketplace.test.ts
@@ -91,4 +91,24 @@ describe("Claude Code skill marketplace", () => {
       expect(existsSync(join(base, link))).toBe(true);
     }
   });
+
+  test("SKILL.md does not document the invalid `<chain>.inspect` dotpath form", () => {
+    // Regression: `inspect` is a top-level command, not a dotpath category.
+    // `dot polkadot.inspect` / `dot my-chain.inspect` do not parse.
+    const md = readFileSync(join(ROOT, "dot-cli/SKILL.md"), "utf-8");
+    // Match any word followed by ".inspect" at a word boundary, but allow the
+    // phrase `<chain>.inspect` when used to *describe* the invalid form.
+    const bareMatches = [...md.matchAll(/\b([a-z][a-z0-9-]+)\.inspect\b/g)]
+      .map((m) => m[0])
+      .filter((s) => !s.includes("<"));
+    expect(bareMatches).toEqual([]);
+  });
+
+  test("SKILL.md covers the post-feedback content areas", () => {
+    const md = readFileSync(join(ROOT, "dot-cli/SKILL.md"), "utf-8");
+    expect(md).toContain("## Common Errors");
+    expect(md).toContain("Complex Arguments");
+    expect(md).toMatch(/--at\s*<block>/);
+    expect(md).toContain("historical state reads are not supported");
+  });
 });


### PR DESCRIPTION
## Summary

Polish the `dot-cli` Claude Code skill based on a first-contact evaluation by Claude Opus 4.7 (running in plan mode against `dot 1.15.0`). No CLI behavior changes — documentation and one new test.

**SKILL.md**

- **P0 fix:** the old `dot <chain>.inspect` dotpath form doesn't parse (`inspect` is a top-level command, not a dotpath category). Show both valid forms: `dot inspect <Pallet> --chain <name>` and chain-prefixed target `dot inspect <chain>.<Pallet>`. Also call out that a bare `dot inspect <chain>` is parsed as a pallet name.
- **Complex Arguments** subsection under Runtime APIs with a worked `{type, value}` `Location` example — so first-time users don't have to reverse-engineer XCM location JSON from `--dump` output.
- **`--at <block>`** documented as tx-only; queries always read the latest finalized head. Added to the Key Flags table.
- **Common Errors** appendix: `Incompatible runtime entry`, unknown account, `undefined` piped into `jq`, decode errors after runtime upgrades.
- Replaced the bare pointer to `references/scripting-patterns.md` with three inline highlights so readers know whether to click through.

**references/scripting-patterns.md**

- One-line fix to stop citing the broken `dot polkadot.inspect` form in the common-gotchas list.

**Tests**

- Extended `src/skill-marketplace.test.ts` with:
  - regression guard against the `<chain>.inspect` dotpath form reappearing in SKILL.md
  - positive checks that the new content areas (Common Errors, Complex Arguments, `--at`, no-historical-queries note) stay present
- Full suite: **1348 pass / 0 fail**, 4589 assertions (was 1346 / 4583).

## Test plan

- [x] `bun test --concurrent` passes with the new tests
- [x] No src/ code changed, so coverage cannot decrease
- [x] `grep` confirms no remaining `<word>.inspect` dotpath forms in skill docs
- [x] New skill examples (`dot polkadot-asset-hub.apis.AssetConversionApi.get_reserves ...`, `dot inspect System --chain polkadot`) work against preconfigured chains shipped in `config.json`, executable from a fresh `npm install -g polkadot-cli@latest`
- [x] Pre-commit hooks (biome, tsc, full test suite) ran and passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)