### PR TITLE
fix(tx): pass nested [u8; N] fields as 0x hex string

### DIFF
--- a/.changeset/xcm-nested-sized-binary.md
+++ b/.changeset/xcm-nested-sized-binary.md
@@ -1,0 +1,41 @@
+---
+"polkadot-cli": patch
+---
+
+Fix `Incompatible runtime entry Tx(...)` when submitting XCM extrinsics whose
+JSON args contain a nested `[u8; N]` field (e.g. `AccountId32.id` inside a
+`DepositAsset` beneficiary, or inside `custom_xcm_on_dest` for
+`PolkadotXcm.transfer_assets_using_type_and_then`).
+
+```bash
+# Now works (previously failed with "Incompatible runtime entry" on dry-run/submit):
+dot polkadot-asset-hub.tx.PolkadotXcm.transfer_assets_using_type_and_then \
+  '{"type":"V4","value":{"parents":1,"interior":{"type":"X1","value":[{"type":"Parachain","value":1004}]}}}' \
+  '{"type":"V4","value":[{"id":{"parents":0,"interior":{"type":"X2","value":[{"type":"PalletInstance","value":50},{"type":"GeneralIndex","value":"1337"}]}},"fun":{"type":"Fungible","value":"1000000000000"}}]}' \
+  LocalReserve \
+  '{"type":"V4","value":{"parents":0,"interior":{"type":"X2","value":[{"type":"PalletInstance","value":50},{"type":"GeneralIndex","value":"1337"}]}}}' \
+  LocalReserve \
+  '{"type":"V4","value":[{"type":"DepositAsset","value":{"assets":{"type":"Wild","value":{"type":"All"}},"beneficiary":{"parents":0,"interior":{"type":"X1","value":{"type":"AccountId32","value":{"network":null,"id":"0xae89f7d3ddb5b5d7ff4323d1699e71fe061138de0c74316263c5bcf935023249"}}}}}}]}' \
+  Unlimited \
+  --from alice --dry-run
+```
+
+`normalizeValue` (the recursive normalizer for nested JSON args) always wrapped
+hex-string `u8` arrays in `Binary.fromHex(...)`. For *sized* `[u8; N]` fields
+this produced a `Binary` / `Uint8Array` that PAPI's substrate-bindings codec
+silently encodes as zero-length bytes, yielding a truncated call that
+subsequently fails PAPI's `isCompat` check with `Incompatible runtime entry
+Tx(<Pallet>.<call>)`. `--encode` masked the bug (no `isCompat` check and no
+round-trip), so the problem only surfaced on `--dry-run` and actual submission.
+
+`normalizeValue` now mirrors `parseTypedArg`'s existing sized-vs-unsized rule:
+
+- `[u8; N]` (sized array of `u8`) with a `0x…` input → passed through as a
+  `0x`-hex string so PAPI's codec encodes it correctly
+- `Vec<u8>` (sequence of `u8`) → still wrapped in `Binary` via `Binary.fromHex`
+  / `Binary.fromText`
+- Non-byte arrays/sequences are unaffected
+
+This completes the sibling fix for runtime-API args (`fix: pass [u8; N]
+runtime-API args as 0x hex string`); both code paths now agree on the shape
+PAPI expects.

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -539,9 +539,13 @@ describe("parseTypedArg", () => {
       },
     };
     const hex = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
-    const result = (await parseTypedArg(meta, enumEntry, `AccountId32({"id":"${hex}"})`)) as any;
+    const result = (await parseTypedArg(meta, enumEntry, `AccountId32({"id":"${hex}"})`)) as {
+      type: string;
+      value: { id: string };
+    };
     expect(result.type).toBe("AccountId32");
-    expect(result.value.id).toBeInstanceOf(Uint8Array);
+    // Sized [u8; 32] stays as a hex string so PAPI's codec encodes it correctly.
+    expect(result.value.id).toBe(hex);
   });
 
   test("enum shorthand does not break SS58 auto-wrap", async () => {
@@ -973,7 +977,9 @@ describe("normalizeValue", () => {
     expect(result).toEqual({ type: "X1", value: 7 });
   });
 
-  test("converts hex string to Binary for [u8; N] byte arrays", () => {
+  test("passes through hex string for sized [u8; N] byte arrays", () => {
+    // Sized arrays must stay as hex strings — PAPI's codec silently
+    // miscompiles Binary/Uint8Array for [u8; N] to zero-length bytes.
     const mockEntry = {
       type: "array",
       value: { type: "primitive", value: "u8" },
@@ -981,8 +987,7 @@ describe("normalizeValue", () => {
     };
     const hex = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
     const result = normalizeValue(meta.lookup, mockEntry, hex);
-    expect(result).toBeInstanceOf(Uint8Array);
-    expect(Binary.toHex(result as Uint8Array)).toBe(hex);
+    expect(result).toBe(hex);
   });
 
   test("converts text string to Binary for Vec<u8> byte sequences", () => {
@@ -995,18 +1000,17 @@ describe("normalizeValue", () => {
     expect(Binary.toText(result as Uint8Array)).toBe("hello");
   });
 
-  test("converts hex string to Binary for [u8; N] through lookupEntry indirection", () => {
+  test("passes through hex string for [u8; N] through lookupEntry indirection", () => {
     const mockEntry = {
       type: "array",
       value: { type: "lookupEntry", value: { type: "primitive", value: "u8" } },
       len: 4,
     };
     const result = normalizeValue(meta.lookup, mockEntry, "0xdeadbeef");
-    expect(result).toBeInstanceOf(Uint8Array);
-    expect(Binary.toHex(result as Uint8Array)).toBe("0xdeadbeef");
+    expect(result).toBe("0xdeadbeef");
   });
 
-  test("converts nested byte arrays inside structs", () => {
+  test("passes through nested byte arrays inside structs as hex strings", () => {
     const mockEntry = {
       type: "struct",
       value: {
@@ -1014,12 +1018,11 @@ describe("normalizeValue", () => {
       },
     };
     const hex = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
-    const result = normalizeValue(meta.lookup, mockEntry, { id: hex }) as any;
-    expect(result.id).toBeInstanceOf(Uint8Array);
-    expect(Binary.toHex(result.id as Uint8Array)).toBe(hex);
+    const result = normalizeValue(meta.lookup, mockEntry, { id: hex }) as { id: string };
+    expect(result.id).toBe(hex);
   });
 
-  test("converts nested byte arrays inside enum variants", () => {
+  test("passes through nested byte arrays inside enum variants as hex strings", () => {
     const mockEntry = {
       type: "enum",
       value: {
@@ -1033,9 +1036,23 @@ describe("normalizeValue", () => {
     };
     const hex = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
     const input = { type: "AccountId32", value: { id: hex } };
-    const result = normalizeValue(meta.lookup, mockEntry, input) as any;
-    expect(result.value.id).toBeInstanceOf(Uint8Array);
-    expect(Binary.toHex(result.value.id as Uint8Array)).toBe(hex);
+    const result = normalizeValue(meta.lookup, mockEntry, input) as {
+      value: { id: string };
+    };
+    expect(result.value.id).toBe(hex);
+  });
+
+  test("wraps hex string in Binary for unsized Vec<u8> sequences", () => {
+    // Unsized byte sequences (Vec<u8>, e.g. System.remark) DO use Binary —
+    // the codec treats sized vs unsized u8 arrays differently.
+    const mockEntry = {
+      type: "sequence",
+      value: { type: "primitive", value: "u8" },
+    };
+    const hex = "0xdeadbeef";
+    const result = normalizeValue(meta.lookup, mockEntry, hex);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(Binary.toHex(result as Uint8Array)).toBe(hex);
   });
 
   test("converts string to bigint for u128 primitives in JSON", () => {
@@ -1824,6 +1841,32 @@ describe("dot tx CLI integration", () => {
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     expect(stdout).toMatch(/^0x[0-9a-f]+$/);
+  });
+
+  test("XcmPallet.teleport_assets round-trips nested AccountId32.id bytes", async () => {
+    // Regression: normalizeValue used to wrap sized [u8; N] fields (e.g.
+    // AccountId32.id) in Binary, which PAPI's codec silently miscompiles to
+    // zero-length bytes. Verify the encoded call round-trips back with the
+    // original id intact.
+    const ID_HEX = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
+    const dest =
+      '{"type":"V5","value":{"parents":0,"interior":{"type":"X1","value":[{"type":"Parachain","value":1000}]}}}';
+    const beneficiary = `{"type":"V5","value":{"parents":0,"interior":{"type":"X1","value":[{"type":"AccountId32","value":{"network":null,"id":"${ID_HEX}"}}]}}}`;
+    const assets =
+      '{"type":"V5","value":[{"id":{"parents":0,"interior":{"type":"Here"}},"fun":{"type":"Fungible","value":1000000000000}}]}';
+
+    const callData = await parseCallArgs(meta, "XcmPallet", "teleport_assets", [
+      dest,
+      beneficiary,
+      assets,
+      "0",
+    ]);
+    const { codec } = meta.builder.buildCall("XcmPallet", "teleport_assets");
+    const encoded = codec.enc(callData);
+    const decoded = codec.dec(encoded) as {
+      beneficiary: { value: { interior: { value: { value: { id: string } } } } };
+    };
+    expect(decoded.beneficiary.value.interior.value.value.id).toBe(ID_HEX);
   });
 
   test("--encode XcmPallet.teleport_assets with quoted large Fungible value", async () => {

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -1157,7 +1157,11 @@ function normalizeValue(lookup: Lookup, entry: any, value: unknown): unknown {
         innerResolved.value === "u8" &&
         typeof value === "string"
       ) {
-        if (/^0x[0-9a-fA-F]*$/.test(value)) return Binary.fromHex(value as `0x${string}`);
+        const isHex = /^0x[0-9a-fA-F]*$/.test(value);
+        // Sized [u8; N]: PAPI's codec expects a hex string, not a Binary —
+        // passing Binary silently miscompiles to zero-length bytes.
+        if (resolved.type === "array" && isHex) return value;
+        if (isHex) return Binary.fromHex(value as `0x${string}`);
         return Binary.fromText(value);
       }
 


### PR DESCRIPTION
## Summary

- `normalizeValue` (the nested-JSON normalizer in `src/commands/tx.ts`) always wrapped hex-string `u8` arrays in `Binary.fromHex(...)`. For sized `[u8; N]` fields, PAPI's codec silently miscompiles this to zero-length bytes, producing a truncated call that fails `isCompat` with `Error: Incompatible runtime entry Tx(<Pallet>.<call>)` on `--dry-run`/submit. `--encode` masked it (skips `isCompat`, no round-trip).
- Any XCM call whose JSON arg contains a nested `[u8; N]` is affected — notably `AccountId32.id` inside a `DepositAsset` beneficiary, or nested inside `custom_xcm_on_dest` for `PolkadotXcm.transfer_assets_using_type_and_then`.
- Mirror `parseTypedArg`'s existing sized-vs-unsized rule inside `normalizeValue`: `[u8; N]` with `0x…` input → pass through as hex string; `Vec<u8>` → still wrapped in `Binary`.
- Completes the sibling fix `1f18c0d` for runtime-API args; both code paths now agree on the shape PAPI expects.

## Reproduction (before the fix)

```sh
dot polkadot-asset-hub.tx.PolkadotXcm.transfer_assets_using_type_and_then \
  '{"type":"V4","value":{"parents":1,"interior":{"type":"X1","value":[{"type":"Parachain","value":1004}]}}}' \
  '{"type":"V4","value":[{"id":{"parents":0,"interior":{"type":"X2","value":[{"type":"PalletInstance","value":50},{"type":"GeneralIndex","value":"1337"}]}},"fun":{"type":"Fungible","value":"1000000000000"}}]}' \
  LocalReserve \
  '{"type":"V4","value":{"parents":0,"interior":{"type":"X2","value":[{"type":"PalletInstance","value":50},{"type":"GeneralIndex","value":"1337"}]}}}' \
  LocalReserve \
  '{"type":"V4","value":[{"type":"DepositAsset","value":{"assets":{"type":"Wild","value":{"type":"All"}},"beneficiary":{"parents":0,"interior":{"type":"X1","value":{"type":"AccountId32","value":{"network":null,"id":"0xae89f7d3ddb5b5d7ff4323d1699e71fe061138de0c74316263c5bcf935023249"}}}}}}]}' \
  Unlimited \
  --from alice --dry-run
# Before: Error: Incompatible runtime entry Tx(PolkadotXcm.transfer_assets_using_type_and_then)
# After:  Estimated fees: <value>
```

## Tests

- Added `XcmPallet.teleport_assets round-trips nested AccountId32.id bytes` — encodes/decodes against the polkadot metadata fixture and asserts the id survives the round-trip (fails on old code with `Out of bounds access`).
- Added `wraps hex string in Binary for unsized Vec<u8> sequences` — locks in the unchanged `Vec<u8>` path.
- Updated 5 pre-existing `normalizeValue`/`parseTypedArg` unit tests that had asserted the buggy behavior (expected `Uint8Array` for sized `[u8; N]`).

Coverage on `src/commands/tx.ts`: **73.68% line / 46.32% function** (vs baseline 73.68% / 46.31%); tests 260 → 262. No regression.

## Test plan

- [x] `bun test` — full suite passes (1348/0)
- [x] `bun run typecheck` — clean
- [x] Live `--dry-run` against `polkadot-asset-hub` for `transfer_assets_using_type_and_then` with the original failing args → succeeds, decoded call shows correct AccountId32 id bytes
- [x] Live `--dry-run` for README's `teleport-dot.xcm.yaml` and `reserve-transfer-usdc.xcm.yaml` → both succeed (both have the affected nested-AccountId32 shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)