### PR TITLE
feat(metadata): add `dot metadata` command and stale-metadata suggestion

### DIFF
--- a/.changeset/dot-metadata-and-staleness.md
+++ b/.changeset/dot-metadata-and-staleness.md
@@ -1,0 +1,38 @@
+---
+"polkadot-cli": minor
+---
+
+Add `dot metadata <chain>` command and detect stale local metadata after a failed call.
+
+**`dot metadata <chain>`**
+
+A new top-level command that fetches a chain's runtime metadata and prints it as a single JSON blob with everything needed to drive the chain — pallets (with calls, events, errors, storage, constants), runtime APIs, transaction extensions, and a runtime fingerprint header (`specVersion`, `transactionVersion`, `codeHash`, etc.). Closes [#170](https://github.com/peetzweg/polkadot-cli/issues/170).
+
+```bash
+dot metadata polkadot                  # decoded JSON, fetched fresh from the chain
+dot metadata polkadot --raw            # SCALE-encoded metadata bytes as a single 0x… hex line
+dot metadata polkadot --cached         # use locally cached metadata, skip the network round-trip
+dot metadata polkadot --rpc wss://…    # override the RPC endpoint
+```
+
+**Stale-metadata suggestion**
+
+When `dot tx`, `--dry-run`, or `dot query` fails with an error that smells like stale metadata (a runtime wasm trap, codec/decode failure, or fee-estimation panic), the CLI now compares your local metadata's runtime fingerprint against the live chain. If it has changed, the original error is wrapped with a one-line suggestion telling you exactly which command to run:
+
+```
+Error: The runtime rejected this transaction in the runtime's validate_transaction step.
+  Cause: a runtime invariant failed — typically the call's arguments are out of range, …
+
+⚠ Local metadata for "paseo-people-next" is out of date (spec 1018 → 1020).
+   Run: dot chain update paseo-people-next
+```
+
+The fingerprint includes the runtime **code hash** (from `state_getStorageHash(":code:")`) — so the check also catches local-node restarts where the runtime wasm changed but `specVersion` was kept the same. No automatic refetch happens; the suggestion is shown once and the original error still propagates with the non-zero exit code.
+
+The check only fires on suspected-stale errors, so the happy path pays no extra RPC. Set `DOT_TRUST_CACHED_METADATA=1` to skip the check entirely (e.g. for CI or scripted loops where you've just refreshed manually).
+
+**Companion improvements**
+
+- `formatRuntimeError` now translates raw polkadot-api wasm-trap stack traces into a friendly "the runtime rejected this transaction" message with a hint pointing at `--dry-run`.
+- `dot tx --dry-run` now surfaces the underlying reason when fee estimation fails (previously the error message was silently dropped, leaving only "unable to estimate").
+- A global `unhandledRejection` filter swallows benign late-timer rejections from `@polkadot-api/observable-client` (`Not connected`, `DisjointError`) that previously crashed `dot chain update --all` after the actual work had completed.

--- a/.changeset/friendly-runtime-errors.md
+++ b/.changeset/friendly-runtime-errors.md
@@ -1,0 +1,17 @@
+---
+"polkadot-cli": patch
+---
+
+Friendlier error output when the runtime panics or papi cleanup races leak.
+
+**Runtime wasm traps**
+
+Errors from inside `validate_transaction` (wasm `unreachable` instruction / `Execution aborted due to trap`) used to be printed as a verbatim wasm backtrace from polkadot-api. They now render as a one-paragraph "the runtime rejected this transaction" message that names the failing entrypoint where possible (e.g. `the runtime's validate_transaction step`) and points at `--dry-run` for the next step.
+
+**`--dry-run` no longer hides the reason fee estimation failed**
+
+Previously `dot tx … --dry-run` swallowed any exception from `getEstimatedFees` and printed only `Estimated fees: unable to estimate`. The error reason is now captured and displayed alongside the estimate (and included in the JSON output as `estimationError`), so users see *why* estimation failed before deciding to submit.
+
+**`dot chain update --all` no longer crashes on cleanup races**
+
+`@polkadot-api/observable-client` schedules timers inside its chain-head follow stream that can fire after `client.destroy()` has cleared the connection, rejecting with `Error: Not connected` or `DisjointError`. Previously these unhandled rejections killed the process *after* the actual update work had completed. A `process.on('unhandledRejection')` filter at the CLI entry point now swallows that specific class of teardown noise (matched by name) and lets unrelated rejections through with the new friendlier formatting.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Ships with Polkadot and all system parachains preconfigured with multiple fallba
 - ✅ Account management — BIP39 mnemonics, derivation paths, env-backed secrets, watch-only, dev accounts
 - ✅ Named address resolution across all commands
 - ✅ Runtime API calls — `dot polkadot.apis.Core.version`
+- ✅ Full-metadata dump — `dot metadata <chain>` emits one JSON blob with pallets, runtime APIs, and transaction extensions (or raw SCALE bytes via `--raw`)
+- ✅ Stale-metadata detection — when a tx or query fails because the runtime upgraded, the CLI tells you exactly which `dot chain update` to run
 - ✅ Chain topology — relay/parachain hierarchy with tree display and auto-detection
 - ✅ Batteries included — all system parachains and testnets already setup to be used
 - ✅ File-based commands — run any command from a YAML/JSON file with variable substitution
@@ -577,6 +579,32 @@ The pallet listing view shows type information inline so you can understand item
 
 Documentation from the runtime metadata is shown on an indented line below each item. The detail view (`dot inspect Balances.transfer_allow_death`) shows the full argument signature and complete documentation text. Use call inspection to discover argument names, types, and docs before constructing `dot tx` commands.
 
+### Dump full metadata
+
+`dot metadata <chain>` fetches the chain's runtime metadata and prints **everything** as one JSON blob — pallets (with calls, events, errors, storage, constants), runtime APIs, and transaction extensions, headed by a runtime fingerprint (`specVersion`, `transactionVersion`, `codeHash`, etc.). Useful for feeding LLM agents or pipelines that want a single source of truth instead of walking `dot inspect` piecemeal.
+
+```bash
+# Decoded JSON — fetches fresh from the chain
+dot metadata polkadot
+
+# SCALE-encoded metadata bytes as a single 0x… hex line (for tools that re-parse)
+dot metadata polkadot --raw
+
+# Skip the network round-trip and use cached metadata
+dot metadata polkadot --cached
+
+# Override the RPC endpoint
+dot metadata polkadot --rpc wss://rpc.example.com
+
+# Slice with jq — list call names in a pallet
+dot metadata polkadot | jq '.pallets[] | select(.name=="Balances") | .calls[].name'
+
+# All transaction extension identifiers
+dot metadata polkadot | jq '.transactionExtensions[].identifier'
+```
+
+The decoded JSON is structured-only (no colorization), so it's safe to redirect to a file or pipe into other tools. The default fetches fresh from the RPC and atomically updates the local metadata cache and runtime-fingerprint sidecar — so subsequent commands benefit from the freshest possible metadata.
+
 ### Runtime APIs
 
 Browse and call Substrate runtime APIs. These are top-level APIs exposed by the runtime (e.g. `Core`, `AccountNonceApi`, `TransactionPaymentApi`), accessed as `dot <chain>.apis.ApiName.method`.
@@ -847,6 +875,22 @@ dot tx.Balances.transferKeepAlive 5FHneW46... 999999999999999999 --from alice --
 # Error: Transaction dispatch error: Balances.InsufficientBalance
 echo $?  # 1
 ```
+
+#### Stale metadata detection
+
+When a `tx`, `--dry-run`, or `query` fails with an error that smells like stale metadata — a runtime wasm trap, a SCALE codec/decode error, or a fee-estimation panic — the CLI compares your locally cached metadata's runtime fingerprint against the live chain. If it has changed, the CLI appends a one-line suggestion telling you exactly which command to run:
+
+```
+Error: The runtime rejected this transaction in the runtime's validate_transaction step.
+  Cause: a runtime invariant failed — typically the call's arguments are out of range, …
+
+⚠ Local metadata for "paseo-people-next" is out of date (spec 1018 → 1020).
+   Run: dot chain update paseo-people-next
+```
+
+The fingerprint includes the runtime code hash, so the check also catches local-node restarts where the wasm changed but `specVersion` was kept the same. No automatic refetch happens — the original error still propagates with a non-zero exit code, you just get an actionable suggestion.
+
+The check only fires on suspected-stale errors, so the happy path pays no extra RPC. Set `DOT_TRUST_CACHED_METADATA=1` to disable the check entirely (e.g. for CI loops where you've just refreshed manually).
 
 #### Argument parsing errors
 
@@ -1450,10 +1494,15 @@ Config and metadata caches live in `~/.polkadot/` by default:
 ├── update-check.json    # cached update check result
 └── chains/
     └── polkadot/
-        └── metadata.bin # cached SCALE-encoded metadata
+        ├── metadata.bin              # cached SCALE-encoded metadata
+        └── metadata.fingerprint.json # runtime fingerprint (specVersion, codeHash, …) for stale-metadata detection
 ```
 
 > **Warning:** `accounts.json` stores secrets (mnemonics and seeds) in **plain text**. Encrypted-at-rest storage is planned but not yet implemented. Keep appropriate file permissions (`chmod 600 ~/.polkadot/accounts.json`) and do not use this for high-value mainnet accounts.
+
+### `DOT_TRUST_CACHED_METADATA` — skip the staleness check
+
+Set `DOT_TRUST_CACHED_METADATA=1` to disable the post-failure stale-metadata check on `dot tx`, `dot tx --dry-run`, and `dot query`. When set, errors propagate exactly as the runtime / RPC reported them, with no extra `state_getRuntimeVersion` / `state_getStorageHash` round-trip. Useful in CI loops where you've just refreshed metadata manually and don't want the overhead.
 
 ### `DOT_HOME` — redirect the config directory
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -15,6 +15,8 @@ A command-line tool for interacting with Polkadot-ecosystem chains. Manage chain
 - ✅ Account management — BIP39 mnemonics, derivation paths, env-backed secrets, watch-only, dev accounts
 - ✅ Named address resolution across all commands
 - ✅ Runtime API calls — `dot polkadot.apis.Core.version`
+- ✅ Full-metadata dump — `dot metadata <chain>` emits one JSON blob with pallets, runtime APIs, and transaction extensions (or raw SCALE bytes via `--raw`)
+- ✅ Stale-metadata detection — when a tx or query fails because the runtime upgraded, the CLI tells you exactly which `dot chain update` to run
 - ✅ Batteries included — all system parachains and testnets already setup to be used
 - ✅ File-based commands — run any command from a YAML/JSON file with variable substitution
 - ✅ Parachain sovereign accounts — derive child and sibling addresses from a parachain ID
@@ -891,6 +893,32 @@ dot polkadot.const.Balances                        # list constants (offline onc
 dot polkadot.const.Balances.ExistentialDeposit     # look up value (connects to chain)
 ```
 
+### Dump full metadata
+
+`dot metadata <chain>` fetches the chain's runtime metadata and prints **everything** as one JSON blob — pallets (with calls, events, errors, storage, constants), runtime APIs, and transaction extensions, headed by a runtime fingerprint (`specVersion`, `transactionVersion`, `codeHash`, etc.). Useful for feeding LLM agents or pipelines that want a single source of truth instead of walking `dot inspect` piecemeal.
+
+```bash
+# Decoded JSON — fetches fresh from the chain
+dot metadata polkadot
+
+# SCALE-encoded metadata bytes as a single 0x… hex line (for tools that re-parse)
+dot metadata polkadot --raw
+
+# Skip the network round-trip and use cached metadata
+dot metadata polkadot --cached
+
+# Override the RPC endpoint
+dot metadata polkadot --rpc wss://rpc.example.com
+
+# Slice with jq — list call names in a pallet
+dot metadata polkadot | jq '.pallets[] | select(.name=="Balances") | .calls[].name'
+
+# All transaction extension identifiers
+dot metadata polkadot | jq '.transactionExtensions[].identifier'
+```
+
+The decoded JSON is structured-only (no colorization), so it's safe to redirect to a file or pipe into other tools. The default fetches fresh from the RPC and atomically updates the local metadata cache and runtime-fingerprint sidecar — so subsequent commands benefit from the freshest possible metadata.
+
 ### Runtime APIs
 
 Browse and call Substrate runtime APIs. Unlike pallets, runtime APIs are top-level named interfaces (e.g. `Core`, `AccountNonceApi`, `TransactionPaymentApi`) that expose methods callable via `dot <chain>.apis.ApiName.method`.
@@ -1170,6 +1198,22 @@ echo $?  # 1
 ```
 
 This makes it easy to detect on-chain failures in scripts and CI pipelines.
+
+### Stale metadata detection
+
+When a `tx`, `--dry-run`, or `query` fails with an error that smells like stale metadata — a runtime wasm trap, a SCALE codec/decode error, or a fee-estimation panic — the CLI compares your locally cached metadata's runtime fingerprint against the live chain. If it has changed, the CLI appends a one-line suggestion telling you exactly which command to run:
+
+```
+Error: The runtime rejected this transaction in the runtime's validate_transaction step.
+  Cause: a runtime invariant failed — typically the call's arguments are out of range, …
+
+⚠ Local metadata for "paseo-people-next" is out of date (spec 1018 → 1020).
+   Run: dot chain update paseo-people-next
+```
+
+The fingerprint includes the runtime code hash, so the check also catches local-node restarts where the wasm changed but `specVersion` was kept the same. No automatic refetch happens — the original error still propagates with a non-zero exit code, you just get an actionable suggestion.
+
+The check only fires on suspected-stale errors, so the happy path pays no extra RPC. Set `DOT_TRUST_CACHED_METADATA=1` to disable the check entirely (e.g. for CI loops where you've just refreshed manually).
 
 ### Argument parsing errors
 
@@ -2086,8 +2130,13 @@ Config and metadata caches live in `~/.polkadot/` by default:
 ├── update-check.json    # cached update check result
 └── chains/
     └── polkadot/
-        └── metadata.bin # cached SCALE-encoded metadata
+        ├── metadata.bin              # cached SCALE-encoded metadata
+        └── metadata.fingerprint.json # runtime fingerprint (specVersion, codeHash, …) for stale-metadata detection
 ```
+
+### `DOT_TRUST_CACHED_METADATA` — skip the staleness check
+
+Set `DOT_TRUST_CACHED_METADATA=1` to disable the post-failure stale-metadata check on `dot tx`, `dot tx --dry-run`, and `dot query`. When set, errors propagate exactly as the runtime / RPC reported them, with no extra `state_getRuntimeVersion` / `state_getStorageHash` round-trip. Useful in CI loops where you've just refreshed metadata manually and don't want the overhead.
 
 ### `DOT_HOME` — redirect the config directory
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -18,7 +18,9 @@ Unified CLI for Polkadot/Substrate chains. Install: `npm install -g polkadot-cli
 dot [chain.]<category>[.Pallet[.Item]] [args] [options]
 ```
 
-Categories: `query`, `tx`, `apis`, `const`, `events`, `errors`
+Categories: `query`, `tx`, `apis`, `const`, `events`, `errors`, `extensions`
+
+Top-level commands: `dot inspect`, `dot metadata`, `dot chain`, `dot account`, `dot parachain`, `dot sign`, `dot hash`.
 
 Omit deeper levels to discover what's available:
 ```bash
@@ -140,6 +142,28 @@ Tips for discovering the exact shape a runtime expects:
 
 See [references/scripting-patterns.md](references/scripting-patterns.md) for more Location examples and the bash string-escaping pattern (`'"$VAR"'`).
 
+## Full Metadata Dump
+
+`dot metadata <chain>` prints the chain's runtime metadata as one structured JSON blob — pallets (with calls, events, errors, storage, constants), runtime APIs, transaction extensions, and a runtime fingerprint header. Use this when you (or an agent) want a single source of truth for what's available on a chain instead of walking `dot inspect` piecemeal.
+
+```bash
+# Decoded JSON — fetches fresh from the chain (also refreshes the local cache)
+dot metadata polkadot
+
+# SCALE-encoded metadata bytes as a single 0x… hex line (for re-decoding tools)
+dot metadata polkadot --raw
+
+# Use cached metadata only — no network round-trip (offline / CI)
+dot metadata polkadot --cached
+
+# Slice with jq
+dot metadata polkadot | jq '.pallets[] | select(.name=="Balances") | .calls[].name'
+dot metadata polkadot | jq '.transactionExtensions[].identifier'
+dot metadata polkadot | jq '.runtime'   # specVersion, transactionVersion, codeHash, …
+```
+
+The default fetch always hits the chain and updates the local fingerprint sidecar. Pair with `--raw` if you want the canonical SCALE bytes; the JSON form is decoded and includes docs.
+
 ## Inspect / Explore
 
 `inspect` is a top-level command, **not** a dotpath category. `dot <chain>.inspect...` does not parse. Two valid forms:
@@ -200,6 +224,7 @@ dot tx.System.remark 0xdead --to-yaml                   # encode call → YAML
 - **`Unknown account or address "X"`** / account has no public key resolved yet — the `--from` name isn't registered. Check `dot account list`, or import with `dot account import <name> ...`.
 - **`undefined` piped into `jq`** — the literal string `undefined` is not JSON. Guard with `[ "$X" == "undefined" ]` before piping.
 - **Decode errors after a runtime upgrade** — metadata cache is keyed by chain name; register a fresh `dot chain add` alias for the upgraded chain rather than reusing the old one.
+- **Wasm trap / "validate_transaction" panic on submit** — almost always stale local metadata. The CLI now prints a `⚠ Local metadata for "<chain>" is out of date … Run: dot chain update <chain>` line right after such errors. Run that command and retry. The check uses both `specVersion` and the runtime code hash, so it also catches local-node restarts where the wasm changed but `specVersion` was kept the same. Set `DOT_TRUST_CACHED_METADATA=1` to suppress the check entirely.
 
 ## Scripting Patterns
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -333,6 +333,9 @@ if (process.argv[2] === "__complete") {
     console.log("  dot polkadot.events.Balances                        List events in Balances");
     console.log("  dot polkadot.apis.Core.version                      Call a runtime API");
     console.log(
+      "  dot metadata polkadot                               Dump runtime metadata as JSON",
+    );
+    console.log(
       "  dot polkadot.extensions                             List transaction extensions",
     );
     console.log("  dot polkadot.extensions.CheckMortality              Inspect one extension");
@@ -348,6 +351,7 @@ if (process.argv[2] === "__complete") {
     console.log();
     console.log("Commands:");
     console.log("  inspect [target]   Inspect chain metadata (alias: explore)");
+    console.log("  metadata <chain>   Dump runtime metadata as JSON (--raw for SCALE hex)");
     console.log("  chain              Manage chain configurations");
     console.log("  account            Manage accounts");
     console.log("  hash               Hash utilities");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import {
 } from "./commands/focused-inspect.ts";
 import { registerHashCommand } from "./commands/hash.ts";
 import { registerInspectCommand } from "./commands/inspect.ts";
+import { registerMetadataCommand } from "./commands/metadata.ts";
 import { registerParachainCommand } from "./commands/parachain.ts";
 import { handleQuery } from "./commands/query.ts";
 import { registerSignCommand } from "./commands/sign.ts";
@@ -26,7 +27,7 @@ import {
   startBackgroundCheck,
   waitForPendingCheck,
 } from "./core/update-notifier.ts";
-import { CliError } from "./utils/errors.ts";
+import { CliError, formatRuntimeError, isPapiCleanupError } from "./utils/errors.ts";
 import { parseDotPath } from "./utils/parse-dot-path.ts";
 
 // Early exit for shell completion — avoid loading update checker or heavy imports
@@ -61,6 +62,7 @@ if (process.argv[2] === "__complete") {
 
   registerChainCommands(cli);
   registerInspectCommand(cli);
+  registerMetadataCommand(cli);
   registerAccountCommands(cli);
   registerHashCommand(cli);
   registerSignCommand(cli);
@@ -374,13 +376,22 @@ if (process.argv[2] === "__complete") {
     if (err instanceof CliError) {
       console.error(`Error: ${err.message}`);
     } else if (err instanceof Error) {
-      // CACError for missing args, etc. — show just the message
-      console.error(`Error: ${err.message}`);
+      // CACError for missing args, polkadot-api errors, etc.
+      console.error(`Error: ${formatRuntimeError(err)}`);
     } else {
       console.error("An unexpected error occurred:", err);
     }
     return showUpdateAndExit(1);
   }
+
+  // papi schedules timers inside chainHead follow streams that can fire after
+  // client.destroy() — those rejections are benign cleanup races and would
+  // otherwise crash the process (e.g. after `dot chain update --all`).
+  process.on("unhandledRejection", (reason) => {
+    if (isPapiCleanupError(reason)) return;
+    console.error(`Error: ${formatRuntimeError(reason)}`);
+    process.exit(1);
+  });
 
   async function main() {
     try {

--- a/src/commands/metadata.test.ts
+++ b/src/commands/metadata.test.ts
@@ -183,10 +183,19 @@ describe("handleMetadata --cached", () => {
   });
 });
 
+// handleMetadata writes via process.stdout.write directly (callback form,
+// to ensure pipe drain before exit) — not console.log — so we patch the
+// stream's write to capture output without going through stdout.
 function patchConsoleLog(capture: (msg: string) => void): () => void {
-  const original = console.log;
-  console.log = (msg?: unknown) => capture(typeof msg === "string" ? msg : String(msg));
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: unknown, ...rest: unknown[]) => {
+    const text = typeof chunk === "string" ? chunk : String(chunk);
+    capture(text.endsWith("\n") ? text.slice(0, -1) : text);
+    const cb = rest.find((a) => typeof a === "function") as ((err?: Error) => void) | undefined;
+    cb?.();
+    return true;
+  }) as typeof process.stdout.write;
   return () => {
-    console.log = original;
+    process.stdout.write = original;
   };
 }

--- a/src/commands/metadata.test.ts
+++ b/src/commands/metadata.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../config/types.ts";
+import { parseMetadata } from "../core/metadata.ts";
+import { withDotHome } from "../test-helpers/with-dot-home.ts";
+import { runCli } from "./__fixtures__/run-cli.ts";
+import { buildMetadataPayload, handleMetadata } from "./metadata.ts";
+
+const FIXTURE_METADATA = join(import.meta.dir, "__fixtures__", "polkadot-metadata.bin");
+
+describe("buildMetadataPayload", () => {
+  test("payload has the expected top-level shape", async () => {
+    const raw = await Bun.file(FIXTURE_METADATA).bytes();
+    const meta = parseMetadata(raw);
+    const payload = buildMetadataPayload("polkadot", meta, null);
+
+    expect(payload.chain).toBe("polkadot");
+    expect(payload.runtime.metadataVersion).toBeGreaterThanOrEqual(14);
+    expect(Array.isArray(payload.pallets)).toBe(true);
+    expect(Array.isArray(payload.runtimeApis)).toBe(true);
+    expect(Array.isArray(payload.transactionExtensions)).toBe(true);
+  });
+
+  test("pallets include System with calls / events / errors / storage / constants", async () => {
+    const raw = await Bun.file(FIXTURE_METADATA).bytes();
+    const meta = parseMetadata(raw);
+    const payload = buildMetadataPayload("polkadot", meta, null);
+
+    const system = payload.pallets.find((p) => p.name === "System");
+    expect(system).toBeDefined();
+    expect(system!.calls.length).toBeGreaterThan(0);
+    expect(system!.events.length).toBeGreaterThan(0);
+    expect(system!.errors.length).toBeGreaterThan(0);
+    expect(system!.storage.length).toBeGreaterThan(0);
+    expect(system!.constants.length).toBeGreaterThan(0);
+  });
+
+  test("transactionExtensions include common signed extensions", async () => {
+    const raw = await Bun.file(FIXTURE_METADATA).bytes();
+    const meta = parseMetadata(raw);
+    const payload = buildMetadataPayload("polkadot", meta, null);
+
+    const idents = payload.transactionExtensions.map((e) => e.identifier);
+    expect(idents).toContain("CheckMortality");
+    expect(idents).toContain("CheckNonce");
+  });
+
+  test("runtime block merges fingerprint when supplied", async () => {
+    const raw = await Bun.file(FIXTURE_METADATA).bytes();
+    const meta = parseMetadata(raw);
+    const fingerprint = {
+      specName: "polkadot",
+      specVersion: 1018,
+      transactionVersion: 24,
+      implName: "parity-polkadot",
+      implVersion: 0,
+      authoringVersion: 0,
+      codeHash: "0xabcd",
+      fetchedAt: "2026-04-27T12:00:00Z",
+    };
+    const payload = buildMetadataPayload("polkadot", meta, fingerprint);
+
+    expect(payload.runtime.specVersion).toBe(1018);
+    expect(payload.runtime.codeHash).toBe("0xabcd");
+    expect(payload.runtime.metadataVersion).toBeGreaterThanOrEqual(14);
+  });
+});
+
+describe("dot metadata (CLI)", () => {
+  test("--cached prints decoded JSON with the fixture metadata", async () => {
+    const { stdout, exitCode } = await runCli(["metadata", "polkadot", "--cached"], {
+      noDefaultChain: true,
+    });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.chain).toBe("polkadot");
+    expect(parsed.runtime.metadataVersion).toBeGreaterThanOrEqual(14);
+    expect(parsed.pallets.some((p: { name: string }) => p.name === "System")).toBe(true);
+    expect(parsed.transactionExtensions.length).toBeGreaterThan(0);
+  });
+
+  test("--cached --raw prints a single 0x hex line", async () => {
+    const { stdout, exitCode } = await runCli(["metadata", "polkadot", "--cached", "--raw"], {
+      noDefaultChain: true,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout.startsWith("0x")).toBe(true);
+    expect(stdout).not.toContain("\n");
+    expect(/^0x[0-9a-f]+$/i.test(stdout)).toBe(true);
+  });
+
+  test("errors with a clear message when the chain is not configured", async () => {
+    const { stderr, exitCode } = await runCli(["metadata", "made-up-chain", "--cached"], {
+      noDefaultChain: true,
+    });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unknown chain");
+  });
+});
+
+// In-process unit tests for handleMetadata. These run the handler directly
+// (not through a subprocess) so the coverage tooling can measure which
+// lines run. process.env.DOT_HOME mutations are serialized by withDotHome
+// against other tests in this file; bun's per-file process.env isolation
+// keeps cross-file tests safe.
+
+function setupHome(withFixture: boolean): string {
+  const tmpHome = mkdtempSync(join(tmpdir(), "dot-metadata-handler-"));
+  if (withFixture) {
+    const polkadotDir = join(tmpHome, "chains", "polkadot");
+    mkdirSync(polkadotDir, { recursive: true });
+    copyFileSync(FIXTURE_METADATA, join(polkadotDir, "metadata.bin"));
+  }
+  writeFileSync(join(tmpHome, "config.json"), JSON.stringify(DEFAULT_CONFIG));
+  return tmpHome;
+}
+
+describe("handleMetadata --cached", () => {
+  test("writes JSON with the expected shape against fixture metadata", async () => {
+    const home = setupHome(true);
+    const captured: string[] = [];
+    try {
+      await withDotHome(home, async () => {
+        const restore = patchConsoleLog((msg) => captured.push(msg));
+        try {
+          await handleMetadata("polkadot", { cached: true });
+        } finally {
+          restore();
+        }
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+    expect(captured.length).toBe(1);
+    const parsed = JSON.parse(captured[0]!);
+    expect(parsed.chain).toBe("polkadot");
+    expect(parsed.runtime.metadataVersion).toBeGreaterThanOrEqual(14);
+    expect(parsed.pallets.length).toBeGreaterThan(0);
+    expect(parsed.transactionExtensions.length).toBeGreaterThan(0);
+  });
+
+  test("--cached --raw writes a single 0x hex line", async () => {
+    const home = setupHome(true);
+    const captured: string[] = [];
+    try {
+      await withDotHome(home, async () => {
+        const restore = patchConsoleLog((msg) => captured.push(msg));
+        try {
+          await handleMetadata("polkadot", { cached: true, raw: true });
+        } finally {
+          restore();
+        }
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+    expect(captured.length).toBe(1);
+    expect(captured[0]!.startsWith("0x")).toBe(true);
+  });
+
+  test("--cached on chain with no cached metadata throws CliError", async () => {
+    const home = setupHome(false);
+    try {
+      await expect(
+        withDotHome(home, () => handleMetadata("polkadot", { cached: true })),
+      ).rejects.toThrow(/No cached metadata/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects unknown chains", async () => {
+    const home = setupHome(false);
+    try {
+      await expect(
+        withDotHome(home, () => handleMetadata("made-up", { cached: true })),
+      ).rejects.toThrow(/Unknown chain/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+function patchConsoleLog(capture: (msg: string) => void): () => void {
+  const original = console.log;
+  console.log = (msg?: unknown) => capture(typeof msg === "string" ? msg : String(msg));
+  return () => {
+    console.log = original;
+  };
+}

--- a/src/commands/metadata.ts
+++ b/src/commands/metadata.ts
@@ -74,13 +74,25 @@ export async function handleMetadata(chain: string, opts: MetadataCommandOpts): 
   }
 
   if (opts.raw) {
-    console.log(`0x${Buffer.from(rawBytes).toString("hex")}`);
+    await writeStdout(`0x${Buffer.from(rawBytes).toString("hex")}\n`);
     return;
   }
 
   const meta = parseMetadata(rawBytes);
   const fingerprint = await loadMetadataFingerprint(chainName);
-  console.log(formatJson(buildMetadataPayload(chainName, meta, fingerprint)));
+  await writeStdout(`${formatJson(buildMetadataPayload(chainName, meta, fingerprint))}\n`);
+}
+
+// Awaitable write to process.stdout — multi-MB JSON via console.log gets
+// truncated when piped on Linux because process.exit() doesn't wait for the
+// stream's userspace buffer to drain. The write-callback form fires after
+// the chunk has been handed to the OS, so awaiting it before the command
+// returns ensures the full payload reaches the reader. EPIPE is swallowed
+// — that's the reader closing early (e.g. `… | head -c 50`).
+function writeStdout(text: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    process.stdout.write(text, () => resolve());
+  });
 }
 
 export function registerMetadataCommand(cli: CAC) {

--- a/src/commands/metadata.ts
+++ b/src/commands/metadata.ts
@@ -1,0 +1,93 @@
+import type { CAC } from "cac";
+import {
+  loadConfig,
+  loadMetadata,
+  loadMetadataFingerprint,
+  resolveChain,
+} from "../config/store.ts";
+import { createChainClient } from "../core/client.ts";
+import {
+  fetchMetadataFromChain,
+  getSignedExtensions,
+  listPallets,
+  listRuntimeApis,
+  type MetadataBundle,
+  parseMetadata,
+} from "../core/metadata.ts";
+import { formatJson } from "../core/output.ts";
+import { CliError } from "../utils/errors.ts";
+import type { RuntimeFingerprint } from "../utils/runtime-fingerprint.ts";
+
+export interface MetadataPayload {
+  chain: string;
+  runtime: { metadataVersion: number } & Partial<RuntimeFingerprint>;
+  pallets: ReturnType<typeof listPallets>;
+  runtimeApis: ReturnType<typeof listRuntimeApis>;
+  transactionExtensions: ReturnType<typeof getSignedExtensions>;
+}
+
+export function buildMetadataPayload(
+  chainName: string,
+  meta: MetadataBundle,
+  fingerprint: RuntimeFingerprint | null,
+): MetadataPayload {
+  return {
+    chain: chainName,
+    runtime: { ...(fingerprint ?? {}), metadataVersion: meta.version },
+    pallets: listPallets(meta),
+    runtimeApis: listRuntimeApis(meta),
+    transactionExtensions: getSignedExtensions(meta),
+  };
+}
+
+export interface MetadataCommandOpts {
+  raw?: boolean;
+  cached?: boolean;
+  rpc?: string | string[];
+}
+
+export async function handleMetadata(chain: string, opts: MetadataCommandOpts): Promise<void> {
+  const config = await loadConfig();
+  const { name: chainName, chain: chainConfig } = resolveChain(config, chain);
+
+  let rawBytes: Uint8Array | null;
+  if (opts.cached) {
+    rawBytes = await loadMetadata(chainName);
+    if (!rawBytes) {
+      throw new CliError(
+        `No cached metadata for "${chainName}". Run \`dot chain update ${chainName}\` first, or omit --cached to fetch fresh.`,
+      );
+    }
+  } else {
+    const clientHandle = await createChainClient(chainName, chainConfig, opts.rpc);
+    try {
+      // fetchMetadataFromChain also persists the runtime fingerprint sidecar
+      // so subsequent commands can detect drift.
+      await fetchMetadataFromChain(clientHandle, chainName);
+    } finally {
+      clientHandle.destroy();
+    }
+    rawBytes = await loadMetadata(chainName);
+    if (!rawBytes) {
+      throw new CliError(`Failed to load metadata for "${chainName}" after fetch.`);
+    }
+  }
+
+  if (opts.raw) {
+    console.log(`0x${Buffer.from(rawBytes).toString("hex")}`);
+    return;
+  }
+
+  const meta = parseMetadata(rawBytes);
+  const fingerprint = await loadMetadataFingerprint(chainName);
+  console.log(formatJson(buildMetadataPayload(chainName, meta, fingerprint)));
+}
+
+export function registerMetadataCommand(cli: CAC) {
+  cli
+    .command("metadata <chain>", "Fetch chain metadata (decoded JSON; --raw for SCALE hex)")
+    .option("--raw", "Print SCALE-encoded metadata bytes as hex instead of decoded JSON")
+    .option("--cached", "Use cached metadata instead of fetching fresh from the chain")
+    .option("--rpc <url>", "Override RPC endpoint(s)")
+    .action((chain: string, opts: MetadataCommandOpts) => handleMetadata(chain, opts));
+}

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -7,6 +7,7 @@ import {
   getOrFetchMetadata,
   getPalletNames,
   listPallets,
+  withStalenessSuggestion,
 } from "../core/metadata.ts";
 import {
   CYAN,
@@ -173,8 +174,10 @@ export async function handleQuery(
         return;
       }
       // Fetch entries with partial (or no) keys
-      const entries: Array<{ keyArgs: any; value: any }> = await storageApi.getEntries(
-        ...parsedKeys,
+      const entries: Array<{ keyArgs: any; value: any }> = await withStalenessSuggestion(
+        chainName,
+        clientHandle,
+        () => storageApi.getEntries(...parsedKeys),
       );
 
       printResult(
@@ -186,7 +189,9 @@ export async function handleQuery(
       );
     } else {
       // Full key → single value lookup
-      const result = await storageApi.getValue(...parsedKeys);
+      const result = await withStalenessSuggestion(chainName, clientHandle, () =>
+        storageApi.getValue(...parsedKeys),
+      );
       printResult(result, format);
     }
   } finally {

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -19,6 +19,7 @@ import {
   getSignedExtensions,
   listPallets,
   PAPI_BUILTIN_EXTENSIONS,
+  withStalenessSuggestion,
 } from "../core/metadata.ts";
 import {
   BOLD,
@@ -38,7 +39,7 @@ import {
 } from "../core/output.ts";
 import { resolveAccountAddress } from "../core/resolve-address.ts";
 import { binaryToDisplay } from "../utils/binary-display.ts";
-import { CliError } from "../utils/errors.ts";
+import { CliError, formatRuntimeError } from "../utils/errors.ts";
 import { suggestMessage } from "../utils/fuzzy-match.ts";
 import { parseValue } from "../utils/parse-value.ts";
 import { loadMeta, resolvePallet, showItemHelp } from "./focused-inspect.ts";
@@ -446,10 +447,15 @@ export async function handleTx(
       const signerAddress = toSs58(signer!.publicKey);
 
       let estimatedFees: string | undefined;
+      let estimationError: string | undefined;
       try {
-        estimatedFees = String(await tx.getEstimatedFees(signer?.publicKey, txOptions));
-      } catch {
-        estimatedFees = undefined;
+        estimatedFees = String(
+          await withStalenessSuggestion(chainName, clientHandle!, () =>
+            tx.getEstimatedFees(signer?.publicKey, txOptions),
+          ),
+        );
+      } catch (err) {
+        estimationError = err instanceof Error ? err.message : String(err);
       }
 
       if (isJsonOutput(opts)) {
@@ -460,6 +466,7 @@ export async function handleTx(
           decoded: decodedStr,
           estimatedFees,
         };
+        if (estimationError !== undefined) result.estimationError = estimationError;
         if (nonce !== undefined) result.nonce = nonce;
         if (tip !== undefined) result.tip = String(tip);
         if (asset !== undefined) result.asset = asset;
@@ -487,6 +494,11 @@ export async function handleTx(
         console.log(`  ${BOLD}Estimated fees:${RESET} ${estimatedFees}`);
       } else {
         console.log(`  ${BOLD}Estimated fees:${RESET} ${YELLOW}unable to estimate${RESET}`);
+        if (estimationError) {
+          const formatted = formatRuntimeError(estimationError).replace(/\n/g, `\n  `);
+          console.log(`  ${YELLOW}⚠${RESET} ${formatted}`);
+          console.log(`  ${DIM}Submitting this transaction is likely to fail.${RESET}`);
+        }
       }
       return;
     }
@@ -515,7 +527,9 @@ export async function handleTx(
       ) as import("rxjs").Observable<TxEvent>;
 
       if (isJsonOutput(opts)) {
-        const result = await watchTransactionJson(observable, waitLevel, { unsigned: true });
+        const result = await withStalenessSuggestion(chainName, clientHandle!, () =>
+          watchTransactionJson(observable, waitLevel, { unsigned: true }),
+        );
         const rpcUrl = primaryRpc(opts.rpc ?? chainConfig.rpc);
         if (result.type === "broadcasted") {
           printJsonLine({ event: "broadcasted", txHash: result.txHash });
@@ -550,7 +564,9 @@ export async function handleTx(
         return;
       }
 
-      const result = await watchTransaction(observable, waitLevel, { unsigned: true });
+      const result = await withStalenessSuggestion(chainName, clientHandle!, () =>
+        watchTransaction(observable, waitLevel, { unsigned: true }),
+      );
 
       console.log();
       console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
@@ -612,9 +628,8 @@ export async function handleTx(
 
     // JSON output: NDJSON stream
     if (isJsonOutput(opts)) {
-      const result = await watchTransactionJson(
-        tx.signSubmitAndWatch(signer, txOptions),
-        waitLevel,
+      const result = await withStalenessSuggestion(chainName, clientHandle!, () =>
+        watchTransactionJson(tx.signSubmitAndWatch(signer, txOptions), waitLevel),
       );
       const rpcUrl = primaryRpc(opts.rpc ?? chainConfig.rpc);
       if (result.type === "broadcasted") {
@@ -650,7 +665,9 @@ export async function handleTx(
       return;
     }
 
-    const result = await watchTransaction(tx.signSubmitAndWatch(signer, txOptions), waitLevel);
+    const result = await withStalenessSuggestion(chainName, clientHandle!, () =>
+      watchTransaction(tx.signSubmitAndWatch(signer, txOptions), waitLevel),
+    );
 
     console.log();
     console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -2,6 +2,7 @@ import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { CliError } from "../utils/errors.ts";
+import { isRuntimeFingerprint, type RuntimeFingerprint } from "../utils/runtime-fingerprint.ts";
 import type { ChainConfig, Config } from "./types.ts";
 import { DEFAULT_CONFIG } from "./types.ts";
 
@@ -20,6 +21,10 @@ export function getChainDir(chainName: string): string {
 
 export function getMetadataPath(chainName: string): string {
   return join(getChainDir(chainName), "metadata.bin");
+}
+
+export function getMetadataFingerprintPath(chainName: string): string {
+  return join(getChainDir(chainName), "metadata.fingerprint.json");
 }
 
 function getConfigPath(): string {
@@ -74,10 +79,33 @@ export async function loadMetadata(chainName: string): Promise<Uint8Array | null
   return null;
 }
 
-export async function saveMetadata(chainName: string, data: Uint8Array): Promise<void> {
+export async function saveMetadata(
+  chainName: string,
+  data: Uint8Array,
+  fingerprint?: RuntimeFingerprint,
+): Promise<void> {
   const dir = getChainDir(chainName);
   await ensureDir(dir);
   await writeFile(getMetadataPath(chainName), data);
+  if (fingerprint) {
+    await writeFile(
+      getMetadataFingerprintPath(chainName),
+      `${JSON.stringify(fingerprint, null, 2)}\n`,
+    );
+  }
+}
+
+export async function loadMetadataFingerprint(
+  chainName: string,
+): Promise<RuntimeFingerprint | null> {
+  const path = getMetadataFingerprintPath(chainName);
+  if (!(await fileExists(path))) return null;
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf-8"));
+    return isRuntimeFingerprint(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 export async function removeChainData(chainName: string): Promise<void> {

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -7,8 +7,15 @@ import {
   unifyMetadata,
 } from "@polkadot-api/substrate-bindings";
 import { toHex } from "@polkadot-api/utils";
-import { loadMetadata, saveMetadata } from "../config/store.ts";
-import { ConnectionError, MetadataError } from "../utils/errors.ts";
+import { loadMetadata, loadMetadataFingerprint, saveMetadata } from "../config/store.ts";
+import {
+  CliError,
+  ConnectionError,
+  formatRuntimeError,
+  isLikelyStaleMetadataError,
+  MetadataError,
+} from "../utils/errors.ts";
+import { fingerprintsMatch, type RuntimeFingerprint } from "../utils/runtime-fingerprint.ts";
 import type { ClientHandle } from "./client.ts";
 
 const METADATA_TIMEOUT_MS = 15_000;
@@ -77,11 +84,43 @@ export function parseMetadata(raw: Uint8Array): MetadataBundle {
   return { unified, lookup, builder, version };
 }
 
+interface RuntimeVersionRpc {
+  specName: string;
+  specVersion: number;
+  transactionVersion: number;
+  implName: string;
+  implVersion: number;
+  authoringVersion: number;
+}
+
+export async function getRuntimeFingerprint(
+  clientHandle: ClientHandle,
+  chainName: string,
+): Promise<RuntimeFingerprint> {
+  const { client } = clientHandle;
+  const [version, codeHash] = await Promise.all([
+    withTimeout(client._request<RuntimeVersionRpc>("state_getRuntimeVersion", []), chainName),
+    withTimeout(client._request<string>("state_getStorageHash", ["0x3a636f6465"]), chainName),
+  ]);
+  return {
+    specName: version.specName,
+    specVersion: version.specVersion,
+    transactionVersion: version.transactionVersion,
+    implName: version.implName,
+    implVersion: version.implVersion,
+    authoringVersion: version.authoringVersion,
+    codeHash,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
 export async function fetchMetadataFromChain(
   clientHandle: ClientHandle,
   chainName: string,
 ): Promise<Uint8Array> {
   const { client } = clientHandle;
+
+  let bytes: Uint8Array | undefined;
 
   // Try v15 metadata first (includes runtime API info)
   try {
@@ -92,27 +131,37 @@ export async function fetchMetadataFromChain(
     const raw = hexToBytes(hex);
     const decoded = optionalOpaqueBytes.dec(raw);
     if (decoded !== undefined) {
-      const bytes = new Uint8Array(decoded);
-      await saveMetadata(chainName, bytes);
-      return bytes;
+      bytes = new Uint8Array(decoded);
     }
   } catch {
     // v15 not available, fall through to v14
   }
 
-  // Fall back to state_getMetadata (v14)
-  try {
-    const hex = await withTimeout(client._request<string>("state_getMetadata", []), chainName);
-    const bytes = hexToBytes(hex);
-    await saveMetadata(chainName, bytes);
-    return bytes;
-  } catch (err) {
-    if (err instanceof ConnectionError) throw err;
-    throw new ConnectionError(
-      `Failed to fetch metadata for "${chainName}": ${err instanceof Error ? err.message : err}. ` +
-        "Check that the RPC endpoint is correct and reachable.",
-    );
+  if (!bytes) {
+    // Fall back to state_getMetadata (v14)
+    try {
+      const hex = await withTimeout(client._request<string>("state_getMetadata", []), chainName);
+      bytes = hexToBytes(hex);
+    } catch (err) {
+      if (err instanceof ConnectionError) throw err;
+      throw new ConnectionError(
+        `Failed to fetch metadata for "${chainName}": ${err instanceof Error ? err.message : err}. ` +
+          "Check that the RPC endpoint is correct and reachable.",
+      );
+    }
   }
+
+  // Best-effort: alongside the metadata, persist a runtime fingerprint so we
+  // can detect stale local metadata after a future failure. Don't fail the
+  // metadata fetch if the fingerprint RPCs are unavailable on this endpoint.
+  let fingerprint: RuntimeFingerprint | undefined;
+  try {
+    fingerprint = await getRuntimeFingerprint(clientHandle, chainName);
+  } catch {
+    fingerprint = undefined;
+  }
+  await saveMetadata(chainName, bytes, fingerprint);
+  return bytes;
 }
 
 function withTimeout<T>(promise: Promise<T>, chainName: string): Promise<T> {
@@ -131,6 +180,44 @@ function withTimeout<T>(promise: Promise<T>, chainName: string): Promise<T> {
       ),
     ),
   ]);
+}
+
+// Run `task` and, if it fails with an error that smells like stale metadata,
+// verify by comparing the cached runtime fingerprint against the live chain.
+// If they differ, re-throw with a CliError that wraps the original error and
+// suggests `dot chain update <chain>`. Never refreshes metadata automatically.
+export async function withStalenessSuggestion<T>(
+  chainName: string,
+  clientHandle: ClientHandle,
+  task: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await task();
+  } catch (err) {
+    if (process.env.DOT_TRUST_CACHED_METADATA === "1") throw err;
+    if (!isLikelyStaleMetadataError(err)) throw err;
+
+    let live: RuntimeFingerprint;
+    try {
+      live = await getRuntimeFingerprint(clientHandle, chainName);
+    } catch {
+      throw err;
+    }
+    const cached = await loadMetadataFingerprint(chainName);
+    if (!cached) throw err;
+    if (fingerprintsMatch(cached, live)) throw err;
+
+    const original = err instanceof Error ? formatRuntimeError(err) : String(err);
+    const versionNote =
+      cached.specVersion !== live.specVersion
+        ? `spec ${cached.specVersion} → ${live.specVersion}`
+        : `runtime code hash changed (same spec ${live.specVersion}; likely a node restart with new wasm)`;
+    throw new CliError(
+      `${original}\n\n` +
+        `⚠ Local metadata for "${chainName}" is out of date (${versionNote}).\n` +
+        `   Run: dot chain update ${chainName}`,
+    );
+  }
 }
 
 export async function getOrFetchMetadata(

--- a/src/core/staleness.test.ts
+++ b/src/core/staleness.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getMetadataFingerprintPath, loadMetadataFingerprint } from "../config/store.ts";
+import { withDotHome } from "../test-helpers/with-dot-home.ts";
+import type { ClientHandle } from "./client.ts";
+import { withStalenessSuggestion } from "./metadata.ts";
+
+interface MockClient {
+  client: { _request: <T>(method: string, params: unknown[]) => Promise<T> };
+  destroy: () => void;
+}
+
+function makeMockClient(handler: (method: string) => unknown): MockClient {
+  return {
+    client: {
+      _request: async <T>(method: string): Promise<T> => handler(method) as T,
+    },
+    destroy: () => {},
+  };
+}
+
+const STALE_WASM_TRAP = new Error(
+  "Execution failed: Execution aborted due to trap: wasm `unreachable` instruction executed",
+);
+
+function makeFreshHome(): string {
+  const home = mkdtempSync(join(tmpdir(), "dot-staleness-"));
+  mkdirSync(join(home, "chains", "polkadot"), { recursive: true });
+  return home;
+}
+
+function withFingerprint(home: string, fp: object) {
+  process.env.DOT_HOME = home;
+  writeFileSync(getMetadataFingerprintPath("polkadot"), JSON.stringify(fp));
+}
+
+describe("withStalenessSuggestion", () => {
+  test("returns the task result on success without doing any RPC", async () => {
+    const home = makeFreshHome();
+    const client = makeMockClient(() => {
+      throw new Error("RPC should not be called on success path");
+    });
+    try {
+      const result = await withDotHome(home, () =>
+        withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => 42),
+      );
+      expect(result).toBe(42);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates non-stale errors unchanged (e.g. pallet not found)", async () => {
+    const home = makeFreshHome();
+    const client = makeMockClient(() => {
+      throw new Error("RPC should not be called for non-stale errors");
+    });
+    try {
+      await expect(
+        withDotHome(home, () =>
+          withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+            throw new Error("pallet 'Foo' not found");
+          }),
+        ),
+      ).rejects.toThrow("pallet 'Foo' not found");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates the original error when DOT_TRUST_CACHED_METADATA=1", async () => {
+    const home = makeFreshHome();
+    const client = makeMockClient(() => {
+      throw new Error("RPC should not be called when env opt-out is set");
+    });
+    process.env.DOT_TRUST_CACHED_METADATA = "1";
+    try {
+      await expect(
+        withDotHome(home, () =>
+          withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+            throw STALE_WASM_TRAP;
+          }),
+        ),
+      ).rejects.toThrow(/wasm.*unreachable/);
+    } finally {
+      delete process.env.DOT_TRUST_CACHED_METADATA;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates original error when fingerprint RPC fails", async () => {
+    const home = makeFreshHome();
+    const client = makeMockClient(() => {
+      throw new Error("network down");
+    });
+    try {
+      await expect(
+        withDotHome(home, () =>
+          withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+            throw STALE_WASM_TRAP;
+          }),
+        ),
+      ).rejects.toThrow(/wasm.*unreachable/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates original error when no cached fingerprint exists", async () => {
+    const home = makeFreshHome();
+    const client = makeMockClient((method) => {
+      if (method === "state_getRuntimeVersion") {
+        return {
+          specName: "polkadot",
+          specVersion: 1018,
+          transactionVersion: 24,
+          implName: "parity-polkadot",
+          implVersion: 0,
+          authoringVersion: 0,
+        };
+      }
+      if (method === "state_getStorageHash") return "0xfeed";
+      throw new Error(`unexpected method: ${method}`);
+    });
+    try {
+      await expect(
+        withDotHome(home, () =>
+          withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+            throw STALE_WASM_TRAP;
+          }),
+        ),
+      ).rejects.toThrow(/wasm.*unreachable/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates original error when cached fingerprint matches live", async () => {
+    const home = makeFreshHome();
+    const fp = {
+      specName: "polkadot",
+      specVersion: 1018,
+      transactionVersion: 24,
+      implName: "parity-polkadot",
+      implVersion: 0,
+      authoringVersion: 0,
+      codeHash: "0xfeed",
+      fetchedAt: "2026-04-27T12:00:00Z",
+    };
+    const client = makeMockClient((method) => {
+      if (method === "state_getRuntimeVersion") {
+        return {
+          specName: fp.specName,
+          specVersion: fp.specVersion,
+          transactionVersion: fp.transactionVersion,
+          implName: fp.implName,
+          implVersion: fp.implVersion,
+          authoringVersion: fp.authoringVersion,
+        };
+      }
+      if (method === "state_getStorageHash") return "0xfeed";
+      throw new Error(`unexpected method: ${method}`);
+    });
+    try {
+      await withDotHome(home, async () => {
+        withFingerprint(home, fp);
+        expect(await loadMetadataFingerprint("polkadot")).not.toBeNull();
+        await expect(
+          withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+            throw STALE_WASM_TRAP;
+          }),
+        ).rejects.toThrow(/wasm.*unreachable/);
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("wraps with a 'spec X → Y' note when specVersion bumped", async () => {
+    const home = makeFreshHome();
+    const cached = {
+      specName: "polkadot",
+      specVersion: 1018,
+      transactionVersion: 24,
+      implName: "parity-polkadot",
+      implVersion: 0,
+      authoringVersion: 0,
+      codeHash: "0xaaaa",
+      fetchedAt: "2026-04-27T12:00:00Z",
+    };
+    const client = makeMockClient((method) => {
+      if (method === "state_getRuntimeVersion") {
+        return {
+          specName: "polkadot",
+          specVersion: 1020,
+          transactionVersion: 25,
+          implName: "parity-polkadot",
+          implVersion: 0,
+          authoringVersion: 0,
+        };
+      }
+      if (method === "state_getStorageHash") return "0xbbbb";
+      throw new Error(`unexpected method: ${method}`);
+    });
+    try {
+      await withDotHome(home, async () => {
+        withFingerprint(home, cached);
+        let captured: Error | undefined;
+        try {
+          await withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+            throw STALE_WASM_TRAP;
+          });
+        } catch (err) {
+          captured = err as Error;
+        }
+        expect(captured).toBeDefined();
+        expect(captured!.message).toContain('Local metadata for "polkadot" is out of date');
+        expect(captured!.message).toContain("spec 1018 → 1020");
+        expect(captured!.message).toContain("dot chain update polkadot");
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("wraps with code-hash note when only codeHash differs (same spec)", async () => {
+    const home = makeFreshHome();
+    const cached = {
+      specName: "polkadot",
+      specVersion: 1018,
+      transactionVersion: 24,
+      implName: "parity-polkadot",
+      implVersion: 0,
+      authoringVersion: 0,
+      codeHash: "0xCACHED",
+      fetchedAt: "2026-04-27T12:00:00Z",
+    };
+    const client = makeMockClient((method) => {
+      if (method === "state_getRuntimeVersion") {
+        return {
+          specName: "polkadot",
+          specVersion: 1018, // same spec
+          transactionVersion: 24,
+          implName: "parity-polkadot",
+          implVersion: 0,
+          authoringVersion: 0,
+        };
+      }
+      if (method === "state_getStorageHash") return "0xLIVE"; // different code
+      throw new Error(`unexpected method: ${method}`);
+    });
+    try {
+      await withDotHome(home, async () => {
+        withFingerprint(home, cached);
+        let captured: Error | undefined;
+        try {
+          await withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+            throw STALE_WASM_TRAP;
+          });
+        } catch (err) {
+          captured = err as Error;
+        }
+        expect(captured).toBeDefined();
+        expect(captured!.message).toContain("code hash changed");
+        expect(captured!.message).toContain("same spec 1018");
+        expect(captured!.message).toContain("dot chain update polkadot");
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/staleness.test.ts
+++ b/src/core/staleness.test.ts
@@ -75,17 +75,18 @@ describe("withStalenessSuggestion", () => {
     const client = makeMockClient(() => {
       throw new Error("RPC should not be called when env opt-out is set");
     });
-    process.env.DOT_TRUST_CACHED_METADATA = "1";
     try {
       await expect(
-        withDotHome(home, () =>
-          withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
-            throw STALE_WASM_TRAP;
-          }),
+        withDotHome(
+          home,
+          () =>
+            withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+              throw STALE_WASM_TRAP;
+            }),
+          { DOT_TRUST_CACHED_METADATA: "1" },
         ),
       ).rejects.toThrow(/wasm.*unreachable/);
     } finally {
-      delete process.env.DOT_TRUST_CACHED_METADATA;
       rmSync(home, { recursive: true, force: true });
     }
   });

--- a/src/test-helpers/with-dot-home.ts
+++ b/src/test-helpers/with-dot-home.ts
@@ -1,0 +1,35 @@
+// Per-file serialization helper for tests that mutate process.env.DOT_HOME.
+//
+// `bun test --concurrent` runs tests within a file in parallel — they share
+// process.env. Without serialization, tmpHome mutations from concurrent
+// tests trample each other and `loadMetadata` / `loadMetadataFingerprint`
+// can read the wrong directory mid-test.
+//
+// Each test file that imports this gets its OWN module-scoped lock (because
+// each test file is a fresh module evaluation under bun's worker model). So
+// this mutex serializes within-file env mutations, while between-file
+// isolation is provided by bun's per-file process.env separation.
+
+let lock: Promise<unknown> = Promise.resolve();
+
+export async function withDotHome<T>(tmpHome: string, fn: () => Promise<T>): Promise<T> {
+  const prior = lock;
+  let release: () => void = () => {};
+  lock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  try {
+    await prior;
+  } catch {
+    // ignore prior errors
+  }
+  const original = process.env.DOT_HOME;
+  process.env.DOT_HOME = tmpHome;
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) delete process.env.DOT_HOME;
+    else process.env.DOT_HOME = original;
+    release();
+  }
+}

--- a/src/test-helpers/with-dot-home.ts
+++ b/src/test-helpers/with-dot-home.ts
@@ -1,9 +1,13 @@
-// Per-file serialization helper for tests that mutate process.env.DOT_HOME.
+// Per-file serialization helper for tests that mutate process.env.DOT_HOME
+// (and any other env vars passed via the optional `env` map).
 //
 // `bun test --concurrent` runs tests within a file in parallel — they share
 // process.env. Without serialization, tmpHome mutations from concurrent
 // tests trample each other and `loadMetadata` / `loadMetadataFingerprint`
-// can read the wrong directory mid-test.
+// can read the wrong directory mid-test. Any other env var that affects
+// production behavior (e.g. DOT_TRUST_CACHED_METADATA) has the same
+// problem if set/cleared outside this helper, so this helper accepts an
+// `env` map and serializes those mutations under the same lock.
 //
 // Each test file that imports this gets its OWN module-scoped lock (because
 // each test file is a fresh module evaluation under bun's worker model). So
@@ -12,7 +16,11 @@
 
 let lock: Promise<unknown> = Promise.resolve();
 
-export async function withDotHome<T>(tmpHome: string, fn: () => Promise<T>): Promise<T> {
+export async function withDotHome<T>(
+  tmpHome: string,
+  fn: () => Promise<T>,
+  env: Record<string, string | undefined> = {},
+): Promise<T> {
   const prior = lock;
   let release: () => void = () => {};
   lock = new Promise<void>((resolve) => {
@@ -23,13 +31,23 @@ export async function withDotHome<T>(tmpHome: string, fn: () => Promise<T>): Pro
   } catch {
     // ignore prior errors
   }
-  const original = process.env.DOT_HOME;
+  const originalDotHome = process.env.DOT_HOME;
+  const originalEnv: Record<string, string | undefined> = {};
+  for (const k of Object.keys(env)) originalEnv[k] = process.env[k];
   process.env.DOT_HOME = tmpHome;
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
   try {
     return await fn();
   } finally {
-    if (original === undefined) delete process.env.DOT_HOME;
-    else process.env.DOT_HOME = original;
+    if (originalDotHome === undefined) delete process.env.DOT_HOME;
+    else process.env.DOT_HOME = originalDotHome;
+    for (const [k, v] of Object.entries(originalEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
     release();
   }
 }

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { formatRuntimeError, isLikelyStaleMetadataError, isPapiCleanupError } from "./errors.ts";
+
+describe("isPapiCleanupError", () => {
+  test("matches bare 'Not connected'", () => {
+    expect(isPapiCleanupError(new Error("Not connected"))).toBe(true);
+  });
+
+  test("matches DisjointError", () => {
+    expect(isPapiCleanupError(new Error("DisjointError: chain head was disconnected"))).toBe(true);
+  });
+
+  test("matches aborted ChainHead messages", () => {
+    expect(isPapiCleanupError(new Error("ChainHead operation aborted"))).toBe(true);
+  });
+
+  test("does not match unrelated errors", () => {
+    expect(isPapiCleanupError(new Error("ECONNREFUSED"))).toBe(false);
+    expect(isPapiCleanupError(new Error("Invalid signature"))).toBe(false);
+  });
+
+  test("does not match non-Error values", () => {
+    expect(isPapiCleanupError("Not connected")).toBe(false);
+    expect(isPapiCleanupError(undefined)).toBe(false);
+    expect(isPapiCleanupError(null)).toBe(false);
+  });
+});
+
+describe("formatRuntimeError", () => {
+  test("rewrites a wasm trap from validate_transaction", () => {
+    const wasmErr = new Error(
+      [
+        "Execution failed: Execution aborted due to trap: wasm trap: wasm `unreachable` instruction executed",
+        "WASM backtrace:",
+        "    0:  0x1e8c1 - next_people_paseo_runtime.wasm!__rustc[d131491b]::rust_begin_unwind",
+        "    1:   0x32ae - next_people_paseo_runtime.wasm!core::panicking::panic_fmt::h076e68bde4b88b39",
+        "    2: 0x5bf2d0 - next_people_paseo_runtime.wasm!TaggedTransactionQueue_validate_transaction",
+      ].join("\n"),
+    );
+    const formatted = formatRuntimeError(wasmErr);
+    expect(formatted).toContain("The runtime rejected this transaction");
+    expect(formatted).toContain("validate_transaction step");
+    expect(formatted).toContain("--dry-run");
+    expect(formatted).not.toContain("0x5bf2d0");
+  });
+
+  test("rewrites a generic wasm trap with no recognised function", () => {
+    const wasmErr = new Error(
+      "Execution failed: Execution aborted due to trap: wasm trap: wasm `unreachable` instruction executed",
+    );
+    const formatted = formatRuntimeError(wasmErr);
+    expect(formatted).toContain("The runtime rejected this transaction in the runtime");
+  });
+
+  test("frames Invalid Transaction errors", () => {
+    const formatted = formatRuntimeError(new Error("Invalid Transaction: BadProof"));
+    expect(formatted).toContain("Transaction rejected as invalid");
+    expect(formatted).toContain("BadProof");
+  });
+
+  test("passes other error messages through unchanged", () => {
+    expect(formatRuntimeError(new Error("ECONNREFUSED"))).toBe("ECONNREFUSED");
+  });
+
+  test("handles non-Error values", () => {
+    expect(formatRuntimeError("plain string")).toBe("plain string");
+    expect(formatRuntimeError(42)).toBe("42");
+  });
+});
+
+describe("isLikelyStaleMetadataError", () => {
+  test("matches wasm trap errors", () => {
+    expect(
+      isLikelyStaleMetadataError(
+        new Error("Execution aborted due to trap: wasm `unreachable` instruction executed"),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches codec / decode failures", () => {
+    expect(isLikelyStaleMetadataError(new Error("codec error: invalid input"))).toBe(true);
+    expect(isLikelyStaleMetadataError(new Error("Decoding failed: end of buffer"))).toBe(true);
+    expect(isLikelyStaleMetadataError(new Error("Lookup failed for type id 42"))).toBe(true);
+  });
+
+  test("matches metadata mismatch", () => {
+    expect(isLikelyStaleMetadataError(new Error("metadata mismatch detected"))).toBe(true);
+  });
+
+  test("does NOT match user-typo errors", () => {
+    expect(isLikelyStaleMetadataError(new Error("pallet 'Foo' not found"))).toBe(false);
+    expect(isLikelyStaleMetadataError(new Error("call 'bar' not found in pallet System"))).toBe(
+      false,
+    );
+    expect(isLikelyStaleMetadataError(new Error("BadOrigin"))).toBe(false);
+  });
+
+  test("ignores empty / non-string-y values", () => {
+    expect(isLikelyStaleMetadataError(undefined)).toBe(false);
+    expect(isLikelyStaleMetadataError(null)).toBe(false);
+    expect(isLikelyStaleMetadataError(42)).toBe(false);
+  });
+
+  test("matches plain strings (not just Error instances)", () => {
+    expect(isLikelyStaleMetadataError("wasm trap: unreachable")).toBe(true);
+  });
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -18,3 +18,67 @@ export class MetadataError extends CliError {
     this.name = "MetadataError";
   }
 }
+
+// papi internal teardown races we deliberately ignore at the process boundary.
+// These come from @polkadot-api/observable-client follow-stream timers firing
+// after client.destroy() has already cleared the underlying connection.
+const PAPI_CLEANUP_PATTERNS: RegExp[] = [
+  /^Not connected$/,
+  /DisjointError/,
+  /ChainHead.*(aborted|stopped)/i,
+];
+
+export function isPapiCleanupError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return PAPI_CLEANUP_PATTERNS.some((re) => re.test(err.message));
+}
+
+// Errors that smell like the runtime saw a SCALE-encoded extrinsic / storage
+// key produced from out-of-date type tables. These are the symptoms of stale
+// local metadata. User-typo errors ("pallet not found", "call not found") are
+// deliberately NOT in this set — they propagate immediately.
+const STALE_METADATA_PATTERNS: RegExp[] = [
+  /wasm trap/i,
+  /wasm `?unreachable`? instruction/i,
+  /Execution aborted due to trap/i,
+  /codec/i,
+  /decod(e|ing)/i,
+  /Lookup failed/i,
+  /metadata.*mismatch/i,
+];
+
+export function isLikelyStaleMetadataError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  if (!msg) return false;
+  return STALE_METADATA_PATTERNS.some((re) => re.test(msg));
+}
+
+export function formatRuntimeError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+
+  if (/wasm trap|wasm `?unreachable`? instruction|Execution aborted due to trap/i.test(msg)) {
+    // wasm backtrace lists innermost frames first (rust_begin_unwind, panic_fmt,
+    // …) and the runtime entrypoint last. Skip the panic plumbing and pick the
+    // last informative frame.
+    const frames = Array.from(msg.matchAll(/\.wasm!([A-Za-z_]\w+)/g)).map((m) => m[1] as string);
+    const fn = [...frames]
+      .reverse()
+      .find((name) => !/^(?:__rustc|core::panicking|rust_begin_unwind|panic_fmt)/.test(name));
+    const where = fn?.includes("validate_transaction")
+      ? "the runtime's validate_transaction step"
+      : fn
+        ? `runtime function ${fn}`
+        : "the runtime";
+    return [
+      `The runtime rejected this transaction in ${where}.`,
+      "  Cause: a runtime invariant failed — typically the call's arguments are out of range, reference an unknown id, or violate a precondition.",
+      "  Tip:   re-check the arguments and the signing account's permissions; --dry-run will surface the same error before signing.",
+    ].join("\n");
+  }
+
+  if (/Invalid Transaction/i.test(msg)) {
+    return `Transaction rejected as invalid by the runtime: ${msg}`;
+  }
+
+  return msg;
+}

--- a/src/utils/runtime-fingerprint.test.ts
+++ b/src/utils/runtime-fingerprint.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+  fingerprintsMatch,
+  isRuntimeFingerprint,
+  type RuntimeFingerprint,
+} from "./runtime-fingerprint.ts";
+
+const base: RuntimeFingerprint = {
+  specName: "polkadot",
+  specVersion: 1018,
+  transactionVersion: 24,
+  implName: "parity-polkadot",
+  implVersion: 0,
+  authoringVersion: 0,
+  codeHash: "0xaaaa",
+  fetchedAt: "2026-04-27T12:00:00Z",
+};
+
+describe("fingerprintsMatch", () => {
+  test("identical fingerprints match", () => {
+    expect(fingerprintsMatch(base, { ...base })).toBe(true);
+  });
+
+  test("different specVersion does not match", () => {
+    expect(fingerprintsMatch(base, { ...base, specVersion: 1019 })).toBe(false);
+  });
+
+  test("different transactionVersion does not match", () => {
+    expect(fingerprintsMatch(base, { ...base, transactionVersion: 25 })).toBe(false);
+  });
+
+  test("different codeHash does not match (local-restart-with-new-wasm-same-spec)", () => {
+    expect(fingerprintsMatch(base, { ...base, codeHash: "0xbbbb" })).toBe(false);
+  });
+
+  test("different fetchedAt is ignored", () => {
+    expect(fingerprintsMatch(base, { ...base, fetchedAt: "2030-01-01T00:00:00Z" })).toBe(true);
+  });
+
+  test("different implVersion is ignored (operator info, not staleness)", () => {
+    expect(fingerprintsMatch(base, { ...base, implVersion: 7 })).toBe(true);
+  });
+});
+
+describe("isRuntimeFingerprint", () => {
+  test("accepts a well-formed object", () => {
+    expect(isRuntimeFingerprint(base)).toBe(true);
+  });
+
+  test("rejects when codeHash is missing", () => {
+    const { codeHash, ...rest } = base;
+    expect(isRuntimeFingerprint(rest)).toBe(false);
+  });
+
+  test("rejects when specVersion is a string", () => {
+    expect(isRuntimeFingerprint({ ...base, specVersion: "1018" })).toBe(false);
+  });
+
+  test("rejects null and primitives", () => {
+    expect(isRuntimeFingerprint(null)).toBe(false);
+    expect(isRuntimeFingerprint(undefined)).toBe(false);
+    expect(isRuntimeFingerprint("nope")).toBe(false);
+    expect(isRuntimeFingerprint(42)).toBe(false);
+  });
+});

--- a/src/utils/runtime-fingerprint.ts
+++ b/src/utils/runtime-fingerprint.ts
@@ -1,0 +1,36 @@
+export interface RuntimeFingerprint {
+  specName: string;
+  specVersion: number;
+  transactionVersion: number;
+  implName: string;
+  implVersion: number;
+  authoringVersion: number;
+  // Hex of `state_getStorageHash(":code:")` — changes whenever the runtime
+  // wasm changes, even if specVersion was kept the same (e.g. local node
+  // restarted with a different runtime). The authoritative staleness signal.
+  codeHash: string;
+  fetchedAt: string;
+}
+
+export function fingerprintsMatch(a: RuntimeFingerprint, b: RuntimeFingerprint): boolean {
+  return (
+    a.codeHash === b.codeHash &&
+    a.specVersion === b.specVersion &&
+    a.transactionVersion === b.transactionVersion
+  );
+}
+
+export function isRuntimeFingerprint(value: unknown): value is RuntimeFingerprint {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.specName === "string" &&
+    typeof v.specVersion === "number" &&
+    typeof v.transactionVersion === "number" &&
+    typeof v.implName === "string" &&
+    typeof v.implVersion === "number" &&
+    typeof v.authoringVersion === "number" &&
+    typeof v.codeHash === "string" &&
+    typeof v.fetchedAt === "string"
+  );
+}


### PR DESCRIPTION
## Summary

- New `dot metadata <chain>` command — fetches runtime metadata and prints **everything** (pallets / calls / events / errors / storage / constants / runtime APIs / transaction extensions) as one JSON blob with a runtime fingerprint header. `--raw` emits SCALE-encoded bytes as hex; `--cached` uses cached metadata for offline / CI use. Closes #170.
- **Stale-metadata suggestion** — when `dot tx`, `--dry-run`, or `dot query` fails with a wasm trap / codec error / fee-estimation panic, the CLI compares the local metadata's runtime fingerprint against the live chain (`state_getRuntimeVersion` + `state_getStorageHash(":code:")`). If they differ, the original error gains a `⚠ Local metadata for "<chain>" is out of date … Run: dot chain update <chain>` line. The code-hash check also catches local-node restarts that keep `specVersion` but ship new wasm. No automatic refetch — the original error still propagates with a non-zero exit code.
- **Friendlier runtime errors** — `formatRuntimeError` translates polkadot-api's verbatim wasm backtraces into a "the runtime rejected this transaction" message that names the failing entrypoint and points at `--dry-run`.
- **`--dry-run` no longer hides fee-estimation errors** — the underlying reason is now surfaced (and exposed in JSON output as `estimationError`).
- **`dot chain update --all` no longer crashes on cleanup races** — a `process.on('unhandledRejection')` filter swallows benign late-timer rejections from `@polkadot-api/observable-client` (`Not connected`, `DisjointError`) that previously killed the process after the actual update had finished.

Set `DOT_TRUST_CACHED_METADATA=1` to skip the staleness check for CI / scripted loops.

## Test plan

- [x] `bun test --concurrent` — 1400 pass / 0 fail (was 1355 before this branch; +41 new tests across `runtime-fingerprint.test.ts`, `errors.test.ts`, `metadata.test.ts`, `staleness.test.ts`).
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] Coverage essentially flat: 88.98% → 88.80% lines (`-0.18%`); new helpers (`runtime-fingerprint.ts`, `errors.ts`) at 100% / 95%.
- [x] Hooks (lint + typecheck + tests) ran on commit, no `--no-verify` used.
- [ ] Smoke-test against a real chain: `dot metadata polkadot --raw | head -c 200` → starts with `0x`; `dot metadata polkadot | jq '.runtime.codeHash'` → non-empty hex.
- [ ] Reproduce the original bug: corrupt `~/.polkadot/chains/<chain>/metadata.bin`, submit a tx, expect the new staleness suggestion line.

## Docs

- README, `docs/content/_index.md`, and `dot-cli/SKILL.md` all updated with the new `dot metadata` section, stale-metadata explanation, and `DOT_TRUST_CACHED_METADATA` opt-out.
- Two changesets: `dot-metadata-and-staleness.md` (minor) and `friendly-runtime-errors.md` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)