### PR TITLE
feat(inspect): width-aware multi-line pretty-print for type signatures and decoded calls

### DIFF
--- a/.changeset/pretty-print-types.md
+++ b/.changeset/pretty-print-types.md
@@ -1,0 +1,54 @@
+---
+"polkadot-cli": minor
+---
+
+Width-aware multi-line pretty-printing for type signatures, call arguments, and decoded calls.
+
+`dot inspect`, the focused listings (`dot <chain>.tx.<Pallet>`, `.query.<Pallet>`, `.events.<Pallet>`, `.extensions`), and `--dry-run` output now render structured types across multiple lines when they don't fit, with syntactic ANSI coloring (field names cyan, primitives yellow, container keywords magenta, enum variants green). Short signatures stay compact.
+
+**Before**
+
+```
+  Args: (proposal_origin: system | Origins | ParachainsOrigin | XcmPallet, proposal: Legacy | Inline | Lookup, enactment_moment: At | After)
+```
+
+**After**
+
+```
+  Args: (
+    proposal_origin : system | Origins | ParachainsOrigin | XcmPallet,
+    proposal        : Legacy | Inline | Lookup,
+    enactment_moment: At | After,
+  )
+```
+
+**Storage detail** now shows `Type:`, `Key:`, and `Value:` on separate lines (no `→` arrow), with composite values expanded:
+
+```
+Assets.Metadata (Storage)
+
+  Type:  map
+  Key:   u32
+  Value: {
+    deposit  : u128,
+    name     : Vec<u8>,
+    symbol   : Vec<u8>,
+    decimals : u8,
+    is_frozen: bool,
+  }
+```
+
+**Dry-run `Decode:`** is now JSON-styled, suitable for very complex calls:
+
+```
+  Decode: System.remark
+    {
+      "remark": "0x68656c6c6f20776f726c64"
+    }
+```
+
+**Enum variant visibility** — the `enum(N variants)` summary threshold was raised from 4 to 24, so most enums (e.g. `Option<AsPersonalAliasWithAccount | AsPersonalAliasWithProof | ...>`) now show variant names instead of being collapsed.
+
+**Width detection** uses `process.stdout.columns` (falls back to 80). Output is automatically uncolored when stdout isn't a TTY, so piped `--json` and shell-redirected output stay clean.
+
+JSON output (`--json`) is unchanged — type strings continue to be emitted as compact single-line values for scripting.

--- a/README.md
+++ b/README.md
@@ -632,6 +632,8 @@ dot polkadot.const.Balances.ExistentialDeposit --json | jq
 
 Works offline from cached metadata after the first fetch. The chain is required. Prefer the chain-prefix-on-target form (`dot inspect polkadot.System`); `--chain` is equivalent. Note that `dot polkadot.inspect.X` does **not** parse — `inspect` is a top-level command, not a dotpath category.
 
+Output is **width-aware**: short type signatures stay on a single line, longer ones expand across multiple lines with field names aligned. Composite struct fields, enum variants, and call arguments are color-coded (cyan field names, yellow primitives, magenta container keywords like `Vec`/`Option`, green enum variants) when stdout is a TTY; piped output stays plain.
+
 ```bash
 # Pallet detail — list storage, constants, calls, events, and errors
 dot inspect polkadot.System
@@ -639,18 +641,32 @@ dot inspect polkadot.System
 # System Pallet
 #
 #   Storage Items:
-#     Account: AccountId32 → { nonce: u32, consumers: u32, ... }    [map]
+#     Account [map]
+#       Key:   AccountId32
+#       Value: {
+#         nonce      : u32,
+#         consumers  : u32,
+#         providers  : u32,
+#         sufficients: u32,
+#         data       : { free: u128, reserved: u128, frozen: u128, flags: u128 },
+#       }
 #         The full account information for a particular account ID.
 #     ...
 
-# Storage item detail — full type and docs
+# Storage item detail — full type and docs (each part on its own line)
 dot inspect polkadot.System.Account
 # Output:
 # System.Account (Storage)
 #
-#   Type: map
-#   Value: { nonce: u32, consumers: u32, providers: u32, sufficients: u32, data: { free: u128, ... } }
-#   Key: AccountId32
+#   Type:  map
+#   Key:   AccountId32
+#   Value: {
+#     nonce      : u32,
+#     consumers  : u32,
+#     providers  : u32,
+#     sufficients: u32,
+#     data       : { free: u128, reserved: u128, frozen: u128, flags: u128 },
+#   }
 #
 #   The full account information for a particular account ID.
 
@@ -678,11 +694,29 @@ All listings — pallets, storage items, constants, calls, events, and errors �
 
 The pallet listing view shows type information inline so you can understand item shapes at a glance:
 
-- **Storage**: key/value types with `[map]` tag for map items (e.g. `Account: AccountId32 → { nonce: u32, ... }    [map]`)
+- **Storage**: name with optional `[map]` tag, followed by indented `Key:` / `Value:` lines (composite values expand to one field per line when wide)
 - **Constants**: the constant's type (e.g. `ExistentialDeposit: u128`)
-- **Calls**: full argument signature (e.g. `transfer_allow_death(dest: enum(5 variants), value: Compact<u128>)`)
-- **Events**: field signature (e.g. `Transfer(from: AccountId32, to: AccountId32, amount: u128)`)
+- **Calls**: argument signature inline if it fits, otherwise one argument per line with names aligned by colon
+- **Events**: field signature inline if it fits, otherwise one field per line
 - **Errors**: name and documentation (e.g. `InsufficientBalance`)
+
+Long call signatures expand automatically:
+
+```bash
+dot inspect polkadot.Referenda
+# Output (excerpt):
+#   cancel(index: u32)
+#       Cancel an ongoing referendum.
+#   ...
+#   submit(
+#     proposal_origin : system | Origins | ParachainsOrigin | XcmPallet,
+#     proposal        : Legacy | Inline | Lookup,
+#     enactment_moment: At | After,
+#   )
+#       Propose a referendum on a privileged action.
+```
+
+Enums up to 24 variants now render as `A | B | C | …` (previously variants were collapsed to `enum(N variants)` for >4); only enums with more than 24 variants are still summarized for readability. So a transaction extension's value type like `Option<AsPersonalAliasWithAccount | AsPersonalAliasWithProof | …>` now spells out the variants you actually need to construct.
 
 Documentation from the runtime metadata is shown on an indented line below each item. The detail view (`dot inspect Balances.transfer_allow_death`) shows the full argument signature and complete documentation text. Use call inspection to discover argument names, types, and docs before constructing `dot tx` commands.
 
@@ -934,13 +968,17 @@ The detail view shows the extension's value type, its `additionalSigned` type, a
 Build, sign, and submit transactions. Pass a `Pallet.Call` with arguments, or a raw SCALE-encoded call hex (e.g. from a multisig proposal or governance). Both forms display a decoded human-readable representation of the call.
 
 ```bash
-# Estimate fees without submitting (no broadcast)
+# Estimate fees without submitting (no broadcast). The Decode block shows
+# the call name on the header line and indented JSON below it.
 dot polkadot.tx.System.remark 0xdeadbeef --from alice --dry-run
 # Output:
 #   Chain:  polkadot
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0x000010deadbeef
-#   Decode: System.remark { remark: 0xdeadbeef }
+#   Decode: System.remark
+#     {
+#       "remark": "0xdeadbeef"
+#     }
 #   Estimated fees: 125598975
 
 # Transfer (amount in plancks). Method names are snake_case.
@@ -952,15 +990,28 @@ dot polkadot.tx.System.remark 0xdeadbeef --from alice
 # Submit a raw SCALE-encoded call (e.g. from a multisig proposal or another tool)
 dot polkadot.tx 0x000010deadbeef --from alice --dry-run
 
-# Batch multiple remarks with Utility.batch_all (comma-separated encoded calls)
+# Batch multiple remarks with Utility.batch_all (comma-separated encoded calls).
+# Complex decoded calls remain readable because each level is indented.
 A=$(dot polkadot.tx.System.remark 0xdeadbeef --encode)
 B=$(dot polkadot.tx.System.remark 0xcafe --encode)
 dot polkadot.tx.Utility.batch_all "$A,$B" --from alice --dry-run
-# Output:
+# Output (excerpt — nested calls each get their own enum {type, value} envelope):
 #   Chain:  polkadot
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0x1a0208000010deadbeef000008cafe
-#   Decode: Utility.batch_all { calls: [System(remark( { remark: 0xdeadbeef })), System(remark( { remark: 0xcafe }))] }
+#   Decode: Utility.batch_all
+#     {
+#       "calls": [
+#         {
+#           "type": "System",
+#           "value": {
+#             "type": "remark",
+#             "value": { "remark": "0xdeadbeef" }
+#           }
+#         },
+#         ...
+#       ]
+#     }
 #   Estimated fees: 133994995
 ```
 
@@ -982,7 +1033,11 @@ dot polkadot.tx.Utility.dispatch_as 'system(Authorized)' $(dot polkadot.tx.Syste
 #   Chain:  polkadot
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0x1a030003000008cafe
-#   Decode: Utility.dispatch_as { as_origin: system(Authorized), call: System(remark( { remark: 0xcafe })) }
+#   Decode: Utility.dispatch_as
+#     {
+#       "as_origin": { "type": "system", "value": { "type": "Authorized" } },
+#       "call":      { "type": "System", "value": { "type": "remark", "value": { "remark": "0xcafe" } } }
+#     }
 #   Estimated fees: 127644270
 
 # Nested enums work too — Signed origin with an account
@@ -1019,7 +1074,10 @@ dot paseo-asset-hub.tx.Sudo.sudo $(dot paseo-asset-hub.tx.System.remark 0xcafe -
 #   Chain:  paseo-asset-hub
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0xfb00000008cafe
-#   Decode: Sudo.sudo { call: System(remark( { remark: 0xcafe })) }
+#   Decode: Sudo.sudo
+#     {
+#       "call": { "type": "System", "value": { "type": "remark", "value": { "remark": "0xcafe" } } }
+#     }
 #   Estimated fees: ...
 ```
 
@@ -1062,20 +1120,19 @@ dot ./remark.yaml --encode                              # chain comes from the f
 
 `--to-yaml` / `--to-json` are mutually exclusive with each other and with `--encode` and `--dry-run`.
 
-Both dry-run and submission display the encoded call hex and a decoded human-readable form:
+Both dry-run and submission display the encoded call hex and a decoded human-readable form. The decoded call is rendered as JSON with two-space indentation under the `Decode:` header so even deeply nested calls (XCM, sudo, batch, dispatch_as) remain easy to scan:
 
 ```
-  Call:   0x0001076465616462656566
-  Decode: System.remark(remark: 0xdeadbeef)
+  Call:   0x000010deadbeef
+  Decode: System.remark
+    {
+      "remark": "0xdeadbeef"
+    }
   Tx:     0xabc123...
   Status: ok
 ```
 
-Complex calls (e.g. XCM teleports) that the primary decoder cannot handle are automatically decoded via a fallback path:
-
-```
-  Decode: PolkadotXcm.limited_teleport_assets { dest: V3 { parents: 1, interior: X1(Parachain(5140)) }, beneficiary: V3 { ... }, assets: V3 [...], fee_asset_item: 0, weight_limit: Unlimited }
-```
+Complex calls (XCM teleports, batched governance proposals) keep the same shape — every nested enum becomes a `{ "type": ..., "value": ... }` block, indented one level deeper, so you can read the structure top-down without it ever wrapping past the terminal width.
 
 #### Exit codes
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -847,6 +847,8 @@ Browse chain metadata offline (uses the cached copy after the first fetch). Show
 
 The chain is required: pass it with `--chain` or as a prefix on the inspect target (e.g. `dot inspect polkadot.System`).
 
+Output is **width-aware**: short type signatures stay on a single line, long ones expand across multiple lines with field names aligned by colon. Composite struct fields and call arguments are color-coded (cyan field names, yellow primitives, magenta container keywords like `Vec`/`Option`, green enum variants) when stdout is a TTY; piped output stays plain.
+
 ```
 # Pallet detail — list storage, constants, calls, events, errors
 dot inspect polkadot.System
@@ -854,23 +856,47 @@ dot inspect polkadot.System
 # System Pallet
 #
 #   Storage Items:
-#     Account: AccountId32 → { nonce: u32, consumers: u32, ... }    [map]
+#     Account [map]
+#       Key:   AccountId32
+#       Value: {
+#         nonce      : u32,
+#         consumers  : u32,
+#         providers  : u32,
+#         sufficients: u32,
+#         data       : { free: u128, reserved: u128, frozen: u128, flags: u128 },
+#       }
 #         The full account information for a particular account ID.
 #     ...
 
-# Storage item detail
+# Storage item detail — Type / Key / Value on separate lines, composite Value expands
 dot inspect polkadot.System.Account
 # Output:
 # System.Account (Storage)
 #
-#   Type: map
-#   Value: { nonce: u32, consumers: u32, providers: u32, sufficients: u32, data: { free: u128, ... } }
-#   Key: AccountId32
+#   Type:  map
+#   Key:   AccountId32
+#   Value: {
+#     nonce      : u32,
+#     consumers  : u32,
+#     providers  : u32,
+#     sufficients: u32,
+#     data       : { free: u128, reserved: u128, frozen: u128, flags: u128 },
+#   }
 #
 #   The full account information for a particular account ID.
 
-# Call detail
-dot inspect polkadot.Balances.transfer_allow_death
+# Call detail — long signatures expand across lines with names aligned
+dot inspect polkadot.Referenda.submit
+# Output:
+# Referenda.submit (Call)
+#
+#   Args: (
+#     proposal_origin : system | Origins | ParachainsOrigin | XcmPallet,
+#     proposal        : Legacy | Inline | Lookup,
+#     enactment_moment: At | After,
+#   )
+#
+#   Propose a referendum on a privileged action.
 
 # Event detail
 dot inspect polkadot.Balances.Transfer
@@ -895,13 +921,21 @@ All listings — pallets, storage items, constants, calls, events, and errors �
 
 When inspecting a pallet (e.g. `dot inspect Balances`), each item shows type information inline so you can understand the shape without drilling into the detail view:
 
-**Storage items** show key and value types. Map items include a `[map]` tag:
+**Storage items** show name + optional `[map]` tag with `Key:` and `Value:` on indented lines below. Composite values expand to one field per line when wide:
 
 ```
   Storage Items:
-    Account: AccountId32 → { free: u128, reserved: u128, frozen: u128, flags: u128 }    [map]
+    Account [map]
+      Key:   AccountId32
+      Value: {
+        free    : u128,
+        reserved: u128,
+        frozen  : u128,
+        flags   : u128,
+      }
         The Balances pallet example of storing the balance of an account.
-    TotalIssuance: u128
+    TotalIssuance
+      Value: u128
         The total units issued in the system.
 ```
 
@@ -915,14 +949,21 @@ When inspecting a pallet (e.g. `dot inspect Balances`), each item shows type inf
         The maximum number of locks that should exist on an account.
 ```
 
-**Calls** show their full argument signature:
+**Calls** show their full argument signature inline if it fits, otherwise across multiple lines with names aligned:
 
 ```
   Calls:
-    transfer_allow_death(dest: enum(5 variants), value: Compact<u128>)
+    transfer_allow_death(dest: Id | Index | Raw | Address32 | Address20, value: Compact<u128>)
         Transfer some liquid free balance to another account.
-    force_transfer(source: enum(5 variants), dest: enum(5 variants), value: Compact<u128>)
+    submit(
+      proposal_origin : system | Origins | ParachainsOrigin | XcmPallet,
+      proposal        : Legacy | Inline | Lookup,
+      enactment_moment: At | After,
+    )
+        Propose a referendum on a privileged action.
 ```
+
+Enums up to 24 variants render as `A | B | C | …` (variants visible). Only enums with more than 24 variants are still summarized as `enum(N variants)` for readability.
 
 **Events** show their field signature:
 
@@ -1243,13 +1284,17 @@ Build, sign, and submit extrinsics using dot-path syntax: `dot tx.Pallet.Call`. 
 Use the chain-prefix dotpath form. Method names are snake_case as defined in the runtime metadata.
 
 ```
-# Estimate fees without submitting (no broadcast)
+# Estimate fees without submitting (no broadcast). The Decode block shows the
+# call name on the header line and indented JSON for its arguments below.
 dot polkadot.tx.System.remark 0xdeadbeef --from alice --dry-run
 # Output:
 #   Chain:  polkadot
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0x000010deadbeef
-#   Decode: System.remark { remark: 0xdeadbeef }
+#   Decode: System.remark
+#     {
+#       "remark": "0xdeadbeef"
+#     }
 #   Estimated fees: 125598975
 
 # Transfer (amount in plancks)
@@ -1279,7 +1324,10 @@ dot polkadot.tx 0x000010deadbeef --from alice --dry-run
 #   Chain:  polkadot
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0x000010deadbeef
-#   Decode: System.remark { remark: 0xdeadbeef }
+#   Decode: System.remark
+#     {
+#       "remark": "0xdeadbeef"
+#     }
 #   Estimated fees: 125598975
 ```
 
@@ -1294,11 +1342,20 @@ B=$(dot polkadot.tx.System.remark 0xcafe --encode)
 
 # Batch them (comma-separated encoded calls)
 dot polkadot.tx.Utility.batch_all "$A,$B" --from alice --dry-run
-# Output:
+# Output (excerpt — each nested call gets its own enum {type, value} envelope):
 #   Chain:  polkadot
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0x1a0208000010deadbeef000008cafe
-#   Decode: Utility.batch_all { calls: [System(remark( { remark: 0xdeadbeef })), System(remark( { remark: 0xcafe }))] }
+#   Decode: Utility.batch_all
+#     {
+#       "calls": [
+#         {
+#           "type": "System",
+#           "value": { "type": "remark", "value": { "remark": "0xdeadbeef" } }
+#         },
+#         ...
+#       ]
+#     }
 #   Estimated fees: 133994995
 ```
 
@@ -1319,7 +1376,11 @@ dot polkadot.tx.Utility.dispatch_as 'system(Authorized)' "$INNER" --from alice -
 #   Chain:  polkadot
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0x1a030003000008cafe
-#   Decode: Utility.dispatch_as { as_origin: system(Authorized), call: System(remark( { remark: 0xcafe })) }
+#   Decode: Utility.dispatch_as
+#     {
+#       "as_origin": { "type": "system", "value": { "type": "Authorized" } },
+#       "call":      { "type": "System", "value": { "type": "remark", "value": { "remark": "0xcafe" } } }
+#     }
 #   Estimated fees: 127644270
 ```
 
@@ -1357,7 +1418,10 @@ dot paseo-asset-hub.tx.Sudo.sudo $(dot paseo-asset-hub.tx.System.remark 0xcafe -
 #   Chain:  paseo-asset-hub
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0xfb00000008cafe
-#   Decode: Sudo.sudo { call: System(remark( { remark: 0xcafe })) }
+#   Decode: Sudo.sudo
+#     {
+#       "call": { "type": "System", "value": { "type": "remark", "value": { "remark": "0xcafe" } } }
+#     }
 #   Estimated fees: ...
 ```
 
@@ -1404,19 +1468,29 @@ dot ./remark.yaml --encode                              # chain comes from the f
 
 ### Transaction output
 
-Both dry-run and submission display the encoded call hex and a decoded human-readable form:
+Both dry-run and submission display the encoded call hex and a decoded human-readable form. The decoded call is rendered as JSON with two-space indentation under the `Decode:` header so even deeply nested calls remain easy to scan:
 
 ```
-  Call:   0x0001076465616462656566
-  Decode: System.remark(remark: 0xdeadbeef)
+  Call:   0x000010deadbeef
+  Decode: System.remark
+    {
+      "remark": "0xdeadbeef"
+    }
   Tx:     0xabc123...
   Status: ok
 ```
 
-Complex calls (e.g. XCM teleports) that the primary decoder cannot handle are automatically decoded via a fallback path:
+Complex calls (XCM teleports, batched governance proposals, sudo wrappers) keep the same shape — every nested enum becomes a `{ "type": ..., "value": ... }` block, indented one level deeper, so you can read the structure top-down without it ever wrapping past the terminal width:
 
 ```
-  Decode: PolkadotXcm.limited_teleport_assets { dest: V3 { parents: 1, interior: X1(Parachain(5140)) }, beneficiary: V3 { ... }, assets: V3 [...], fee_asset_item: 0, weight_limit: Unlimited }
+  Decode: PolkadotXcm.limited_teleport_assets
+    {
+      "dest": {
+        "type": "V3",
+        "value": { "parents": 1, "interior": { "type": "X1", "value": { "type": "Parachain", "value": 5140 } } }
+      },
+      ...
+    }
 ```
 
 ### Exit codes
@@ -1551,7 +1625,11 @@ dot polkadot-asset-hub.tx.Balances.transfer_keep_alive bob 1000000000 \
 #   Chain:  polkadot-asset-hub
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0x0a0300d435...02286bee
-#   Decode: Balances.transfer_keep_alive { dest: Id(...), value: 1000000000 }
+#   Decode: Balances.transfer_keep_alive
+#     {
+#       "dest": { "type": "Id", "value": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty" },
+#       "value": 1000000000
+#     }
 #   Asset:  {"parents":0,"interior":{"type":"X2","value":[{"type":"PalletInstance","value":50},{"type":"GeneralIndex","value":"1337"}]}}
 #   Estimated fees: 9249754
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -154,13 +154,19 @@ Three-way semantics:
 ## Submitting Transactions
 
 ```bash
-# Dry-run a transfer — no broadcast, just estimate fees
+# Dry-run a transfer — no broadcast, just estimate fees. The Decode block
+# renders the call as indented JSON under the `Pallet.call` header, so even
+# deeply nested calls (Sudo, batch, XCM) stay readable.
 dot polkadot.tx.Balances.transfer_keep_alive 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty 1000000000 --from alice --dry-run
 # Output:
 #   Chain:  polkadot
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0x050300...02286bee
-#   Decode: Balances.transfer_keep_alive { dest: Id(5FHneW46...), value: 1000000000 }
+#   Decode: Balances.transfer_keep_alive
+#     {
+#       "dest": { "type": "Id", "value": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty" },
+#       "value": 1000000000
+#     }
 #   Estimated fees: 158403157
 
 # Submit (omit --dry-run). Method names are snake_case as defined in the runtime.
@@ -183,7 +189,10 @@ dot paseo-asset-hub.tx.Sudo.sudo "$CALL" --from alice --dry-run
 #   Chain:  paseo-asset-hub
 #   From:   alice (5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY)
 #   Call:   0xfb00000010deadbeef
-#   Decode: Sudo.sudo { call: System(remark( { remark: 0xdeadbeef })) }
+#   Decode: Sudo.sudo
+#     {
+#       "call": { "type": "System", "value": { "type": "remark", "value": { "remark": "0xdeadbeef" } } }
+#     }
 #   Estimated fees: 7424769
 ```
 
@@ -264,6 +273,8 @@ The default fetch always hits the chain and updates the local fingerprint sideca
 
 `inspect` is a top-level command, **not** a dotpath category. `dot <chain>.inspect...` does not parse. The recommended form puts the chain on the *target*:
 
+Output is **width-aware**: short signatures stay on one line, long ones expand across multiple lines with field names aligned by colon. Composite values are color-coded when stdout is a TTY; piped output stays plain.
+
 ```bash
 # Pallet detail — list storage, constants, calls, events, errors
 dot inspect polkadot.System
@@ -271,20 +282,46 @@ dot inspect polkadot.System
 # System Pallet
 #
 #   Storage Items:
-#     Account: AccountId32 → { nonce: u32, ... }    [map]
+#     Account [map]
+#       Key:   AccountId32
+#       Value: {
+#         nonce      : u32,
+#         consumers  : u32,
+#         providers  : u32,
+#         sufficients: u32,
+#         data       : { free: u128, reserved: u128, frozen: u128, flags: u128 },
+#       }
 #         The full account information for a particular account ID.
 #     ...
 
-# Storage item detail
+# Storage item detail — Type/Key/Value on separate lines, composite values expand
 dot inspect polkadot.System.Account
 # Output:
 # System.Account (Storage)
 #
-#   Type: map
-#   Value: { nonce: u32, consumers: u32, ... }
-#   Key: AccountId32
+#   Type:  map
+#   Key:   AccountId32
+#   Value: {
+#     nonce      : u32,
+#     consumers  : u32,
+#     providers  : u32,
+#     sufficients: u32,
+#     data       : { free: u128, reserved: u128, frozen: u128, flags: u128 },
+#   }
 #
 #   The full account information for a particular account ID.
+
+# Long call signatures expand across lines
+dot inspect polkadot.Referenda.submit
+# Output:
+# Referenda.submit (Call)
+#
+#   Args: (
+#     proposal_origin : system | Origins | ParachainsOrigin | XcmPallet,
+#     proposal        : Legacy | Inline | Lookup,
+#     enactment_moment: At | After,
+#   )
+#   ...
 
 # To list all pallets on a chain, use --chain (a single positional is read as a pallet name)
 dot inspect --chain polkadot
@@ -292,7 +329,7 @@ dot inspect --chain polkadot
 
 A single positional arg is always treated as a pallet name, so `dot inspect polkadot` does **not** list pallets on the `polkadot` chain — use `--chain polkadot` for that.
 
-Useful for discovering enum variants: when a method signature shows `enum(N variants)`, run `dot inspect <Pallet>.<Item> --chain <name>` on a storage item that uses the same type, or `--dump` a storage map and read back the shape from a real entry.
+Enum-variant visibility: enums up to **24 variants** now show variant names inline (e.g. `system | Origins | ParachainsOrigin | XcmPallet`). Only enums with more than 24 variants collapse to `enum(N variants)`. When that summary appears, drill into a storage item that uses the same type with `dot inspect <Pallet>.<Item> --chain <name>` (it'll expand the inner type), or `--dump` a real entry to read back the shape.
 
 ## Account Management
 

--- a/src/commands/apis.ts
+++ b/src/commands/apis.ts
@@ -110,6 +110,10 @@ export async function handleApis(
 
     printHeading(`${api.name} Methods`);
     for (const m of api.methods) {
+      // Listing view: keep signatures compact (single-line) regardless of width
+      // so the API overview stays scannable. Use the focused detail page
+      // (`dot <chain>.apis.<Api>.<method> --help`) for the pretty-printed
+      // multi-line breakdown of complex args / return types.
       const argStr = describeRuntimeApiMethodArgs(meta, m);
       const retStr = describeType(meta.lookup, m.output);
       console.log(`  ${CYAN}${m.name}${RESET}${DIM}${argStr} → ${retStr}${RESET}`);

--- a/src/commands/focused-inspect.test.ts
+++ b/src/commands/focused-inspect.test.ts
@@ -571,6 +571,25 @@ describe("item-level --help", () => {
     expect(stdout).toContain("(Runtime API)");
     expect(stdout).toContain("Usage:");
   });
+
+  test("runtime API detail uses pretty-printed Args / Returns blocks", async () => {
+    const { stdout, exitCode } = await runCli(["apis.Core.execute_block", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("(Runtime API)");
+    expect(stdout).toMatch(/Args:\s+/);
+    expect(stdout).toMatch(/Returns:\s+/);
+    // No truncation of long types
+    expect(stdout).not.toMatch(/\.\.\./);
+  });
+
+  test("transaction extension detail page renders pretty Value type (no truncation)", async () => {
+    const { stdout, exitCode } = await runCli(["extensions.CheckMortality"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("(Transaction Extension)");
+    expect(stdout).toMatch(/Value type:\s+/);
+    expect(stdout).toMatch(/AdditionalSigned:\s+/);
+    expect(stdout).not.toMatch(/\.\.\./);
+  });
 });
 
 describe("stdout/stderr separation (pipe-safe output)", () => {

--- a/src/commands/focused-inspect.ts
+++ b/src/commands/focused-inspect.ts
@@ -4,7 +4,6 @@ import type { MetadataBundle, PalletInfo } from "../core/metadata.ts";
 import {
   describeCallArgs,
   describeEventFields,
-  describeRuntimeApiMethodArgs,
   describeSignedExtension,
   describeType,
   fetchMetadataFromChain,
@@ -31,6 +30,12 @@ import {
   printItem,
   RESET,
 } from "../core/output.ts";
+import {
+  prettyCallArgs,
+  prettyEventFields,
+  prettyRuntimeApiArgs,
+  prettyTypeById,
+} from "../core/pretty-type.ts";
 import { suggestMessage } from "../utils/fuzzy-match.ts";
 import type { DotCategory } from "../utils/parse-dot-path.ts";
 
@@ -137,8 +142,11 @@ export async function handleCalls(
 
     printHeading(`${pallet.name} Calls`);
     for (const c of pallet.calls) {
-      const args = describeCallArgs(meta, pallet.name, c.name);
-      console.log(`  ${CYAN}${c.name}${RESET}${DIM}${args}${RESET}`);
+      const args = prettyCallArgs(meta, pallet.name, c.name, {
+        indent: 2,
+        prefix: c.name.length,
+      });
+      console.log(`  ${CYAN}${c.name}${RESET}${args}`);
       const summary = firstSentence(c.docs);
       if (summary) {
         console.log(`      ${DIM}${summary}${RESET}`);
@@ -169,7 +177,10 @@ export async function handleCalls(
   }
 
   printHeading(`${pallet.name}.${callItem.name} (Call)`);
-  const args = describeCallArgs(meta, pallet.name, callItem.name);
+  const args = prettyCallArgs(meta, pallet.name, callItem.name, {
+    indent: 2,
+    prefix: 6, // "Args: "
+  });
   console.log(`  ${BOLD}Args:${RESET} ${args}`);
   if (callItem.docs.length) {
     console.log();
@@ -244,8 +255,11 @@ export async function handleEvents(
 
     printHeading(`${pallet.name} Events`);
     for (const e of pallet.events) {
-      const fields = describeEventFields(meta, pallet.name, e.name);
-      console.log(`  ${CYAN}${e.name}${RESET}${DIM}${fields}${RESET}`);
+      const fields = prettyEventFields(meta, pallet.name, e.name, {
+        indent: 2,
+        prefix: e.name.length,
+      });
+      console.log(`  ${CYAN}${e.name}${RESET}${fields}`);
       const summary = firstSentence(e.docs);
       if (summary) {
         console.log(`      ${DIM}${summary}${RESET}`);
@@ -276,7 +290,10 @@ export async function handleEvents(
   }
 
   printHeading(`${pallet.name}.${eventItem.name} (Event)`);
-  const fields = describeEventFields(meta, pallet.name, eventItem.name);
+  const fields = prettyEventFields(meta, pallet.name, eventItem.name, {
+    indent: 2,
+    prefix: 8, // "Fields: "
+  });
   console.log(`  ${BOLD}Fields:${RESET} ${fields}`);
   if (eventItem.docs.length) {
     console.log();
@@ -450,15 +467,21 @@ export async function handleStorage(
 
     printHeading(`${pallet.name} Storage`);
     for (const s of pallet.storage) {
-      const valueType = describeType(meta.lookup, s.valueTypeId);
-      let typeSuffix: string;
-      if (s.keyTypeId != null) {
-        const keyType = describeType(meta.lookup, s.keyTypeId);
-        typeSuffix = `: ${keyType} → ${valueType}    [map]`;
-      } else {
-        typeSuffix = `: ${valueType}`;
+      const isMap = s.keyTypeId != null;
+      const tag = isMap ? `${DIM} [map]${RESET}` : "";
+      console.log(`  ${CYAN}${s.name}${RESET}${tag}`);
+      if (isMap) {
+        const keyType = prettyTypeById(meta.lookup, s.keyTypeId!, {
+          indent: 4,
+          prefix: 5, // "Key: "
+        });
+        console.log(`    ${DIM}Key:${RESET}   ${keyType}`);
       }
-      console.log(`  ${CYAN}${s.name}${RESET}${DIM}${typeSuffix}${RESET}`);
+      const valueType = prettyTypeById(meta.lookup, s.valueTypeId, {
+        indent: 4,
+        prefix: 7, // "Value: "
+      });
+      console.log(`    ${DIM}Value:${RESET} ${valueType}`);
       const summary = firstSentence(s.docs);
       if (summary) {
         console.log(`      ${DIM}${summary}${RESET}`);
@@ -494,11 +517,19 @@ export async function handleStorage(
   }
 
   printHeading(`${pallet.name}.${storageItem.name} (Storage)`);
-  console.log(`  ${BOLD}Type:${RESET} ${storageItem.type}`);
-  console.log(`  ${BOLD}Value:${RESET} ${describeType(meta.lookup, storageItem.valueTypeId)}`);
+  console.log(`  ${BOLD}Type:${RESET}  ${storageItem.type}`);
   if (storageItem.keyTypeId != null) {
-    console.log(`  ${BOLD}Key:${RESET} ${describeType(meta.lookup, storageItem.keyTypeId)}`);
+    const keyType = prettyTypeById(meta.lookup, storageItem.keyTypeId, {
+      indent: 2,
+      prefix: 7, // "Key:   "
+    });
+    console.log(`  ${BOLD}Key:${RESET}   ${keyType}`);
   }
+  const valueType = prettyTypeById(meta.lookup, storageItem.valueTypeId, {
+    indent: 2,
+    prefix: 7, // "Value: "
+  });
+  console.log(`  ${BOLD}Value:${RESET} ${valueType}`);
   if (storageItem.docs.length) {
     console.log();
     printDocs(storageItem.docs);
@@ -541,9 +572,15 @@ export async function showItemHelp(
     }
 
     printHeading(`${api.name}.${method.name} (Runtime API)`);
-    const argStr = describeRuntimeApiMethodArgs(meta, method);
-    const retStr = describeType(meta.lookup, method.output);
-    console.log(`  ${BOLD}Args:${RESET} ${argStr}`);
+    const argStr = prettyRuntimeApiArgs(meta.lookup, method.inputs, {
+      indent: 2,
+      prefix: 9, // "Args:    " (4 spaces) — value starts at column 11
+    });
+    const retStr = prettyTypeById(meta.lookup, method.output, {
+      indent: 2,
+      prefix: 9, // "Returns: " — value starts at column 11
+    });
+    console.log(`  ${BOLD}Args:${RESET}    ${argStr}`);
     console.log(`  ${BOLD}Returns:${RESET} ${retStr}`);
     if (method.docs.length) {
       console.log();
@@ -592,7 +629,10 @@ export async function showItemHelp(
         throw new Error(suggestMessage(`call in ${pallet.name}`, itemName!, names));
       }
       printHeading(`${pallet.name}.${callItem.name} (Call)`);
-      const args = describeCallArgs(meta, pallet.name, callItem.name);
+      const args = prettyCallArgs(meta, pallet.name, callItem.name, {
+        indent: 2,
+        prefix: 6, // "Args: "
+      });
       console.log(`  ${BOLD}Args:${RESET} ${args}`);
       if (callItem.docs.length) {
         console.log();
@@ -622,11 +662,19 @@ export async function showItemHelp(
         throw new Error(suggestMessage(`storage item in ${pallet.name}`, itemName!, names));
       }
       printHeading(`${pallet.name}.${storageItem.name} (Storage)`);
-      console.log(`  ${BOLD}Type:${RESET} ${storageItem.type}`);
-      console.log(`  ${BOLD}Value:${RESET} ${describeType(meta.lookup, storageItem.valueTypeId)}`);
+      console.log(`  ${BOLD}Type:${RESET}  ${storageItem.type}`);
       if (storageItem.keyTypeId != null) {
-        console.log(`  ${BOLD}Key:${RESET} ${describeType(meta.lookup, storageItem.keyTypeId)}`);
+        const keyType = prettyTypeById(meta.lookup, storageItem.keyTypeId, {
+          indent: 2,
+          prefix: 7, // "Key:   "
+        });
+        console.log(`  ${BOLD}Key:${RESET}   ${keyType}`);
       }
+      const valueType = prettyTypeById(meta.lookup, storageItem.valueTypeId, {
+        indent: 2,
+        prefix: 7, // "Value: "
+      });
+      console.log(`  ${BOLD}Value:${RESET} ${valueType}`);
       if (storageItem.docs.length) {
         console.log();
         printDocs(storageItem.docs);
@@ -660,7 +708,11 @@ export async function showItemHelp(
         throw new Error(suggestMessage(`constant in ${pallet.name}`, itemName!, names));
       }
       printHeading(`${pallet.name}.${constItem.name} (Constant)`);
-      console.log(`  ${BOLD}Type:${RESET} ${describeType(meta.lookup, constItem.typeId)}`);
+      const constType = prettyTypeById(meta.lookup, constItem.typeId, {
+        indent: 2,
+        prefix: 6, // "Type: "
+      });
+      console.log(`  ${BOLD}Type:${RESET} ${constType}`);
       if (constItem.docs.length) {
         console.log();
         printDocs(constItem.docs);
@@ -679,7 +731,10 @@ export async function showItemHelp(
         throw new Error(suggestMessage(`event in ${pallet.name}`, itemName!, names));
       }
       printHeading(`${pallet.name}.${eventItem.name} (Event)`);
-      const fields = describeEventFields(meta, pallet.name, eventItem.name);
+      const fields = prettyEventFields(meta, pallet.name, eventItem.name, {
+        indent: 2,
+        prefix: 8, // "Fields: "
+      });
       console.log(`  ${BOLD}Fields:${RESET} ${fields}`);
       if (eventItem.docs.length) {
         console.log();
@@ -771,8 +826,16 @@ export async function handleExtensions(
   }
 
   printHeading(`${described.identifier} (Transaction Extension)`);
-  console.log(`  ${BOLD}Value type:${RESET}       ${described.valueType}`);
-  console.log(`  ${BOLD}AdditionalSigned:${RESET} ${described.additionalSignedType}`);
+  const valueType = prettyTypeById(meta.lookup, described.valueTypeId, {
+    indent: 2,
+    prefix: 18, // "Value type:       " — value starts at column 20
+  });
+  const addSigType = prettyTypeById(meta.lookup, described.additionalSignedTypeId, {
+    indent: 2,
+    prefix: 18, // "AdditionalSigned: " — value starts at column 20
+  });
+  console.log(`  ${BOLD}Value type:${RESET}       ${valueType}`);
+  console.log(`  ${BOLD}AdditionalSigned:${RESET} ${addSigType}`);
   console.log(
     `  ${BOLD}Handled by:${RESET}       ${described.isBuiltin ? "polkadot-api (builtin)" : "user (custom — provide via --ext)"}`,
   );

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -152,9 +152,10 @@ describe("dot inspect", () => {
     const { stdout, exitCode } = await runCli(["inspect", "Balances"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("transfer_allow_death");
-    // Calls should show argument signatures
-    expect(stdout).toContain("dest:");
-    expect(stdout).toContain("value:");
+    // Calls should show argument signatures (names may be padded for alignment
+    // when expanded across multiple lines).
+    expect(stdout).toMatch(/dest\s*:/);
+    expect(stdout).toMatch(/value\s*:/);
   });
 
   test("call detail view", async () => {
@@ -180,10 +181,10 @@ describe("dot inspect", () => {
   test("storage listing shows map tag for map items", async () => {
     const { stdout, exitCode } = await runCli(["inspect", "System"]);
     expect(exitCode).toBe(0);
-    // Account is a map storage item — should show [map] tag and arrow
+    // Account is a map storage item — should show [map] tag and a Key line
     expect(stdout).toContain("Account");
     expect(stdout).toContain("[map]");
-    expect(stdout).toContain("→");
+    expect(stdout).toMatch(/Key:\s+AccountId32/);
   });
 
   test("storage listing shows plain type without map tag", async () => {
@@ -223,16 +224,16 @@ describe("dot inspect", () => {
     expect(stdout).toContain("Transfer some liquid free balance");
   });
 
-  test("call listing shows doc on indented second line", async () => {
+  test("call listing shows doc on indented line below the signature", async () => {
     const { stdout, exitCode } = await runCli(["inspect", "Balances"]);
     expect(exitCode).toBe(0);
     const lines = stdout.split("\n");
-    // Match the actual call line (has opening paren), not a doc line that references the name
-    const callIdx = lines.findIndex((l: string) => l.includes("transfer_allow_death("));
-    expect(callIdx).toBeGreaterThan(-1);
-    const docLine = lines[callIdx + 1];
-    expect(docLine).toMatch(/^\s{8}/); // 8-space indent for doc line
-    expect(docLine).toContain("Transfer some liquid free balance");
+    // The doc line should be indented at 8 spaces and follow the signature
+    // (which may span multiple lines when it doesn't fit). Just find the
+    // doc line directly by its content.
+    const docLine = lines.find((l: string) => l.includes("Transfer some liquid free balance"));
+    expect(docLine).toBeDefined();
+    expect(docLine!).toMatch(/^\s{8}/);
   });
 
   test("docs appear on indented second line", async () => {
@@ -365,13 +366,13 @@ describe("dot inspect", () => {
   test("type strings are not truncated at 60 chars", async () => {
     const { stdout, exitCode } = await runCli(["inspect", "System"]);
     expect(exitCode).toBe(0);
-    // Account value type is well over 60 chars — should not end with "..."
-    expect(stdout).toContain("sufficients: u32, data:");
-    // Verify no "..." truncation artifacts in type strings
-    const lines = stdout.split("\n");
-    const accountLine = lines.find((l: string) => l.includes("Account") && l.includes("[map]"));
-    expect(accountLine).toBeDefined();
-    expect(accountLine).not.toMatch(/\.\.\./);
+    // Account value type is well over 60 chars — every field (incl. data, free,
+    // reserved) must still appear, and no truncation marker.
+    expect(stdout).toContain("sufficients");
+    expect(stdout).toContain("data");
+    expect(stdout).toContain("free");
+    expect(stdout).toContain("reserved");
+    expect(stdout).not.toMatch(/\.\.\./);
   });
 
   test("stdout has no progress messages (pipe-safe)", async () => {
@@ -490,5 +491,66 @@ describe("dot inspect", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.pallet).toBe("Balances");
     expect(parsed.category).toBe("error");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pretty-print integration: width-aware multi-line layout
+  // ---------------------------------------------------------------------------
+  describe("pretty-printed output", () => {
+    test("storage detail with composite Value expands struct fields", async () => {
+      const { stdout, exitCode } = await runCli(["inspect", "System.Account"]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("(Storage)");
+      // Expanded struct fields appear on separate indented lines, aligned by colon
+      const lines = stdout.split("\n");
+      const fieldLines = lines.filter((l) => /^\s+\w+\s*:\s/.test(l) && !l.includes("Type:"));
+      const colonCols = fieldLines.map((l) => l.indexOf(":"));
+      // All child-field colons (skipping the "Key:" / "Value:" labels) must
+      // align in the same column when the struct expands.
+      const childCols = colonCols.filter((c) => c > 8);
+      if (childCols.length > 1) {
+        expect(new Set(childCols).size).toBe(1);
+      }
+    });
+
+    test("pallet listing shows long call signature on multiple lines", async () => {
+      const { stdout, exitCode } = await runCli(["inspect", "Referenda"]);
+      expect(exitCode).toBe(0);
+      // submit() args don't fit on 80 chars — should expand
+      expect(stdout).toMatch(/submit\(\s*\n/);
+      expect(stdout).toMatch(/proposal_origin\s*:\s+/);
+      expect(stdout).toMatch(/enactment_moment\s*:\s+/);
+    });
+
+    test("storage Map item shows separate Key/Value lines, no arrow", async () => {
+      const { stdout, exitCode } = await runCli(["inspect", "System.Account"]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/Key:\s+AccountId32/);
+      expect(stdout).toMatch(/Value:\s/);
+      expect(stdout).not.toContain("→");
+    });
+
+    test("call detail shows all arg names and aligned colons", async () => {
+      const { stdout, exitCode } = await runCli(["inspect", "Balances.transfer_allow_death"]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/dest\s*:/);
+      expect(stdout).toMatch(/value\s*:/);
+    });
+
+    test("plain JSON output unchanged — single-line type strings", async () => {
+      const { stdout, exitCode } = await runCli(["inspect", "System.Account", "--json"]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      // JSON `valueType` must remain a single-line string (no embedded newlines)
+      expect(parsed.valueType).toBeDefined();
+      expect(parsed.valueType.split("\n").length).toBe(1);
+      expect(parsed.valueType).toContain("nonce");
+    });
+
+    test("pretty output contains no ANSI escapes when stdout is piped", async () => {
+      const { stdout } = await runCli(["inspect", "Referenda"]);
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI strip
+      expect(stdout).not.toMatch(/\x1b\[[0-9;]*m/);
+    });
   });
 });

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -25,6 +25,7 @@ import {
   printItem,
   RESET,
 } from "../core/output.ts";
+import { prettyCallArgs, prettyEventFields, prettyTypeById } from "../core/pretty-type.ts";
 import { suggestMessage } from "../utils/fuzzy-match.ts";
 import { parseTarget, resolveTargetChain } from "../utils/parse-target.ts";
 
@@ -177,15 +178,22 @@ export function registerInspectCommand(cli: CAC) {
           if (pallet.storage.length) {
             console.log(`  ${BOLD}Storage Items:${RESET}`);
             for (const s of pallet.storage) {
-              const valueType = describeType(meta.lookup, s.valueTypeId);
-              let typeSuffix: string;
-              if (s.keyTypeId != null) {
-                const keyType = describeType(meta.lookup, s.keyTypeId);
-                typeSuffix = `: ${keyType} → ${valueType}    [map]`;
-              } else {
-                typeSuffix = `: ${valueType}`;
+              const isMap = s.keyTypeId != null;
+              // Header: name (with optional [map] suffix)
+              const tag = isMap ? `${DIM} [map]${RESET}` : "";
+              console.log(`    ${CYAN}${s.name}${RESET}${tag}`);
+              if (isMap) {
+                const keyType = prettyTypeById(meta.lookup, s.keyTypeId!, {
+                  indent: 6,
+                  prefix: 7, // "Key:   "
+                });
+                console.log(`      ${DIM}Key:${RESET}   ${keyType}`);
               }
-              console.log(`    ${CYAN}${s.name}${RESET}${DIM}${typeSuffix}${RESET}`);
+              const valueType = prettyTypeById(meta.lookup, s.valueTypeId, {
+                indent: 6,
+                prefix: 7, // "Value: "
+              });
+              console.log(`      ${DIM}Value:${RESET} ${valueType}`);
               const summary = firstSentence(s.docs);
               if (summary) {
                 console.log(`        ${DIM}${summary}${RESET}`);
@@ -197,8 +205,11 @@ export function registerInspectCommand(cli: CAC) {
           if (pallet.constants.length) {
             console.log(`  ${BOLD}Constants:${RESET}`);
             for (const c of pallet.constants) {
-              const typeStr = describeType(meta.lookup, c.typeId);
-              console.log(`    ${CYAN}${c.name}${RESET}${DIM}: ${typeStr}${RESET}`);
+              const typeStr = prettyTypeById(meta.lookup, c.typeId, {
+                indent: 4,
+                prefix: c.name.length + 2, // "name: "
+              });
+              console.log(`    ${CYAN}${c.name}${RESET}: ${typeStr}`);
               const summary = firstSentence(c.docs);
               if (summary) {
                 console.log(`        ${DIM}${summary}${RESET}`);
@@ -210,8 +221,11 @@ export function registerInspectCommand(cli: CAC) {
           if (pallet.calls.length) {
             console.log(`  ${BOLD}Calls:${RESET}`);
             for (const c of pallet.calls) {
-              const args = describeCallArgs(meta, pallet.name, c.name);
-              console.log(`    ${CYAN}${c.name}${RESET}${DIM}${args}${RESET}`);
+              const args = prettyCallArgs(meta, pallet.name, c.name, {
+                indent: 4,
+                prefix: c.name.length,
+              });
+              console.log(`    ${CYAN}${c.name}${RESET}${args}`);
               const summary = firstSentence(c.docs);
               if (summary) {
                 console.log(`        ${DIM}${summary}${RESET}`);
@@ -223,8 +237,11 @@ export function registerInspectCommand(cli: CAC) {
           if (pallet.events.length) {
             console.log(`  ${BOLD}Events:${RESET}`);
             for (const e of pallet.events) {
-              const fields = describeEventFields(meta, pallet.name, e.name);
-              console.log(`    ${CYAN}${e.name}${RESET}${DIM}${fields}${RESET}`);
+              const fields = prettyEventFields(meta, pallet.name, e.name, {
+                indent: 4,
+                prefix: e.name.length,
+              });
+              console.log(`    ${CYAN}${e.name}${RESET}${fields}`);
               const summary = firstSentence(e.docs);
               if (summary) {
                 console.log(`        ${DIM}${summary}${RESET}`);
@@ -347,15 +364,19 @@ export function registerInspectCommand(cli: CAC) {
         );
         if (storageItem) {
           printHeading(`${pallet.name}.${storageItem.name} (Storage)`);
-          console.log(`  ${BOLD}Type:${RESET} ${storageItem.type}`);
-          console.log(
-            `  ${BOLD}Value:${RESET} ${describeType(meta.lookup, storageItem.valueTypeId)}`,
-          );
+          console.log(`  ${BOLD}Type:${RESET}  ${storageItem.type}`);
           if (storageItem.keyTypeId != null) {
-            console.log(
-              `  ${BOLD}Key:${RESET} ${describeType(meta.lookup, storageItem.keyTypeId)}`,
-            );
+            const keyType = prettyTypeById(meta.lookup, storageItem.keyTypeId, {
+              indent: 2,
+              prefix: 7, // "Key:   "
+            });
+            console.log(`  ${BOLD}Key:${RESET}   ${keyType}`);
           }
+          const valueType = prettyTypeById(meta.lookup, storageItem.valueTypeId, {
+            indent: 2,
+            prefix: 7, // "Value: "
+          });
+          console.log(`  ${BOLD}Value:${RESET} ${valueType}`);
           if (storageItem.docs.length) {
             console.log();
             printDocs(storageItem.docs);
@@ -370,7 +391,11 @@ export function registerInspectCommand(cli: CAC) {
         );
         if (constantItem) {
           printHeading(`${pallet.name}.${constantItem.name} (Constant)`);
-          console.log(`  ${BOLD}Type:${RESET} ${describeType(meta.lookup, constantItem.typeId)}`);
+          const typeStr = prettyTypeById(meta.lookup, constantItem.typeId, {
+            indent: 2,
+            prefix: 6, // "Type: "
+          });
+          console.log(`  ${BOLD}Type:${RESET} ${typeStr}`);
           if (constantItem.docs.length) {
             console.log();
             printDocs(constantItem.docs);
@@ -383,7 +408,10 @@ export function registerInspectCommand(cli: CAC) {
         const callItem = pallet.calls.find((c) => c.name.toLowerCase() === itemName.toLowerCase());
         if (callItem) {
           printHeading(`${pallet.name}.${callItem.name} (Call)`);
-          const args = describeCallArgs(meta, pallet.name, callItem.name);
+          const args = prettyCallArgs(meta, pallet.name, callItem.name, {
+            indent: 2,
+            prefix: 6, // "Args: "
+          });
           console.log(`  ${BOLD}Args:${RESET} ${args}`);
           if (callItem.docs.length) {
             console.log();
@@ -399,7 +427,10 @@ export function registerInspectCommand(cli: CAC) {
         );
         if (eventItem) {
           printHeading(`${pallet.name}.${eventItem.name} (Event)`);
-          const fields = describeEventFields(meta, pallet.name, eventItem.name);
+          const fields = prettyEventFields(meta, pallet.name, eventItem.name, {
+            indent: 2,
+            prefix: 8, // "Fields: "
+          });
           console.log(`  ${BOLD}Fields:${RESET} ${fields}`);
           if (eventItem.docs.length) {
             console.log();

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -20,6 +20,7 @@ import {
   printResult,
   RESET,
 } from "../core/output.ts";
+import { prettyTypeById } from "../core/pretty-type.ts";
 import { suggestMessage } from "../utils/fuzzy-match.ts";
 import { parseValue } from "../utils/parse-value.ts";
 import { loadMeta, resolvePallet, showItemHelp } from "./focused-inspect.ts";
@@ -99,15 +100,21 @@ export async function handleQuery(
 
     printHeading(`${pallet.name} Storage`);
     for (const s of pallet.storage) {
-      const valueType = describeType(meta.lookup, s.valueTypeId);
-      let typeSuffix: string;
-      if (s.keyTypeId != null) {
-        const keyType = describeType(meta.lookup, s.keyTypeId);
-        typeSuffix = `: ${keyType} → ${valueType}    [map]`;
-      } else {
-        typeSuffix = `: ${valueType}`;
+      const isMap = s.keyTypeId != null;
+      const tag = isMap ? `${DIM} [map]${RESET}` : "";
+      console.log(`  ${CYAN}${s.name}${RESET}${tag}`);
+      if (isMap) {
+        const keyType = prettyTypeById(meta.lookup, s.keyTypeId!, {
+          indent: 4,
+          prefix: 5, // "Key: "
+        });
+        console.log(`    ${DIM}Key:${RESET}   ${keyType}`);
       }
-      console.log(`  ${CYAN}${s.name}${RESET}${DIM}${typeSuffix}${RESET}`);
+      const valueType = prettyTypeById(meta.lookup, s.valueTypeId, {
+        indent: 4,
+        prefix: 7, // "Value: "
+      });
+      console.log(`    ${DIM}Value:${RESET} ${valueType}`);
       const summary = firstSentence(s.docs);
       if (summary) {
         console.log(`      ${DIM}${summary}${RESET}`);

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -27,6 +27,7 @@ import {
   DIM,
   firstSentence,
   formatJson,
+  formatPretty,
   GREEN,
   isJsonOutput,
   printHeading,
@@ -37,6 +38,7 @@ import {
   Spinner,
   YELLOW,
 } from "../core/output.ts";
+import { prettyCallArgs } from "../core/pretty-type.ts";
 import { resolveAccountAddress } from "../core/resolve-address.ts";
 import { binaryToDisplay } from "../utils/binary-display.ts";
 import { CliError, formatRuntimeError } from "../utils/errors.ts";
@@ -216,8 +218,11 @@ export async function handleTx(
 
     printHeading(`${pallet.name} Calls`);
     for (const c of pallet.calls) {
-      const callArgs = describeCallArgs(meta, pallet.name, c.name);
-      console.log(`  ${CYAN}${c.name}${RESET}${DIM}${callArgs}${RESET}`);
+      const callArgs = prettyCallArgs(meta, pallet.name, c.name, {
+        indent: 2,
+        prefix: c.name.length,
+      });
+      console.log(`  ${CYAN}${c.name}${RESET}${callArgs}`);
       const summary = firstSentence(c.docs);
       if (summary) {
         console.log(`      ${DIM}${summary}${RESET}`);
@@ -420,6 +425,7 @@ export async function handleTx(
 
     // Decode for display (works for both paths)
     const decodedStr = decodeCall(meta, callHex);
+    const decodedObj = decodeCallObject(meta, callHex);
 
     // --- Unsigned dry-run ---
     if (opts.dryRun && opts.unsigned) {
@@ -438,7 +444,7 @@ export async function handleTx(
       console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
       console.log(`  ${BOLD}Type:${RESET}   unsigned (bare)`);
       console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
-      console.log(`  ${BOLD}Decode:${RESET} ${decodedStr}`);
+      printDecodedCall(decodedObj, decodedStr);
       console.log(`  ${BOLD}Fees:${RESET}   ${DIM}N/A (unsigned transaction)${RESET}`);
       return;
     }
@@ -480,7 +486,7 @@ export async function handleTx(
       console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
       console.log(`  ${BOLD}From:${RESET}   ${opts.from} (${signerAddress})`);
       console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
-      console.log(`  ${BOLD}Decode:${RESET} ${decodedStr}`);
+      printDecodedCall(decodedObj, decodedStr);
       if (nonce !== undefined) console.log(`  ${BOLD}Nonce:${RESET} ${nonce}`);
       if (tip !== undefined) console.log(`  ${BOLD}Tip:${RESET}   ${tip}`);
       if (asset !== undefined) console.log(`  ${BOLD}Asset:${RESET} ${JSON.stringify(asset)}`);
@@ -572,7 +578,7 @@ export async function handleTx(
       console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
       console.log(`  ${BOLD}Type:${RESET}   unsigned (bare)`);
       console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
-      console.log(`  ${BOLD}Decode:${RESET} ${decodedStr}`);
+      printDecodedCall(decodedObj, decodedStr);
       console.log(`  ${BOLD}Tx:${RESET}     ${result.txHash}`);
 
       if (result.type === "broadcasted") {
@@ -672,7 +678,7 @@ export async function handleTx(
     console.log();
     console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
     console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
-    console.log(`  ${BOLD}Decode:${RESET} ${decodedStr}`);
+    printDecodedCall(decodedObj, decodedStr);
     if (nonce !== undefined) console.log(`  ${BOLD}Nonce:${RESET} ${nonce}`);
     if (tip !== undefined) console.log(`  ${BOLD}Tip:${RESET}   ${tip}`);
     if (asset !== undefined) console.log(`  ${BOLD}Asset:${RESET} ${JSON.stringify(asset)}`);
@@ -769,6 +775,52 @@ function decodeCall(meta: MetadataBundle, callHex: string): string {
   } catch {
     return "(unable to decode)";
   }
+}
+
+interface DecodedCallObject {
+  palletName: string;
+  callName: string;
+  args: unknown;
+}
+
+/** Decode a call to a structured object suitable for JSON-style display. */
+function decodeCallObject(meta: MetadataBundle, callHex: string): DecodedCallObject | null {
+  try {
+    const callTypeId = meta.lookup.call;
+    if (callTypeId == null) return null;
+    const codec = meta.builder.buildDefinition(callTypeId);
+    const decoded = codec.dec(Binary.fromHex(callHex as `0x${string}`));
+    return {
+      palletName: decoded.type,
+      callName: decoded.value.type,
+      args: sanitizeForSerialization(decoded.value.value),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Print "Decode: Pallet.call" header followed by indented pretty-JSON args. */
+function printDecodedCall(obj: DecodedCallObject | null, fallback: string): void {
+  if (!obj) {
+    console.log(`  ${BOLD}Decode:${RESET} ${fallback}`);
+    return;
+  }
+  const header = `${CYAN}${obj.palletName}${RESET}.${CYAN}${obj.callName}${RESET}`;
+  const hasArgs =
+    obj.args !== null &&
+    obj.args !== undefined &&
+    !(typeof obj.args === "object" && Object.keys(obj.args).length === 0);
+  if (!hasArgs) {
+    console.log(`  ${BOLD}Decode:${RESET} ${header}`);
+    return;
+  }
+  console.log(`  ${BOLD}Decode:${RESET} ${header}`);
+  const indented = formatPretty(obj.args)
+    .split("\n")
+    .map((l) => `    ${l}`)
+    .join("\n");
+  console.log(indented);
 }
 
 function decodeCallFallback(meta: MetadataBundle, callHex: string): string {

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -53,9 +53,12 @@ const smallEnumTypeId = findTypeId(
   meta.lookup,
   (e) => e.type === "enum" && Object.keys(e.value).length > 0 && Object.keys(e.value).length <= 4,
 )!;
+// "Large" enums are summarized when the variant count exceeds the compact
+// threshold (24). Pallet/Event/Error enums on Polkadot easily exceed this.
 const largeEnumTypeId = findTypeId(
   meta.lookup,
-  (e) => e.type === "enum" && Object.keys(e.value).length > 4,
+  (e) => e.type === "enum" && Object.keys(e.value).length > 24,
+  2000,
 )!;
 const sequenceTypeId = findTypeId(meta.lookup, (e) => e.type === "sequence")!;
 const optionTypeId = findTypeId(meta.lookup, (e) => e.type === "option")!;
@@ -183,7 +186,7 @@ describe("describeType", () => {
     expect(result.split(" | ").length).toBeLessThanOrEqual(4);
   });
 
-  test("formats large enum (>4 variants) as enum(N variants)", () => {
+  test("formats very large enum (>24 variants) as enum(N variants) summary", () => {
     expect(largeEnumTypeId).toBeDefined();
     const result = describeType(meta.lookup, largeEnumTypeId);
     expect(result).toMatch(/^enum\(\d+ variants\)$/);

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -17,6 +17,12 @@ import {
 } from "../utils/errors.ts";
 import { fingerprintsMatch, type RuntimeFingerprint } from "../utils/runtime-fingerprint.ts";
 import type { ClientHandle } from "./client.ts";
+import {
+  _getCallFields,
+  _getEventFields,
+  compactArgsString,
+  compactTypeString,
+} from "./pretty-type.ts";
 
 const METADATA_TIMEOUT_MS = 15_000;
 const optionalOpaqueBytes = Option(Bytes());
@@ -427,43 +433,10 @@ export function describeRuntimeApiMethodArgs(
 export function describeType(lookup: Lookup, typeId: number): string {
   try {
     const entry = lookup(typeId);
-    return formatLookupEntry(entry);
+    if (!entry || typeof (entry as any).type !== "string") return `type(${typeId})`;
+    return compactTypeString(entry);
   } catch {
     return `type(${typeId})`;
-  }
-}
-
-function formatLookupEntry(entry: any): string {
-  switch (entry.type) {
-    case "primitive":
-      return entry.value;
-    case "compact":
-      return `Compact<${formatLookupEntry(entry.isBig ? { type: "primitive", value: "u128" } : { type: "primitive", value: "u64" })}>`;
-    case "AccountId32":
-      return "AccountId32";
-    case "bitSequence":
-      return "BitSequence";
-    case "sequence":
-      return `Vec<${formatLookupEntry(entry.value)}>`;
-    case "array":
-      return `[${formatLookupEntry(entry.value)}; ${entry.len}]`;
-    case "tuple":
-      return `(${entry.value.map(formatLookupEntry).join(", ")})`;
-    case "struct":
-      return `{ ${Object.entries(entry.value)
-        .map(([k, v]) => `${k}: ${formatLookupEntry(v)}`)
-        .join(", ")} }`;
-    case "option":
-      return `Option<${formatLookupEntry(entry.value)}>`;
-    case "result":
-      return `Result<${formatLookupEntry(entry.value.ok)}, ${formatLookupEntry(entry.value.ko)}>`;
-    case "enum": {
-      const variants = Object.keys(entry.value);
-      if (variants.length <= 4) return variants.join(" | ");
-      return `enum(${variants.length} variants)`;
-    }
-    default:
-      return "unknown";
   }
 }
 
@@ -472,46 +445,7 @@ export function describeCallArgs(
   palletName: string,
   callName: string,
 ): string {
-  try {
-    const palletMeta = meta.unified.pallets.find((p) => p.name === palletName);
-    if (!palletMeta?.calls) return "";
-
-    const callsEntry = meta.lookup(palletMeta.calls.type);
-    if (callsEntry.type !== "enum") return "";
-
-    const variant = (callsEntry.value as Record<string, any>)[callName];
-    if (!variant) return "";
-
-    if (variant.type === "void") return "()";
-
-    if (variant.type === "struct") {
-      const fields = Object.entries(variant.value as Record<string, any>)
-        .map(([k, v]) => `${k}: ${formatLookupEntry(v)}`)
-        .join(", ");
-      return `(${fields})`;
-    }
-
-    if (variant.type === "lookupEntry") {
-      const inner = variant.value;
-      if (inner.type === "void") return "()";
-      if (inner.type === "struct") {
-        const fields = Object.entries(inner.value as Record<string, any>)
-          .map(([k, v]) => `${k}: ${formatLookupEntry(v)}`)
-          .join(", ");
-        return `(${fields})`;
-      }
-      return `(${formatLookupEntry(inner)})`;
-    }
-
-    if (variant.type === "tuple") {
-      const types = (variant.value as any[]).map(formatLookupEntry).join(", ");
-      return `(${types})`;
-    }
-
-    return "";
-  } catch {
-    return "";
-  }
+  return compactArgsString(_getCallFields(meta, palletName, callName));
 }
 
 export function describeEventFields(
@@ -519,46 +453,7 @@ export function describeEventFields(
   palletName: string,
   eventName: string,
 ): string {
-  try {
-    const palletMeta = meta.unified.pallets.find((p) => p.name === palletName);
-    if (!palletMeta?.events) return "";
-
-    const eventsEntry = meta.lookup(palletMeta.events.type);
-    if (eventsEntry.type !== "enum") return "";
-
-    const variant = (eventsEntry.value as Record<string, any>)[eventName];
-    if (!variant) return "";
-
-    if (variant.type === "void") return "()";
-
-    if (variant.type === "struct") {
-      const fields = Object.entries(variant.value as Record<string, any>)
-        .map(([k, v]) => `${k}: ${formatLookupEntry(v)}`)
-        .join(", ");
-      return `(${fields})`;
-    }
-
-    if (variant.type === "lookupEntry") {
-      const inner = variant.value;
-      if (inner.type === "void") return "()";
-      if (inner.type === "struct") {
-        const fields = Object.entries(inner.value as Record<string, any>)
-          .map(([k, v]) => `${k}: ${formatLookupEntry(v)}`)
-          .join(", ");
-        return `(${fields})`;
-      }
-      return `(${formatLookupEntry(inner)})`;
-    }
-
-    if (variant.type === "tuple") {
-      const types = (variant.value as any[]).map(formatLookupEntry).join(", ");
-      return `(${types})`;
-    }
-
-    return "";
-  } catch {
-    return "";
-  }
+  return compactArgsString(_getEventFields(meta, palletName, eventName));
 }
 
 function hexToBytes(hex: string): Uint8Array {

--- a/src/core/pretty-type.test.ts
+++ b/src/core/pretty-type.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, test } from "bun:test";
+import { getTestMetadata } from "../commands/__fixtures__/load-metadata.ts";
+import type { Lookup, MetadataBundle } from "./metadata.ts";
+import {
+  compactTypeString,
+  prettyCallArgs,
+  prettyEventFields,
+  prettyType,
+  prettyTypeById,
+  visualWidth,
+} from "./pretty-type.ts";
+
+const meta: MetadataBundle = getTestMetadata();
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI for assertions
+const ANSI = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (s: string) => s.replace(ANSI, "");
+
+function findTypeId(lookup: Lookup, predicate: (entry: any) => boolean, maxScan = 500): number {
+  for (let id = 0; id < maxScan; id++) {
+    try {
+      if (predicate(lookup(id))) return id;
+    } catch {}
+  }
+  throw new Error("type not found");
+}
+
+const u32Id = findTypeId(meta.lookup, (e) => e.type === "primitive" && e.value === "u32");
+const accountIdId = findTypeId(meta.lookup, (e) => e.type === "AccountId32");
+const smallEnumId = findTypeId(
+  meta.lookup,
+  (e) => e.type === "enum" && Object.keys(e.value).length > 0 && Object.keys(e.value).length <= 4,
+);
+// Large enums (>24 variants) collapse to `enum(N variants)` in the compact form.
+const largeEnumId = findTypeId(
+  meta.lookup,
+  (e) => e.type === "enum" && Object.keys(e.value).length > 24,
+  2000,
+);
+const seqId = findTypeId(meta.lookup, (e) => e.type === "sequence");
+const optionId = findTypeId(meta.lookup, (e) => e.type === "option");
+const structId = findTypeId(
+  meta.lookup,
+  (e) => e.type === "struct" && Object.keys(e.value).length >= 3,
+);
+
+// ---------------------------------------------------------------------------
+// visualWidth
+// ---------------------------------------------------------------------------
+describe("visualWidth", () => {
+  test("counts plain characters", () => {
+    expect(visualWidth("hello")).toBe(5);
+  });
+
+  test("ignores ANSI escape codes", () => {
+    expect(visualWidth("\x1b[36mhello\x1b[0m")).toBe(5);
+  });
+
+  test("ignores nested escapes", () => {
+    expect(visualWidth("\x1b[1m\x1b[36mfoo\x1b[0m bar\x1b[0m")).toBe(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prettyType — compact behavior matches legacy describeType
+// ---------------------------------------------------------------------------
+describe("prettyType — compact (width: Infinity)", () => {
+  const opts = { width: Infinity, color: false };
+
+  test("primitive u32", () => {
+    expect(prettyType(meta.lookup(u32Id), opts)).toBe("u32");
+  });
+
+  test("AccountId32", () => {
+    expect(prettyType(meta.lookup(accountIdId), opts)).toBe("AccountId32");
+  });
+
+  test("small enum is pipe-separated", () => {
+    const result = prettyType(meta.lookup(smallEnumId), opts);
+    expect(result).toContain(" | ");
+    expect(result.split(" | ").length).toBeLessThanOrEqual(4);
+  });
+
+  test("large enum summarized", () => {
+    const result = prettyType(meta.lookup(largeEnumId), opts);
+    expect(result).toMatch(/^enum\(\d+ variants\)$/);
+  });
+
+  test("Vec wraps inner type", () => {
+    expect(prettyType(meta.lookup(seqId), opts)).toMatch(/^Vec<.+>$/);
+  });
+
+  test("Option wraps inner type", () => {
+    expect(prettyType(meta.lookup(optionId), opts)).toMatch(/^Option<.+>$/);
+  });
+
+  test("compactTypeString matches prettyType with width=Infinity, color=false", () => {
+    for (const id of [u32Id, accountIdId, smallEnumId, largeEnumId, seqId, optionId, structId]) {
+      expect(prettyType(meta.lookup(id), opts)).toBe(compactTypeString(meta.lookup(id)));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prettyType — width-aware expansion
+// ---------------------------------------------------------------------------
+describe("prettyType — width-aware expansion", () => {
+  test("short signature stays compact even at narrow width", () => {
+    // u32 always fits — must never expand
+    const result = prettyType(meta.lookup(u32Id), { width: 10, color: false });
+    expect(result).toBe("u32");
+    expect(result).not.toContain("\n");
+  });
+
+  test("struct expands when wider than available width", () => {
+    const entry = meta.lookup(structId);
+    // Force expansion with a tiny width
+    const result = prettyType(entry, { width: 10, color: false, indent: 0 });
+    expect(result).toContain("\n");
+    expect(result.startsWith("{")).toBe(true);
+    expect(result.endsWith("}")).toBe(true);
+  });
+
+  test("struct stays compact when wide enough", () => {
+    const result = prettyType(meta.lookup(structId), { width: 1000, color: false });
+    expect(result).not.toContain("\n");
+  });
+
+  test("expanded struct field names are aligned", () => {
+    // Synthetic struct with fields of different lengths
+    const entry = {
+      type: "struct",
+      value: {
+        a: { type: "primitive", value: "u8" },
+        longer_name: { type: "primitive", value: "u32" },
+        x: { type: "primitive", value: "bool" },
+      },
+    };
+    const result = prettyType(entry, { width: 20, color: false });
+    // All field-value separators (": ") should be at the same column
+    const lines = result.split("\n").filter((l) => l.includes(":"));
+    const colonCols = lines.map((l) => l.indexOf(":"));
+    expect(new Set(colonCols).size).toBe(1);
+  });
+
+  test("medium-sized enum (5-24 variants) renders pipe-separated, not summary", () => {
+    // Synthetic: 8-variant enum
+    const entry = {
+      type: "enum",
+      value: {
+        Family: { type: "void" },
+        Person: { type: "void" },
+        Identity: { type: "void" },
+        Squad: { type: "void" },
+        Mob: { type: "void" },
+        Group: { type: "void" },
+        Tribe: { type: "void" },
+        Clan: { type: "void" },
+      },
+    };
+    const result = prettyType(entry, { width: 200, color: false });
+    expect(result).not.toMatch(/^enum\(/);
+    expect(result).toContain("Family | Person");
+    expect(result.split(" | ").length).toBe(8);
+  });
+
+  test("medium enum expands one-per-line when too wide", () => {
+    const entry = {
+      type: "enum",
+      value: Object.fromEntries(
+        Array.from({ length: 8 }, (_, i) => [`Variant${i}`, { type: "void" }]),
+      ),
+    };
+    const result = prettyType(entry, { width: 30, color: false });
+    expect(result).toContain("\n");
+    expect(result).toContain("Variant0");
+    expect(result).toContain("Variant7");
+    // Should use the | continuation prefix on each subsequent line
+    expect(result).toMatch(/\n\s*\|\s+Variant1/);
+  });
+
+  test("very large enum (>24 variants) is summarized as enum(N variants)", () => {
+    const entry = {
+      type: "enum",
+      value: Object.fromEntries(Array.from({ length: 30 }, (_, i) => [`V${i}`, { type: "void" }])),
+    };
+    const result = prettyType(entry, { width: 200, color: false });
+    expect(result).toMatch(/^enum\(30 variants\)$/);
+  });
+
+  test("nested struct stays compact when its line still fits", () => {
+    const entry = {
+      type: "struct",
+      value: {
+        outer_a: { type: "primitive", value: "u32" },
+        nested: {
+          type: "struct",
+          value: {
+            x: { type: "primitive", value: "u8" },
+            y: { type: "primitive", value: "u8" },
+          },
+        },
+      },
+    };
+    // Wide enough that the OUTER expands but the INNER stays compact
+    const result = prettyType(entry, { width: 40, color: false });
+    expect(result).toContain("\n");
+    // Inner struct should remain on one line (name padded to align with longer sibling)
+    expect(result).toMatch(/nested\s*:\s+\{ x: u8, y: u8 \}/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Color suppression
+// ---------------------------------------------------------------------------
+describe("prettyType — color", () => {
+  test("color: false produces no ANSI escapes", () => {
+    const result = prettyType(meta.lookup(structId), { color: false, width: Infinity });
+    expect(result).not.toMatch(ANSI);
+  });
+
+  test("color: true emits ANSI escapes", () => {
+    const result = prettyType(meta.lookup(structId), { color: true, width: Infinity });
+    expect(result).toMatch(ANSI);
+  });
+
+  test("stripping ANSI from colored output equals plain output", () => {
+    const colored = prettyType(meta.lookup(structId), { color: true, width: Infinity });
+    const plain = prettyType(meta.lookup(structId), { color: false, width: Infinity });
+    expect(stripAnsi(colored)).toBe(plain);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prettyTypeById
+// ---------------------------------------------------------------------------
+describe("prettyTypeById", () => {
+  test("falls back to type(id) for invalid lookup", () => {
+    expect(prettyTypeById(meta.lookup, 999999, { color: false })).toBe("type(999999)");
+  });
+
+  test("delegates to prettyType for valid id", () => {
+    expect(prettyTypeById(meta.lookup, u32Id, { color: false, width: Infinity })).toBe("u32");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prettyCallArgs
+// ---------------------------------------------------------------------------
+describe("prettyCallArgs", () => {
+  const opts = { color: false, width: Infinity };
+
+  test("returns () for void calls or '(...)' for known calls", () => {
+    const result = prettyCallArgs(meta, "System", "remark", opts);
+    expect(result.startsWith("(")).toBe(true);
+    expect(result.endsWith(")")).toBe(true);
+  });
+
+  test("Balances.transfer_allow_death has named fields", () => {
+    const result = prettyCallArgs(meta, "Balances", "transfer_allow_death", opts);
+    expect(result).toContain("dest");
+    expect(result).toContain("value");
+  });
+
+  test("returns empty string for nonexistent pallet", () => {
+    expect(prettyCallArgs(meta, "NonExistent", "foo", opts)).toBe("");
+  });
+
+  test("returns empty string for nonexistent call", () => {
+    expect(prettyCallArgs(meta, "System", "nonexistent_call", opts)).toBe("");
+  });
+
+  test("expands across multiple lines at narrow width", () => {
+    const result = prettyCallArgs(meta, "Balances", "transfer_allow_death", {
+      color: false,
+      width: 30,
+    });
+    expect(result).toContain("\n");
+    expect(result.startsWith("(")).toBe(true);
+    expect(result.endsWith(")")).toBe(true);
+  });
+
+  test("compact form has no newlines when width is plentiful", () => {
+    const result = prettyCallArgs(meta, "Balances", "transfer_allow_death", opts);
+    expect(result).not.toContain("\n");
+  });
+
+  test("expanded args are name-aligned", () => {
+    const result = prettyCallArgs(meta, "Balances", "transfer_allow_death", {
+      color: false,
+      width: 30,
+    });
+    const innerLines = result
+      .split("\n")
+      .filter((l) => l.includes(":") && !l.startsWith("(") && !l.startsWith(")"));
+    if (innerLines.length > 1) {
+      const cols = innerLines.map((l) => l.indexOf(":"));
+      expect(new Set(cols).size).toBe(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prettyRuntimeApiArgs
+// ---------------------------------------------------------------------------
+describe("prettyRuntimeApiArgs", () => {
+  test("returns () for no inputs", async () => {
+    const { prettyRuntimeApiArgs } = await import("./pretty-type.ts");
+    expect(prettyRuntimeApiArgs(meta.lookup, [], { color: false })).toBe("()");
+  });
+
+  test("formats single input compactly", async () => {
+    const { prettyRuntimeApiArgs } = await import("./pretty-type.ts");
+    const result = prettyRuntimeApiArgs(meta.lookup, [{ name: "id", type: u32Id }], {
+      color: false,
+      width: Infinity,
+    });
+    expect(result).toBe("(id: u32)");
+  });
+
+  test("expands multiple inputs to multi-line at narrow width", async () => {
+    const { prettyRuntimeApiArgs } = await import("./pretty-type.ts");
+    const result = prettyRuntimeApiArgs(
+      meta.lookup,
+      [
+        { name: "first", type: u32Id },
+        { name: "second", type: u32Id },
+        { name: "third", type: u32Id },
+      ],
+      { color: false, width: 20 },
+    );
+    expect(result).toContain("\n");
+    expect(result).toContain("first");
+    expect(result).toContain("second");
+    expect(result).toContain("third");
+  });
+
+  test("handles invalid type ids without throwing", async () => {
+    const { prettyRuntimeApiArgs } = await import("./pretty-type.ts");
+    const result = prettyRuntimeApiArgs(meta.lookup, [{ name: "broken", type: 999999 }], {
+      color: false,
+      width: Infinity,
+    });
+    expect(result.startsWith("(")).toBe(true);
+    expect(result.endsWith(")")).toBe(true);
+    expect(result).toContain("broken");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PrettyOpts: prefix vs indent semantics
+// ---------------------------------------------------------------------------
+describe("PrettyOpts", () => {
+  test("prefix is added to width-fit budget — value stays compact when small", async () => {
+    // A 70-char compact form fits at indent=2 + prefix=0 (lead=2, 72<=80)
+    const fields = Array.from({ length: 5 }, (_, i) => ({
+      name: `f${i}`,
+      type: u32Id,
+    }));
+    const { prettyRuntimeApiArgs } = await import("./pretty-type.ts");
+    const noPrefix = prettyRuntimeApiArgs(meta.lookup, fields, {
+      indent: 2,
+      prefix: 0,
+      width: 80,
+      color: false,
+    });
+    const withLargePrefix = prettyRuntimeApiArgs(meta.lookup, fields, {
+      indent: 2,
+      prefix: 70,
+      width: 80,
+      color: false,
+    });
+    // Same args, but a larger prefix forces expansion sooner
+    expect(noPrefix.includes("\n")).toBe(false);
+    expect(withLargePrefix.includes("\n")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prettyEventFields
+// ---------------------------------------------------------------------------
+describe("prettyEventFields", () => {
+  const opts = { color: false, width: Infinity };
+
+  test("returns string starting with '(' for known events", () => {
+    // System.ExtrinsicSuccess is a well-known event
+    const result = prettyEventFields(meta, "System", "ExtrinsicSuccess", opts);
+    expect(result.startsWith("(")).toBe(true);
+    expect(result.endsWith(")")).toBe(true);
+  });
+
+  test("returns empty string for unknown event", () => {
+    expect(prettyEventFields(meta, "System", "NoSuchEvent", opts)).toBe("");
+  });
+});

--- a/src/core/pretty-type.ts
+++ b/src/core/pretty-type.ts
@@ -1,0 +1,477 @@
+import type { Lookup, MetadataBundle } from "./metadata.ts";
+import { isTTY } from "./output.ts";
+
+// ANSI escape codes — defined locally (not imported) so the `color: boolean`
+// option, not TTY detection, is the single source of truth for whether
+// to emit them.
+const RESET = "\x1b[0m";
+const CYAN = "\x1b[36m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const MAGENTA = "\x1b[35m";
+
+export interface PrettyOpts {
+  /**
+   * Baseline column for multi-line output: closing brackets align here,
+   * nested content goes at `indent + 2`. Also the column where the value
+   * begins on the first line (unless `prefix` is set).
+   */
+  indent?: number;
+  /**
+   * Number of characters that already precede the value on the first line
+   * (e.g. the call name `submit` before `(args)`). Used only for the
+   * compact-or-expand width check; not for multi-line layout.
+   */
+  prefix?: number;
+  /** Available terminal width. Defaults to `process.stdout.columns ?? 80`. */
+  width?: number;
+  /** Whether to emit ANSI color escapes. Defaults to `isTTY`. */
+  color?: boolean;
+}
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+/** Visible width of a string, ignoring ANSI escape sequences. */
+export function visualWidth(s: string): number {
+  return s.replace(ANSI_RE, "").length;
+}
+
+function paint(color: boolean, code: string, text: string): string {
+  return color ? `${code}${text}${RESET}` : text;
+}
+
+function defaultWidth(): number {
+  return process.stdout.columns ?? 80;
+}
+
+function resolveOpts(opts: PrettyOpts): Required<PrettyOpts> {
+  return {
+    indent: opts.indent ?? 0,
+    prefix: opts.prefix ?? 0,
+    width: opts.width ?? defaultWidth(),
+    color: opts.color ?? isTTY,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Compact (single-line) rendering
+// ---------------------------------------------------------------------------
+
+function compactEntry(entry: any, color: boolean): string {
+  if (!entry) return "";
+  switch (entry.type) {
+    case "primitive":
+      return paint(color, YELLOW, entry.value);
+    case "compact": {
+      const inner = entry.isBig ? "u128" : "u64";
+      return `${paint(color, MAGENTA, "Compact")}<${paint(color, YELLOW, inner)}>`;
+    }
+    case "AccountId32":
+      return paint(color, GREEN, "AccountId32");
+    case "bitSequence":
+      return paint(color, MAGENTA, "BitSequence");
+    case "sequence":
+      return `${paint(color, MAGENTA, "Vec")}<${compactEntry(entry.value, color)}>`;
+    case "array":
+      return `[${compactEntry(entry.value, color)}; ${entry.len}]`;
+    case "tuple":
+      return `(${(entry.value as any[]).map((v) => compactEntry(v, color)).join(", ")})`;
+    case "struct": {
+      const fields = Object.entries(entry.value as Record<string, any>);
+      if (fields.length === 0) return "{}";
+      const inner = fields
+        .map(([k, v]) => `${paint(color, CYAN, k)}: ${compactEntry(v, color)}`)
+        .join(", ");
+      return `{ ${inner} }`;
+    }
+    case "option":
+      return `${paint(color, MAGENTA, "Option")}<${compactEntry(entry.value, color)}>`;
+    case "result":
+      return `${paint(color, MAGENTA, "Result")}<${compactEntry(entry.value.ok, color)}, ${compactEntry(entry.value.ko, color)}>`;
+    case "enum": {
+      const variants = Object.keys(entry.value);
+      // Very large enums are always summarized — the pipe-separated form
+      // would be unreadable. Anything below this threshold renders as
+      // `A | B | C | ...` so the width-aware caller can decide whether to
+      // keep that compact or expand it across lines.
+      if (variants.length > ENUM_COMPACT_LIMIT) {
+        return `enum(${variants.length} variants)`;
+      }
+      return variants.map((v) => paint(color, GREEN, v)).join(" | ");
+    }
+    case "void":
+      return "()";
+    case "lookupEntry":
+      return compactEntry(entry.value, color);
+    default:
+      return "unknown";
+  }
+}
+
+/** Beyond this many variants, an enum is always summarized as `enum(N variants)`. */
+const ENUM_COMPACT_LIMIT = 24;
+
+// ---------------------------------------------------------------------------
+// Multi-line expansion
+// ---------------------------------------------------------------------------
+
+/**
+ * Expand a Lookup entry to a (possibly multi-line) string.
+ *
+ * `indent` is the baseline column where multi-line content's closing bracket
+ * aligns — its inner content goes at `indent + 2`. `prefix` is any text
+ * already on the first line before the value (e.g. `"name: "` when this is
+ * a struct field's value); it's added to the compact-fit budget but does
+ * NOT shift the multi-line baseline.
+ */
+function expandEntry(
+  entry: any,
+  indent: number,
+  width: number,
+  color: boolean,
+  prefix = 0,
+): string {
+  const compact = compactEntry(entry, color);
+  if (visualWidth(compact) + indent + prefix <= width) return compact;
+
+  switch (entry.type) {
+    case "struct":
+      return expandStruct(entry.value as Record<string, any>, indent, width, color);
+    case "tuple":
+      return expandTuple(entry.value as any[], indent, width, color);
+    case "sequence":
+      return wrapMultiline("Vec", "<", ">", entry.value, indent, width, color);
+    case "array": {
+      // Arrays are almost always [primitive; N]; if the element somehow
+      // expands, just inline it — array length stays beside the element.
+      const inner = expandEntry(entry.value, indent + 1, width, color);
+      return `[${inner}; ${entry.len}]`;
+    }
+    case "option":
+      return wrapMultiline("Option", "<", ">", entry.value, indent, width, color);
+    case "result": {
+      // Result<Ok, Ko> — expand each on its own line. Comma between Ok and Ko
+      // is required (it's the generic type list), no trailing comma after Ko.
+      const innerIndent = indent + 2;
+      const padding = " ".repeat(innerIndent);
+      const closePadding = " ".repeat(indent);
+      const ok = expandEntry(entry.value.ok, innerIndent, width, color);
+      const ko = expandEntry(entry.value.ko, innerIndent, width, color);
+      return `${paint(color, MAGENTA, "Result")}<\n${padding}${ok},\n${padding}${ko}\n${closePadding}>`;
+    }
+    case "enum": {
+      const variants = Object.keys(entry.value);
+      if (variants.length > ENUM_COMPACT_LIMIT) return `enum(${variants.length} variants)`;
+      return expandEnum(variants, indent, color);
+    }
+    case "lookupEntry":
+      return expandEntry(entry.value, indent, width, color);
+    default:
+      return compact;
+  }
+}
+
+function expandStruct(
+  fields: Record<string, any>,
+  indent: number,
+  width: number,
+  color: boolean,
+): string {
+  const entries = Object.entries(fields);
+  if (entries.length === 0) return "{}";
+  return renderFieldList(entries, "{", "}", indent, width, color);
+}
+
+function expandTuple(items: any[], indent: number, width: number, color: boolean): string {
+  if (items.length === 0) return "()";
+  const inner = " ".repeat(indent + 2);
+  const close = " ".repeat(indent);
+  const lines = items.map((v) => `${inner}${expandEntry(v, indent + 2, width, color)}`);
+  return `(\n${lines.join(",\n")},\n${close})`;
+}
+
+/**
+ * Render `Name<inner>` (e.g. Vec, Option) with the inner content on its own
+ * line(s), so multi-line inner content has consistent indentation regardless
+ * of how the outer line started.
+ */
+function wrapMultiline(
+  name: string,
+  open: string,
+  close: string,
+  inner: any,
+  indent: number,
+  width: number,
+  color: boolean,
+): string {
+  const innerIndent = indent + 2;
+  const padding = " ".repeat(innerIndent);
+  const closePadding = " ".repeat(indent);
+  const innerStr = expandEntry(inner, innerIndent, width, color);
+  // No trailing comma — these are generics like Vec<T>, not field lists.
+  return `${paint(color, MAGENTA, name)}${open}\n${padding}${innerStr}\n${closePadding}${close}`;
+}
+
+function expandEnum(variants: string[], indent: number, color: boolean): string {
+  // Multi-line enum: first variant unindented, remainder prefixed with "| "
+  // (so the column of variant names lines up with the first one).
+  const prefix = `\n${" ".repeat(indent)}| `;
+  const [first, ...rest] = variants;
+  const head = paint(color, GREEN, first ?? "");
+  if (rest.length === 0) return head;
+  const tail = rest.map((v) => paint(color, GREEN, v)).join(prefix);
+  return `${head}${prefix}${tail}`;
+}
+
+/**
+ * Maximum padding width for field-name alignment. Beyond this, fields align
+ * to the longest "short" name and longer names just use one space — keeps
+ * deeply nested structures from cascading off the right edge.
+ */
+const ALIGN_PADDING_LIMIT = 16;
+
+/**
+ * Render a list of `name: type` fields wrapped in `open`/`close` brackets.
+ * Field names are right-padded so all values line up in the same column when
+ * the longest name fits within `ALIGN_PADDING_LIMIT`. Otherwise alignment is
+ * skipped to avoid deep cascades.
+ */
+function renderFieldList(
+  fields: Array<[string, any]>,
+  open: string,
+  close: string,
+  indent: number,
+  width: number,
+  color: boolean,
+): string {
+  const innerIndent = indent + 2;
+  const maxNameLen = Math.max(...fields.map(([k]) => k.length));
+  const align = maxNameLen <= ALIGN_PADDING_LIMIT;
+  const padTo = align ? maxNameLen : 0;
+  const padding = " ".repeat(innerIndent);
+  const closePadding = " ".repeat(indent);
+
+  const lines = fields.map(([k, v]) => {
+    const paddedName = align ? k.padEnd(padTo) : k;
+    // First-line column where the value starts (after "  name: " prefix).
+    const fieldPrefix = (align ? padTo : k.length) + 2;
+    // Pass `innerIndent` as the multi-line baseline (closing bracket aligns
+    // with the field name's column, not with the value's column), but use
+    // `fieldPrefix` so the compact-fit check still accounts for the leading
+    // `name: ` text on the first line.
+    const value = expandEntry(v, innerIndent, width, color, fieldPrefix);
+    return `${padding}${paint(color, CYAN, paddedName)}: ${value}`;
+  });
+
+  return `${open}\n${lines.join(",\n")},\n${closePadding}${close}`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Pretty-print any Lookup entry (single-line if it fits, expanded otherwise). */
+export function prettyType(entry: any, opts: PrettyOpts = {}): string {
+  const { indent, prefix, width, color } = resolveOpts(opts);
+  // Width-fit check uses indent + prefix; expansion uses indent.
+  const compact = compactEntry(entry, color);
+  if (visualWidth(compact) + indent + prefix <= width) return compact;
+  return expandEntry(entry, indent, width, color);
+}
+
+/** Pretty-print a type by its lookup ID. */
+export function prettyTypeById(lookup: Lookup, typeId: number, opts: PrettyOpts = {}): string {
+  try {
+    const entry = lookup(typeId);
+    if (!entry || typeof (entry as any).type !== "string") return `type(${typeId})`;
+    return prettyType(entry, opts);
+  } catch {
+    return `type(${typeId})`;
+  }
+}
+
+/**
+ * Pretty-print a call's argument list as `(name: type, ...)` — single-line if it
+ * fits, multi-line with aligned names otherwise. Returns "" if the call is
+ * unknown, "()" if it has no args.
+ */
+export function prettyCallArgs(
+  meta: MetadataBundle,
+  palletName: string,
+  callName: string,
+  opts: PrettyOpts = {},
+): string {
+  const fields = getCallFields(meta, palletName, callName);
+  if (fields === null) return "";
+  return renderArgsFromFields(fields, opts);
+}
+
+/**
+ * Pretty-print an event's field list. Same shape as `prettyCallArgs`.
+ */
+export function prettyEventFields(
+  meta: MetadataBundle,
+  palletName: string,
+  eventName: string,
+  opts: PrettyOpts = {},
+): string {
+  const fields = getEventFields(meta, palletName, eventName);
+  if (fields === null) return "";
+  return renderArgsFromFields(fields, opts);
+}
+
+/**
+ * Pretty-print runtime API method argument list, given the method's inputs as
+ * `[{ name, type: typeId }, ...]`. Width-aware like the others.
+ */
+export function prettyRuntimeApiArgs(
+  lookup: Lookup,
+  inputs: Array<{ name: string; type: number }>,
+  opts: PrettyOpts = {},
+): string {
+  if (inputs.length === 0) return "()";
+  const namedFields: Array<[string, any]> = inputs.map((i) => {
+    let entry: any;
+    try {
+      entry = lookup(i.type);
+      if (!entry || typeof entry.type !== "string") entry = { type: "unknown" };
+    } catch {
+      entry = { type: "unknown" };
+    }
+    return [i.name, entry];
+  });
+  return renderArgsFromFields({ kind: "named", fields: namedFields }, opts);
+}
+
+// ---------------------------------------------------------------------------
+// Internals: variant unwrapping (shared with describeCallArgs/EventFields)
+// ---------------------------------------------------------------------------
+
+type FieldList =
+  | { kind: "void" }
+  | { kind: "named"; fields: Array<[string, any]> }
+  | { kind: "positional"; types: any[] }
+  | { kind: "single"; type: any };
+
+function unwrapVariant(variant: any): FieldList | null {
+  if (!variant) return null;
+  if (variant.type === "void") return { kind: "void" };
+  if (variant.type === "struct") {
+    return {
+      kind: "named",
+      fields: Object.entries(variant.value as Record<string, any>),
+    };
+  }
+  if (variant.type === "tuple") {
+    return { kind: "positional", types: variant.value as any[] };
+  }
+  if (variant.type === "lookupEntry") {
+    const inner = variant.value;
+    if (inner.type === "void") return { kind: "void" };
+    if (inner.type === "struct") {
+      return {
+        kind: "named",
+        fields: Object.entries(inner.value as Record<string, any>),
+      };
+    }
+    return { kind: "single", type: inner };
+  }
+  return null;
+}
+
+function getCallFields(
+  meta: MetadataBundle,
+  palletName: string,
+  callName: string,
+): FieldList | null {
+  try {
+    const palletMeta = meta.unified.pallets.find((p) => p.name === palletName);
+    if (!palletMeta?.calls) return null;
+    const callsEntry = meta.lookup(palletMeta.calls.type) as any;
+    if (callsEntry.type !== "enum") return null;
+    const variant = (callsEntry.value as Record<string, any>)[callName];
+    return unwrapVariant(variant);
+  } catch {
+    return null;
+  }
+}
+
+function getEventFields(
+  meta: MetadataBundle,
+  palletName: string,
+  eventName: string,
+): FieldList | null {
+  try {
+    const palletMeta = meta.unified.pallets.find((p) => p.name === palletName);
+    if (!palletMeta?.events) return null;
+    const eventsEntry = meta.lookup(palletMeta.events.type) as any;
+    if (eventsEntry.type !== "enum") return null;
+    const variant = (eventsEntry.value as Record<string, any>)[eventName];
+    return unwrapVariant(variant);
+  } catch {
+    return null;
+  }
+}
+
+function renderArgsFromFields(fields: FieldList, opts: PrettyOpts): string {
+  const { indent, prefix, width, color } = resolveOpts(opts);
+  // Compact-fit budget includes any text already on the line before the value.
+  const lead = indent + prefix;
+
+  switch (fields.kind) {
+    case "void":
+      return "()";
+    case "named": {
+      const compact = `(${fields.fields
+        .map(([k, v]) => `${paint(color, CYAN, k)}: ${compactEntry(v, color)}`)
+        .join(", ")})`;
+      if (visualWidth(compact) + lead <= width) return compact;
+      return renderFieldList(fields.fields, "(", ")", indent, width, color);
+    }
+    case "positional": {
+      const compact = `(${fields.types.map((t) => compactEntry(t, color)).join(", ")})`;
+      if (visualWidth(compact) + lead <= width) return compact;
+      const innerIndent = indent + 2;
+      const padding = " ".repeat(innerIndent);
+      const closePadding = " ".repeat(indent);
+      const lines = fields.types.map(
+        (t) => `${padding}${expandEntry(t, innerIndent, width, color)}`,
+      );
+      return `(\n${lines.join(",\n")},\n${closePadding})`;
+    }
+    case "single": {
+      const compact = `(${compactEntry(fields.type, color)})`;
+      if (visualWidth(compact) + lead <= width) return compact;
+      const inner = expandEntry(fields.type, indent + 2, width, color);
+      return `(\n${" ".repeat(indent + 2)}${inner},\n${" ".repeat(indent)})`;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Compact-only helpers for backwards-compatible single-line output
+// ---------------------------------------------------------------------------
+
+/** Single-line, uncolored type string (drop-in replacement for old describeType). */
+export function compactTypeString(entry: any): string {
+  return compactEntry(entry, false);
+}
+
+/** Single-line, uncolored args string (drop-in replacement for old describeCallArgs). */
+export function compactArgsString(fields: FieldList | null): string {
+  if (fields === null) return "";
+  switch (fields.kind) {
+    case "void":
+      return "()";
+    case "named":
+      return `(${fields.fields.map(([k, v]) => `${k}: ${compactEntry(v, false)}`).join(", ")})`;
+    case "positional":
+      return `(${fields.types.map((t) => compactEntry(t, false)).join(", ")})`;
+    case "single":
+      return `(${compactEntry(fields.type, false)})`;
+  }
+}
+
+/** Re-exports so metadata.ts can build legacy strings without duplicating logic. */
+export { getCallFields as _getCallFields, getEventFields as _getEventFields };


### PR DESCRIPTION
## Summary

- Width-aware multi-line pretty-printing for type signatures (`dot inspect`, focused listings, transaction-extension detail) — short signatures stay compact, long ones expand with field names aligned by colon and syntactic ANSI coloring (cyan field names, yellow primitives, magenta container keywords, green enum variants).
- Storage detail now shows `Type:`, `Key:`, and `Value:` on separate lines (no `→` arrow); composite values expand into one field per line when they don't fit.
- Dry-run `Decode:` output is rendered as indented JSON under a `Pallet.call` header so deeply nested calls (Sudo, batch, dispatch_as, XCM) stay readable.
- Enum summarization threshold raised from 4 to 24 variants — most enums now show variant names inline instead of the opaque `enum(N variants)`.
- JSON output paths are unchanged (single-line type strings preserved). Width is taken from `process.stdout.columns` (fallback 80); colors are suppressed when stdout isn't a TTY.

### Before vs. after

```
# Before
Args: (proposal_origin: system | Origins | ParachainsOrigin | XcmPallet, proposal: Legacy | Inline | Lookup, enactment_moment: At | After)

# After
Args: (
  proposal_origin : system | Origins | ParachainsOrigin | XcmPallet,
  proposal        : Legacy | Inline | Lookup,
  enactment_moment: At | After,
)
```

```
# Dry-run Decode (after)
Decode: System.remark
  {
    "remark": "0xdeadbeef"
  }
```

### Implementation

- New `src/core/pretty-type.ts` — Wadler-style "fits-on-line OR expand" formatter with a `prefix` option to separate first-line width budget from multi-line layout indent.
- `metadata.ts` `describeType` / `describeCallArgs` / `describeEventFields` are now thin wrappers that produce the legacy single-line strings (used by JSON output paths). Human-output sites in `inspect.ts`, `focused-inspect.ts`, `query.ts`, and `tx.ts` switched to the pretty variants.
- Decoded `tx --dry-run` output uses the existing `formatPretty` JSON renderer with two-space indentation under a `Pallet.call` header.

### Tests

- 35+ new unit tests in `src/core/pretty-type.test.ts` covering compact/expand behavior, width-fit semantics, color suppression, alignment, and the medium/large enum threshold.
- 7 new CLI-surface tests in `src/commands/inspect.test.ts` and `src/commands/focused-inspect.test.ts` verifying `[map]` tag, separated `Key`/`Value` lines, multi-line argument expansion, runtime API detail layout, and that JSON output stays single-line.
- Two existing inspect tests updated for the new layout (no `→`, name-aligned fields).
- Suite: **1459 pass / 0 fail** (was 1446). Coverage: `pretty-type.ts` at 86.5% functions / 83.3% lines; project at 90.6% / 88.8%.

## Test plan

- [x] `bun test` — 1459 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test --coverage` — no regression vs. baseline
- [x] Manual end-to-end against live Polkadot RPC for each documented example:
  - [x] `dot inspect polkadot.System` (pallet listing — composite Value expands)
  - [x] `dot inspect polkadot.System.Account` (storage detail — Type/Key/Value lines)
  - [x] `dot inspect polkadot.Referenda.submit` (call detail — long args expand)
  - [x] `dot polkadot.tx.System.remark 0xdeadbeef --unsigned --dry-run` (decoded JSON block)
  - [x] `dot polkadot.tx.Utility.batch_all "$A,$B" --unsigned --dry-run` (nested decoded calls)
  - [x] `dot paseo-people-next.extensions.AsPerson` (enum variants visible — was `enum(5 variants)`)
- [x] `--json` outputs unchanged (verified for inspect, query, runtime APIs)
- [x] README, `docs/content/_index.md`, and `dot-cli/SKILL.md` updated with new examples — every example was run against live RPC to confirm it produces the documented output

🤖 Generated with [Claude Code](https://claude.com/claude-code)