### PR TITLE
feat(rpc): `dot [chain.]rpc.<method>` for raw JSON-RPC calls

### DIFF
--- a/.changeset/feature-rpc-methods.md
+++ b/.changeset/feature-rpc-methods.md
@@ -1,0 +1,29 @@
+---
+"polkadot-cli": minor
+---
+
+feat(rpc): add `dot [chain.]rpc.<method>` for raw JSON-RPC calls
+
+Closes #196.
+
+Substrate nodes expose a JSON-RPC surface (`system_*`, `chain_*`, `state_*`,
+`author_*`, `payment_*`, consensus and dev families, plus the new spec
+`chainSpec_v1_*` / `archive_v1_*` / `rpc_methods`) that is separate from
+runtime metadata and was previously unreachable from this CLI.
+
+The new `rpc` category mirrors the other dotpath commands: methods are
+discovered per-chain via `rpc_methods`, cached at
+`~/.polkadot/chains/<chain>/rpc-methods.json`, and tab-completed.
+
+- `dot polkadot.rpc` — list methods grouped by family
+- `dot polkadot.rpc.system_health` — call a method
+- `dot polkadot.rpc.chain_getBlock 0x<hash>` — positional args
+- `dot polkadot.rpc.<method> --help` — curated description and arg names
+  for ~50 well-known methods; raw passthrough for the rest
+- `dot polkadot.rpc --refresh` — re-discover methods on a node upgrade
+
+Subscription methods (`*_subscribe*`, `chainHead_v1_follow`, `transaction_v1_*`)
+appear in completion but error out as one-shots with a helpful message.
+
+`dot chain add` and `dot chain update` now also fetch and cache the method
+list, and `dot chain info` shows a per-family breakdown.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Ships with Polkadot and all system parachains preconfigured with multiple fallba
 - ✅ Account management — BIP39 mnemonics, derivation paths, env-backed secrets, watch-only, dev accounts
 - ✅ Named address resolution across all commands
 - ✅ Runtime API calls — `dot polkadot.apis.Core.version`
+- ✅ Raw JSON-RPC calls — `dot polkadot.rpc.system_health`, with discovery via `rpc_methods` and tab-completion
 - ✅ Full-metadata dump — `dot metadata <chain>` emits one JSON blob with pallets, runtime APIs, and transaction extensions (or raw SCALE bytes via `--raw`)
 - ✅ Stale-metadata detection — when a tx or query fails because the runtime upgraded, the CLI tells you exactly which `dot chain update` to run
 - ✅ Chain topology — relay/parachain hierarchy with tree display and auto-detection
@@ -532,7 +533,7 @@ dot polkadot.apis.Core
 dot apis Core --chain polkadot
 ```
 
-This works for all categories (`query`, `tx`, `const`, `events`, `errors`, `apis`, `extensions`). When passing positional method arguments, keep `Pallet` and `Item` either fully dot-joined (`query.System.Account 5Grw...`) or fully space-separated (`query System Account 5Grw...`) — mixing the two (`query System.Account 5Grw...`) does not work because the second arg gets parsed as a pallet name.
+This works for all categories (`query`, `tx`, `const`, `events`, `errors`, `apis`, `extensions`, `rpc`). When passing positional method arguments, keep `Pallet` and `Item` either fully dot-joined (`query.System.Account 5Grw...`) or fully space-separated (`query System Account 5Grw...`) — mixing the two (`query System.Account 5Grw...`) does not work because the second arg gets parsed as a pallet name.
 
 ### Query storage
 
@@ -962,6 +963,74 @@ The list view tags each entry:
 - `[custom]` — you must provide a value with `--ext` when signing, for example `--ext '{"<Identifier>":{"value":<v>}}'`
 
 The detail view shows the extension's value type, its `additionalSigned` type, and a ready-to-adapt `--ext` snippet for custom extensions. Use this to discover what `--ext` payload a chain expects before submitting a `dot tx` command.
+
+### Raw JSON-RPC
+
+Substrate nodes expose a JSON-RPC surface that lives outside runtime metadata: `system_*` (sync state, peers, version), `chain_*` (blocks, headers, finalized head), `state_*` (raw storage, key iteration, runtime version), `author_*` (mempool, key management), `payment_*` (fee estimation), consensus families (`babe_*`, `grandpa_*`, `mmr_*`, `beefy_*`), and the new spec families (`chainSpec_v1_*`, `archive_v1_*`, `rpc_methods`). The `rpc` category exposes them all.
+
+Methods are discovered per-chain via the standard `rpc_methods` JSON-RPC call and cached at `~/.polkadot/chains/<chain>/rpc-methods.json`. The set of available methods depends on the node, not the chain — an archive node adds `archive_v1_*`, validators may add `babe_epochAuthorship`, dev nodes add `dev_newBlock`, and `--rpc-methods safe` strips writes.
+
+```bash
+# List all methods the node exposes, grouped by family
+dot polkadot.rpc
+# Output:
+# RPC methods on polkadot (129)
+#
+# system (20)
+#   system_health  Node sync state (peers, isSyncing, shouldHavePeers).
+#   system_version  Node software version string.
+#   system_chain  Chain name as reported by the node.
+#   ...
+# chain (19)
+#   chain_getBlock  Full block (header + extrinsics) by hash.
+#   chain_getFinalizedHead  Hash of the latest finalized head.
+#   ...
+
+# Call a method
+dot polkadot.rpc.system_health
+# Output:
+# {
+#   "peers": 131,
+#   "isSyncing": false,
+#   "shouldHavePeers": true
+# }
+
+# Positional args (parsed by the same heuristic as tx args)
+dot polkadot.rpc.chain_getBlockHash 1000
+# Output:
+# "0xcf36a1e4a16fc579136137b8388f35490f09c5bdd7b9133835eba907a8b76c30"
+
+# Show curated info for a known method
+dot polkadot.rpc.author_insertKey --help
+# Output:
+# author_insertKey
+#   ⚠️  WRITE / state-changing
+#   Insert a key into the node keystore.
+#
+#   Family: author
+#   Args:   <keyType: string> <suri: string> <publicKey: hex>
+
+# Refresh the cached method list (after a node upgrade)
+dot polkadot.rpc --refresh
+
+# JSON output works on any method
+dot polkadot.rpc.system_health --json
+```
+
+`dot chain add` and `dot chain update` automatically populate the method cache, and `dot chain info <name>` shows a per-family breakdown. Tab completion sources from the cache, so methods on a custom chain start completing the moment you've added or updated it.
+
+About 50 well-known methods carry curated metadata (description, named args, `⚠️ WRITE` tag for state-changing calls). Any other method the node reports is callable via raw passthrough — args are forwarded as-is to the JSON-RPC `params` array.
+
+Subscription methods (`*_subscribe*`, `chainHead_v1_follow`, `transaction_v1_*`) appear in tab-completion but error out as one-shots — they need a long-running follow session that doesn't fit a single CLI invocation:
+
+```bash
+dot polkadot.rpc.chain_subscribeAllHeads
+# Error: "chain_subscribeAllHeads" is a subscription method (requires a follow
+# session) and is not callable as a one-shot. Use a long-running client for
+# streaming RPC.
+```
+
+The `rpc` category is **flat** — there's no pallet level. The form is `[chain.]rpc.<method_name>`, where `<method_name>` keeps its underscores in a single segment (e.g. `polkadot.rpc.chain_getBlock`).
 
 ### Submit extrinsics
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@noble/hashes": "^2.0.1",
         "@polkadot-api/metadata-builders": "^0.14.1",
         "@polkadot-api/substrate-bindings": "^0.20.1",
+        "@polkadot-api/substrate-client": "^0.7.0",
         "@polkadot-api/view-builder": "^0.5.1",
         "@polkadot-labs/hdkd": "^0.0.28",
         "@polkadot-labs/hdkd-helpers": "^0.0.29",

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -15,6 +15,7 @@ A command-line tool for interacting with Polkadot-ecosystem chains. Manage chain
 - ✅ Account management — BIP39 mnemonics, derivation paths, env-backed secrets, watch-only, dev accounts
 - ✅ Named address resolution across all commands
 - ✅ Runtime API calls — `dot polkadot.apis.Core.version`
+- ✅ Raw JSON-RPC calls — `dot polkadot.rpc.system_health`, with discovery via `rpc_methods` and tab-completion
 - ✅ Full-metadata dump — `dot metadata <chain>` emits one JSON blob with pallets, runtime APIs, and transaction extensions (or raw SCALE bytes via `--raw`)
 - ✅ Stale-metadata detection — when a tx or query fails because the runtime upgraded, the CLI tells you exactly which `dot chain update` to run
 - ✅ Batteries included — all system parachains and testnets already setup to be used
@@ -1274,6 +1275,74 @@ Each entry is tagged:
 The detail view also shows the extension's `additionalSigned` type (included in the signed payload but not in the transaction body). `--json` output emits structured records with `identifier`, `valueType`, `additionalSignedType`, `valueTypeId`, `additionalSignedTypeId`, and `isBuiltin` — handy for agents and scripts that generate `--ext` payloads automatically.
 
 This is the companion discovery surface for [Custom signed extensions](#custom-signed-extensions) below — run `dot <chain>.extensions` first to learn what the chain expects, then pass the right values to `dot tx ... --ext`.
+
+### Raw JSON-RPC
+
+Substrate nodes expose a JSON-RPC surface that lives outside runtime metadata: `system_*` (sync state, peers, version), `chain_*` (blocks, headers, finalized head), `state_*` (raw storage, key iteration, runtime version), `author_*` (mempool, key management), `payment_*` (fee estimation), consensus families (`babe_*`, `grandpa_*`, `mmr_*`, `beefy_*`), and the new spec families (`chainSpec_v1_*`, `archive_v1_*`, `rpc_methods`). The `rpc` category exposes them all.
+
+Methods are discovered per-chain via the standard `rpc_methods` JSON-RPC call and cached at `~/.polkadot/chains/<chain>/rpc-methods.json`. The set of available methods depends on the node, not the chain — an archive node adds `archive_v1_*`, validators may add `babe_epochAuthorship`, dev nodes add `dev_newBlock`, and `--rpc-methods safe` strips writes.
+
+```
+# List all methods the node exposes, grouped by family
+dot polkadot.rpc
+# Output:
+# RPC methods on polkadot (129)
+#
+# system (20)
+#   system_health  Node sync state (peers, isSyncing, shouldHavePeers).
+#   system_version  Node software version string.
+#   system_chain  Chain name as reported by the node.
+#   ...
+# chain (19)
+#   chain_getBlock  Full block (header + extrinsics) by hash.
+#   chain_getFinalizedHead  Hash of the latest finalized head.
+#   ...
+
+# Call a method
+dot polkadot.rpc.system_health
+# Output:
+# {
+#   "peers": 131,
+#   "isSyncing": false,
+#   "shouldHavePeers": true
+# }
+
+# Positional args (parsed by the same heuristic as tx args)
+dot polkadot.rpc.chain_getBlockHash 1000
+# Output:
+# "0xcf36a1e4a16fc579136137b8388f35490f09c5bdd7b9133835eba907a8b76c30"
+
+# Show curated info for a known method
+dot polkadot.rpc.author_insertKey --help
+# Output:
+# author_insertKey
+#   ⚠️  WRITE / state-changing
+#   Insert a key into the node keystore.
+#
+#   Family: author
+#   Args:   <keyType: string> <suri: string> <publicKey: hex>
+
+# Refresh the cached method list (after a node upgrade)
+dot polkadot.rpc --refresh
+
+# JSON output works on any method
+dot polkadot.rpc.system_health --json
+```
+
+`dot chain add` and `dot chain update` automatically populate the method cache, and `dot chain info <name>` shows a per-family breakdown. Tab completion sources from the cache, so methods on a custom chain start completing the moment you've added or updated it.
+
+About 50 well-known methods carry curated metadata (description, named args, `⚠️ WRITE` tag for state-changing calls). Any other method the node reports is callable via raw passthrough — args are forwarded as-is to the JSON-RPC `params` array.
+
+Subscription methods (`*_subscribe*`, `chainHead_v1_follow`, `transaction_v1_*`) appear in tab-completion but error out as one-shots — they need a long-running follow session that doesn't fit a single CLI invocation:
+
+```
+dot polkadot.rpc.chain_subscribeAllHeads
+# Error: "chain_subscribeAllHeads" is a subscription method (requires a follow
+# session) and is not callable as a one-shot. Use a long-running client for
+# streaming RPC.
+```
+
+The `rpc` category is **flat** — there's no pallet level. The form is `[chain.]rpc.<method_name>`, where `<method_name>` keeps its underscores in a single segment (e.g. `polkadot.rpc.chain_getBlock`).
 
 ## Transactions
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -3,9 +3,10 @@ name: dot-cli
 description: >
   Guide for using the `dot` CLI (polkadot-cli) to interact with Polkadot/Substrate chains.
   Use when the user works with Substrate-based blockchains — querying storage, submitting
-  transactions, calling runtime APIs, managing chain connections, or scripting multi-chain
-  setups. Triggers: user mentions `dot` CLI, polkadot-cli, Substrate chain queries,
-  extrinsic submission, runtime APIs, XCM, asset pools, or chain setup scripts using `dot`.
+  transactions, calling runtime APIs, raw JSON-RPC calls, managing chain connections, or
+  scripting multi-chain setups. Triggers: user mentions `dot` CLI, polkadot-cli,
+  Substrate chain queries, extrinsic submission, runtime APIs, JSON-RPC, `system_health`
+  / `chain_getBlock` / `rpc_methods`, XCM, asset pools, or chain setup scripts using `dot`.
 ---
 
 # dot CLI (polkadot-cli)
@@ -18,7 +19,7 @@ Unified CLI for Polkadot/Substrate chains. Install: `npm install -g polkadot-cli
 dot [chain.]<category>[.Pallet[.Item]] [args] [options]
 ```
 
-Categories: `query`, `tx`, `apis`, `const`, `events`, `errors`, `extensions`
+Categories: `query`, `tx`, `apis`, `const`, `events`, `errors`, `extensions`, `rpc`
 
 Top-level commands: `dot inspect`, `dot metadata`, `dot chain`, `dot account`, `dot parachain`, `dot sign`, `dot hash`.
 
@@ -235,6 +236,45 @@ dot polkadot-asset-hub.apis.AssetConversionApi.get_reserves \
 ```
 
 Call a method without args to see its signature, or use `--help`.
+
+## Raw JSON-RPC
+
+Runtime APIs and storage cover everything the runtime exposes; the `rpc` category covers what the **node** exposes outside the runtime — `system_*` (sync state, peers, version), `chain_*` (blocks/headers/finalized head), `state_*` (raw storage, key iteration, runtime version), `author_*` (mempool, key management), `payment_*` (fee estimation), consensus families (`babe_*`, `grandpa_*`, `mmr_*`, `beefy_*`), and the new spec families (`chainSpec_v1_*`, `archive_v1_*`, `rpc_methods`).
+
+Methods are discovered per-chain via the `rpc_methods` JSON-RPC call and cached. Use it when the user asks for things like "is the node synced?", "what block hash is at height N?", "what's in the mempool?", or "fee estimate for this encoded tx?":
+
+```bash
+# List the methods this node exposes, grouped by family
+dot polkadot.rpc
+
+# Sync / health
+dot polkadot.rpc.system_health --json
+# Output:
+# {
+#   "peers": 131,
+#   "isSyncing": false,
+#   "shouldHavePeers": true
+# }
+
+# Block hash by height (returns latest if no arg)
+dot polkadot.rpc.chain_getBlockHash 1000
+# Output:
+# "0xcf36a1e4a16fc579136137b8388f35490f09c5bdd7b9133835eba907a8b76c30"
+
+# Mempool snapshot — list pending extrinsics
+dot polkadot.rpc.author_pendingExtrinsics --json | jq length
+
+# Fee estimate for an already-encoded extrinsic
+ENCODED=$(dot polkadot.tx.System.remark 0xdead --from alice --encode)
+dot polkadot.rpc.payment_queryInfo "$ENCODED" --json
+
+# Curated --help shows the arg signature and a ⚠️ WRITE tag for state-changing methods
+dot polkadot.rpc.author_insertKey --help
+```
+
+The `rpc` category is **flat** — there's no pallet level. Form: `[chain.]rpc.<method_name>` (underscores stay in the single segment, e.g. `polkadot.rpc.chain_getBlock`).
+
+Subscription methods (`*_subscribe*`, `chainHead_v1_follow`, `transaction_v1_*`) appear in tab-completion but error out as one-shots — they need a follow session. About 50 well-known methods carry curated descriptions and arg names; any other method the node reports is callable via raw passthrough. Use `dot polkadot.rpc --refresh` to re-discover after a node upgrade.
 
 ### Complex Arguments (Location, enums)
 

--- a/dot-cli/references/scripting-patterns.md
+++ b/dot-cli/references/scripting-patterns.md
@@ -289,6 +289,32 @@ dot polkadot-asset-hub.apis.XcmPaymentApi.query_acceptable_payment_assets 5 --js
 
 This is a runtime API — the accepted assets are derived by the runtime (e.g., from existing AMM pools on Asset Hub), not set manually.
 
+### Node-level checks via raw RPC
+
+`dot polkadot.rpc.<method>` covers things that aren't in runtime metadata — sync state, block hashes, mempool, fee estimation, key management.
+
+```bash
+# Wait for the node to finish syncing before scripting against it
+until [ "$(dot polkadot.rpc.system_health --json | jq -r '.isSyncing')" = "false" ]; do
+  sleep 5
+done
+
+# Block hash for a specific height
+HASH=$(dot polkadot.rpc.chain_getBlockHash 1000 --json | tr -d '"')
+
+# Number of pending txs in the mempool
+dot polkadot.rpc.author_pendingExtrinsics --json | jq length
+
+# Pre-submission fee estimate for an encoded extrinsic
+ENCODED=$(dot polkadot.tx.System.remark 0xdead --from alice --encode)
+dot polkadot.rpc.payment_queryInfo "$ENCODED" --json | jq -r '.partialFee'
+
+# List every method this node exposes (useful for capability detection)
+dot polkadot.rpc --json | jq -r '.methods[] | select(.family=="archive") | .method'
+```
+
+The `rpc` category is flat — `[chain.]rpc.<method_name>`, no pallet level. Methods discovered per-chain via `rpc_methods` and cached; refresh with `dot polkadot.rpc --refresh` after a node upgrade. Subscription methods (`*_subscribe*`, `chainHead_v1_*`, `transaction_v1_*`) are not callable as one-shots.
+
 ### Check pool reserves
 
 ```bash
@@ -318,3 +344,5 @@ dot polkadot-asset-hub.apis.AssetConversionApi.get_reserves "$NATIVE" "$ASSET" -
 6. **`--dump` required for keyless map queries.** `dot polkadot.query.System.Account` without a key or `--dump` shows usage help, not results.
 
 7. **Method names are snake_case.** Calls like `Balances.transfer_keep_alive` use the runtime's `snake_case` identifiers. CamelCase variants don't resolve — the fuzzy matcher will suggest the right name.
+
+8. **JSON-RPC method names use underscores, not dots.** `chain_getBlock`, not `chain.getBlock`. The form is `[chain.]rpc.<method_name>` — the underscored token is one segment.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@noble/hashes": "^2.0.1",
     "@polkadot-api/metadata-builders": "^0.14.1",
     "@polkadot-api/substrate-bindings": "^0.20.1",
+    "@polkadot-api/substrate-client": "^0.7.0",
     "@polkadot-api/view-builder": "^0.5.1",
     "@polkadot-labs/hdkd": "^0.0.28",
     "@polkadot-labs/hdkd-helpers": "^0.0.29",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { registerInspectCommand } from "./commands/inspect.ts";
 import { registerMetadataCommand } from "./commands/metadata.ts";
 import { registerParachainCommand } from "./commands/parachain.ts";
 import { handleQuery } from "./commands/query.ts";
+import { handleRpc } from "./commands/rpc.ts";
 import { registerSignCommand } from "./commands/sign.ts";
 import { handleTx } from "./commands/tx.ts";
 import { registerVerifiableCommands } from "./commands/verifiable.ts";
@@ -94,6 +95,7 @@ if (process.argv[2] === "__complete") {
     .option("--mortality <spec>", '"immortal" or period number (for tx)')
     .option("--at <block>", 'Block hash, "best", or "finalized" to validate against (for tx)')
     .option("--unsigned", "Submit as unsigned/bare transaction (no signer required, for tx)")
+    .option("--refresh", "Refresh the cached RPC method list from the node (for rpc)")
     .action(
       async (
         dotpath: string | undefined,
@@ -117,6 +119,7 @@ if (process.argv[2] === "__complete") {
           at?: string;
           unsigned?: boolean;
           dump?: boolean;
+          refresh?: boolean;
           var?: string | string[];
         },
       ) => {
@@ -197,9 +200,12 @@ if (process.argv[2] === "__complete") {
         // Only consume item from args if pallet was also consumed from args,
         // to avoid misinterpreting method arguments as item names
         // (e.g. `dot query.System 0x1234` should NOT treat 0x1234 as an item).
+        // Flat categories (rpc, extensions) only absorb the identifier slot —
+        // any remaining positionals are method arguments, not sub-items.
+        const isFlatCategory = parsed.category === "rpc" || parsed.category === "extensions";
         if (!parsed.pallet && args.length > 0) {
           parsed.pallet = args.shift()!;
-          if (!parsed.item && args.length > 0) {
+          if (!isFlatCategory && !parsed.item && args.length > 0) {
             parsed.item = args.shift()!;
           }
         }
@@ -284,6 +290,22 @@ if (process.argv[2] === "__complete") {
             await handleExtensions(parsed.pallet, handlerOpts);
             break;
           }
+          case "rpc": {
+            if (parsed.item) {
+              const suggestion = parsed.chain
+                ? `dot ${parsed.chain}.rpc.${parsed.pallet}`
+                : opts.chain
+                  ? `dot rpc.${parsed.pallet} --chain ${opts.chain}`
+                  : `dot rpc.${parsed.pallet} --chain <chain>`;
+              throw new CliError(`RPC methods have no sub-items. Try "${suggestion}".`);
+            }
+            await handleRpc(parsed.pallet, args, {
+              ...handlerOpts,
+              help: cli.options.help,
+              refresh: opts.refresh,
+            });
+            break;
+          }
         }
       },
     );
@@ -321,6 +343,7 @@ if (process.argv[2] === "__complete") {
     console.log("  errors    List or inspect pallet errors");
     console.log("  apis      Browse and call runtime APIs");
     console.log("  extensions  List transaction extensions on a chain");
+    console.log("  rpc       Call raw JSON-RPC methods on a node");
     console.log();
     console.log("Examples:");
     console.log("  dot polkadot.query.System.Account <addr>            Query a storage item");
@@ -339,6 +362,10 @@ if (process.argv[2] === "__complete") {
       "  dot polkadot.extensions                             List transaction extensions",
     );
     console.log("  dot polkadot.extensions.CheckMortality              Inspect one extension");
+    console.log(
+      "  dot polkadot.rpc                                    List RPC methods on the node",
+    );
+    console.log("  dot polkadot.rpc.system_health                      Call a JSON-RPC method");
     console.log("  dot query.System.Number --chain polkadot            --chain flag form");
     console.log(
       "  dot ./transfer.yaml --from alice                    Run from file (chain in YAML)",

--- a/src/commands/chain.test.ts
+++ b/src/commands/chain.test.ts
@@ -904,7 +904,8 @@ describe("dot chain", () => {
     expect(stdout).toContain("metadata:");
     expect(stdout).toContain("polkadot v1003000");
     expect(stdout).toContain("2026-04-29T12:34:56.000Z");
-    expect(stdout).not.toContain("not cached");
+    // Metadata block must not be in the "not cached" state.
+    expect(stdout).not.toMatch(/metadata:\s*\n\s*not cached/);
   });
 
   test("info --json on cached chain emits structured metadata block", async () => {

--- a/src/commands/chain.ts
+++ b/src/commands/chain.ts
@@ -4,9 +4,11 @@ import {
   findChainName,
   loadConfig,
   loadMetadataFingerprint,
+  loadRpcMethods,
   removeChainData,
   resolveChain,
   saveConfig,
+  saveRpcMethods,
 } from "../config/store.ts";
 import {
   BUILTIN_CHAIN_NAMES,
@@ -30,6 +32,8 @@ import {
   RESET,
   YELLOW,
 } from "../core/output.ts";
+import { fetchRpcMethods } from "../core/rpc.ts";
+import { inferFamily, RPC_REGISTRY } from "../data/rpc-registry.ts";
 
 const CHAIN_HELP = `
 ${BOLD}Usage:${RESET}
@@ -131,6 +135,26 @@ export function registerChainCommands(cli: CAC) {
     );
 }
 
+/**
+ * Best-effort fetch + cache of the node's `rpc_methods` list. Failures are
+ * non-fatal — the metadata operation that called us still succeeds.
+ */
+async function refreshRpcMethods(
+  chainName: string,
+  rpcUrl: string | string[],
+  silent = false,
+): Promise<void> {
+  try {
+    const { methods, version } = await fetchRpcMethods(rpcUrl);
+    await saveRpcMethods(chainName, methods, version);
+  } catch (err) {
+    if (!silent) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`${YELLOW}Warning:${RESET} could not fetch rpc_methods — ${msg}\n`);
+    }
+  }
+}
+
 async function chainAdd(
   name: string | undefined,
   opts: {
@@ -167,6 +191,7 @@ async function chainAdd(
   try {
     process.stderr.write("Fetching metadata...\n");
     await fetchMetadataFromChain(clientHandle, name);
+    await refreshRpcMethods(name, opts.rpc);
 
     if (opts.relay) {
       const config = await loadConfig();
@@ -349,6 +374,14 @@ async function chainInfo(name: string | undefined, opts: { output?: string; json
     .map(([n, c]) => ({ name: n, parachainId: c.parachainId }));
 
   const fingerprint = await loadMetadataFingerprint(resolved);
+  const rpcCache = await loadRpcMethods(resolved);
+  const rpcSummary = rpcCache
+    ? {
+        count: rpcCache.methods.length,
+        fetchedAt: rpcCache.fetchedAt,
+        byFamily: countByFamily(rpcCache.methods),
+      }
+    : null;
 
   if (isJsonOutput(opts)) {
     console.log(
@@ -365,6 +398,7 @@ async function chainInfo(name: string | undefined, opts: { output?: string; json
               fetchedAt: fingerprint.fetchedAt,
             }
           : null,
+        rpcMethods: rpcSummary,
       }),
     );
     return;
@@ -400,6 +434,26 @@ async function chainInfo(name: string | undefined, opts: { output?: string; json
   } else {
     console.log(`    ${DIM}not cached — run \`dot chain update ${resolved}\`${RESET}`);
   }
+
+  console.log(`  ${CYAN}rpc methods:${RESET}`);
+  if (rpcSummary) {
+    const families = Object.entries(rpcSummary.byFamily)
+      .map(([f, n]) => `${f}: ${n}`)
+      .join(", ");
+    console.log(`    ${rpcSummary.count} ${DIM}(${families})${RESET}`);
+    console.log(`    ${DIM}cached ${rpcSummary.fetchedAt}${RESET}`);
+  } else {
+    console.log(`    ${DIM}not cached — run \`dot chain update ${resolved}\`${RESET}`);
+  }
+}
+
+function countByFamily(methods: string[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const m of methods) {
+    const family = RPC_REGISTRY[m]?.family ?? inferFamily(m);
+    counts[family] = (counts[family] ?? 0) + 1;
+  }
+  return counts;
 }
 
 async function chainUpdate(
@@ -426,6 +480,7 @@ async function chainUpdate(
   try {
     process.stderr.write("Fetching metadata...\n");
     await fetchMetadataFromChain(clientHandle, chainName);
+    await refreshRpcMethods(chainName, opts.rpc ?? chainConfig.rpc);
     if (isJsonOutput(opts)) {
       console.log(formatJson({ action: "updated", chain: chainName }));
     } else {
@@ -461,6 +516,7 @@ async function updateChainsMetadata(
       const clientHandle = await createChainClient(chainName, chainConfig);
       try {
         await fetchMetadataFromChain(clientHandle, chainName);
+        await refreshRpcMethods(chainName, chainConfig.rpc, true);
       } finally {
         clientHandle.destroy();
       }

--- a/src/commands/rpc.test.ts
+++ b/src/commands/rpc.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { runCli } from "./__fixtures__/run-cli.ts";
+
+const RPC_CACHE = JSON.stringify({
+  methods: [
+    "system_health",
+    "system_version",
+    "chain_getBlock",
+    "chain_subscribeAllHeads",
+    "rpc_methods",
+    "exotic_uncurated",
+  ],
+  version: 1,
+  fetchedAt: "2026-05-07T00:00:00.000Z",
+});
+
+const RPC_CACHE_FILES = {
+  ".polkadot/chains/polkadot/rpc-methods.json": RPC_CACHE,
+};
+
+describe("dot rpc", () => {
+  test("--help on a curated method shows description and args", async () => {
+    const { stdout, exitCode } = await runCli(["polkadot.rpc.author_insertKey", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("author_insertKey");
+    expect(stdout).toContain("WRITE");
+    expect(stdout).toContain("keystore");
+    expect(stdout).toContain("<keyType: string>");
+    expect(stdout).toContain("<suri: string>");
+  });
+
+  test("--help on an unknown method shows generic info", async () => {
+    const { stdout, exitCode } = await runCli(["polkadot.rpc.exotic_uncurated", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("exotic_uncurated");
+    expect(stdout).toContain("No curated metadata");
+  });
+
+  test("list mode reads from cache and groups by family", async () => {
+    const { stdout, exitCode } = await runCli(["polkadot.rpc"], { files: RPC_CACHE_FILES });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("RPC methods on polkadot");
+    expect(stdout).toContain("system");
+    expect(stdout).toContain("system_health");
+    expect(stdout).toContain("chain_getBlock");
+  });
+
+  test("list --json emits structured output from cache", async () => {
+    const { stdout, exitCode } = await runCli(["polkadot.rpc", "--json"], {
+      files: RPC_CACHE_FILES,
+    });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.chain).toBe("polkadot");
+    expect(parsed.fromCache).toBe(true);
+    expect(Array.isArray(parsed.methods)).toBe(true);
+    const health = parsed.methods.find((m: { method: string }) => m.method === "system_health");
+    expect(health.family).toBe("system");
+  });
+
+  test("rejects a method not in the node's rpc_methods list", async () => {
+    const { stderr, exitCode } = await runCli(["polkadot.rpc.bogus_method"], {
+      files: RPC_CACHE_FILES,
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("not exposed by the node");
+  });
+
+  test("rejects subscription methods as one-shots", async () => {
+    const { stderr, exitCode } = await runCli(["polkadot.rpc.chain_subscribeAllHeads"], {
+      files: RPC_CACHE_FILES,
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("subscription");
+  });
+
+  test("dotpath with sub-item returns a clear error", async () => {
+    const { stderr, exitCode } = await runCli(["polkadot.rpc.system_health.extra"], {
+      files: RPC_CACHE_FILES,
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("no sub-items");
+  });
+
+  test("rpc.<method> form works without chain prefix when --chain is set", async () => {
+    const { stdout, exitCode } = await runCli(["rpc.system_health", "--help"], {
+      files: RPC_CACHE_FILES,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("system_health");
+  });
+});
+
+describe("dot rpc completions", () => {
+  test("completes method names from cache", async () => {
+    const { stdout, exitCode } = await runCli(["__complete", "--", "polkadot.rpc."], {
+      files: RPC_CACHE_FILES,
+    });
+    expect(exitCode).toBe(0);
+    const lines = stdout.split("\n").filter(Boolean);
+    expect(lines).toContain("polkadot.rpc.system_health");
+    expect(lines).toContain("polkadot.rpc.exotic_uncurated");
+  });
+
+  test("filters by prefix", async () => {
+    const { stdout, exitCode } = await runCli(["__complete", "--", "polkadot.rpc.system_"], {
+      files: RPC_CACHE_FILES,
+    });
+    expect(exitCode).toBe(0);
+    const lines = stdout.split("\n").filter(Boolean);
+    expect(lines.every((l) => l.startsWith("polkadot.rpc.system_"))).toBe(true);
+    expect(lines).toContain("polkadot.rpc.system_health");
+  });
+});

--- a/src/commands/rpc.ts
+++ b/src/commands/rpc.ts
@@ -1,0 +1,235 @@
+import { loadConfig, loadRpcMethods, resolveChain, saveRpcMethods } from "../config/store.ts";
+import {
+  BOLD,
+  CYAN,
+  DIM,
+  formatJson,
+  isJsonOutput,
+  printHeading,
+  printResult,
+  RESET,
+  YELLOW,
+} from "../core/output.ts";
+import { fetchRpcMethods, rpcRequest } from "../core/rpc.ts";
+import {
+  inferFamily,
+  RPC_REGISTRY,
+  type RpcFamily,
+  type RpcMethodInfo,
+} from "../data/rpc-registry.ts";
+import { CliError } from "../utils/errors.ts";
+import { suggestMessage } from "../utils/fuzzy-match.ts";
+import { parseValue } from "../utils/parse-value.ts";
+
+const FAMILY_ORDER: RpcFamily[] = [
+  "system",
+  "chain",
+  "state",
+  "author",
+  "payment",
+  "babe",
+  "grandpa",
+  "beefy",
+  "mmr",
+  "offchain",
+  "dev",
+  "spec",
+  "chainHead",
+  "chainSpec",
+  "transaction",
+  "archive",
+  "other",
+];
+
+interface RpcOpts {
+  chain?: string;
+  rpc?: string;
+  output?: string;
+  json?: boolean;
+  help?: boolean;
+  refresh?: boolean;
+}
+
+/**
+ * Resolve the method list for a chain. Reads cache; on miss (or with refresh)
+ * fetches `rpc_methods` from the node and saves it.
+ */
+async function getMethodList(
+  chainName: string,
+  rpcUrl: string | string[],
+  refresh: boolean,
+): Promise<{ methods: string[]; version: number; fromCache: boolean }> {
+  if (!refresh) {
+    const cached = await loadRpcMethods(chainName);
+    if (cached) {
+      return { methods: cached.methods, version: cached.version, fromCache: true };
+    }
+  }
+  const fresh = await fetchRpcMethods(rpcUrl);
+  await saveRpcMethods(chainName, fresh.methods, fresh.version);
+  return { methods: fresh.methods, version: fresh.version, fromCache: false };
+}
+
+function groupByFamily(methods: string[]): Map<RpcFamily, string[]> {
+  const groups = new Map<RpcFamily, string[]>();
+  for (const m of methods) {
+    const family = RPC_REGISTRY[m]?.family ?? inferFamily(m);
+    const list = groups.get(family) ?? [];
+    list.push(m);
+    groups.set(family, list);
+  }
+  for (const list of groups.values()) list.sort();
+  return groups;
+}
+
+function formatArgs(info: RpcMethodInfo): string {
+  if (info.args.length === 0) return "(no args)";
+  return info.args.map((a) => `<${a.name}: ${a.type}${a.optional ? "?" : ""}>`).join(" ");
+}
+
+function printMethodHelp(method: string, info: RpcMethodInfo | undefined): void {
+  console.log();
+  console.log(`${BOLD}${method}${RESET}`);
+  if (info) {
+    if (info.dangerous) {
+      console.log(`  ${YELLOW}⚠️  WRITE / state-changing${RESET}`);
+    }
+    if (info.subscription) {
+      console.log(`  ${DIM}subscription — not callable as a one-shot${RESET}`);
+    }
+    console.log(`  ${info.description}`);
+    console.log();
+    console.log(`  ${DIM}Family:${RESET} ${info.family}`);
+    console.log(`  ${DIM}Args:${RESET}   ${formatArgs(info)}`);
+    if (info.args.some((a) => a.description)) {
+      console.log();
+      for (const a of info.args) {
+        if (a.description) {
+          console.log(`    ${CYAN}${a.name}${RESET}  ${DIM}${a.description}${RESET}`);
+        }
+      }
+    }
+  } else {
+    console.log(
+      `  ${DIM}No curated metadata. Args are passed through as raw JSON-RPC params.${RESET}`,
+    );
+    console.log(`  ${DIM}Family:${RESET} ${inferFamily(method)} (inferred)`);
+  }
+  console.log();
+}
+
+async function listMethods(chainName: string, rpcUrl: string | string[], opts: RpcOpts) {
+  const { methods, version, fromCache } = await getMethodList(
+    chainName,
+    rpcUrl,
+    opts.refresh ?? false,
+  );
+
+  if (isJsonOutput(opts)) {
+    console.log(
+      formatJson({
+        chain: chainName,
+        version,
+        fromCache,
+        methods: methods.map((m) => {
+          const info = RPC_REGISTRY[m];
+          return {
+            method: m,
+            family: info?.family ?? inferFamily(m),
+            description: info?.description,
+            dangerous: info?.dangerous ?? false,
+            subscription: info?.subscription ?? false,
+          };
+        }),
+      }),
+    );
+    return;
+  }
+
+  printHeading(`RPC methods on ${chainName} (${methods.length})`);
+  const groups = groupByFamily(methods);
+  for (const family of FAMILY_ORDER) {
+    const list = groups.get(family);
+    if (!list || list.length === 0) continue;
+    console.log(`${BOLD}${family}${RESET} ${DIM}(${list.length})${RESET}`);
+    for (const m of list) {
+      const info = RPC_REGISTRY[m];
+      const tags: string[] = [];
+      if (info?.dangerous) tags.push(`${YELLOW}⚠ write${RESET}`);
+      if (info?.subscription) tags.push(`${DIM}sub${RESET}`);
+      const suffix = tags.length > 0 ? ` ${tags.join(" ")}` : "";
+      const desc = info?.description ? `  ${DIM}${info.description}${RESET}` : "";
+      console.log(`  ${CYAN}${m}${RESET}${suffix}${desc}`);
+    }
+    console.log();
+  }
+  if (!fromCache) {
+    console.log(`${DIM}(fetched from node — cached for next run)${RESET}`);
+  }
+}
+
+export async function handleRpc(method: string | undefined, args: string[], opts: RpcOpts) {
+  const config = await loadConfig();
+  const { name: chainName, chain: chainConfig } = resolveChain(config, opts.chain);
+  const rpcUrl = opts.rpc ?? chainConfig.rpc;
+  if (!rpcUrl) {
+    throw new CliError(
+      `No RPC endpoint for chain "${chainName}". Pass --rpc or run \`dot chain add ${chainName} --rpc <url>\`.`,
+    );
+  }
+
+  // List mode
+  if (!method) {
+    await listMethods(chainName, rpcUrl, opts);
+    return;
+  }
+
+  const info = RPC_REGISTRY[method];
+
+  // Help mode
+  if (opts.help) {
+    printMethodHelp(method, info);
+    return;
+  }
+
+  // Validate against discovered method list. On first use, fetch and cache it
+  // so future runs (and tab completion) are instant.
+  const { methods: knownMethods } = await getMethodList(chainName, rpcUrl, opts.refresh ?? false);
+  if (!knownMethods.includes(method)) {
+    const hint = suggestMessage("method", method, knownMethods);
+    throw new CliError(
+      `Method "${method}" is not exposed by the node for "${chainName}".${hint ? ` ${hint}` : ""} ` +
+        `Run \`dot ${chainName}.rpc --refresh\` if the node has been upgraded.`,
+    );
+  }
+
+  // Reject subscription methods — they need follow-state we can't reasonably
+  // provide as a one-shot CLI call.
+  if (info?.subscription) {
+    throw new CliError(
+      `"${method}" is a subscription method (requires a follow session) and is not callable as a one-shot. ` +
+        `Use a long-running client for streaming RPC.`,
+    );
+  }
+  // Detect undeclared subscription-style methods by name (legacy convention).
+  if (!info && /(_subscribe|_unsubscribe)/.test(method)) {
+    throw new CliError(
+      `"${method}" looks like a subscription/unsubscription method and isn't supported as a one-shot. ` +
+        `Pass --help to see what we know about it.`,
+    );
+  }
+
+  // Parse args. If we have curated metadata, validate count.
+  if (info) {
+    const required = info.args.filter((a) => !a.optional).length;
+    if (args.length < required) {
+      throw new CliError(
+        `"${method}" expects at least ${required} argument(s) (${formatArgs(info)}); got ${args.length}.`,
+      );
+    }
+  }
+  const params = args.map(parseValue);
+
+  const result = await rpcRequest<unknown>(rpcUrl, method, params);
+  printResult(result, isJsonOutput(opts) ? "json" : opts.output);
+}

--- a/src/completions/complete.ts
+++ b/src/completions/complete.ts
@@ -1,5 +1,5 @@
 import { loadAccounts } from "../config/accounts-store.ts";
-import { loadConfig, loadMetadata } from "../config/store.ts";
+import { loadConfig, loadMetadata, loadRpcMethods } from "../config/store.ts";
 import type { Config } from "../config/types.ts";
 import { DEV_NAMES } from "../core/accounts.ts";
 import { getAlgorithmNames } from "../core/hash.ts";
@@ -10,8 +10,18 @@ import {
   listRuntimeApis,
   parseMetadata,
 } from "../core/metadata.ts";
+import { RPC_REGISTRY } from "../data/rpc-registry.ts";
 
-const CATEGORIES = ["query", "tx", "const", "events", "errors", "apis", "extensions"] as const;
+const CATEGORIES = [
+  "query",
+  "tx",
+  "const",
+  "events",
+  "errors",
+  "apis",
+  "extensions",
+  "rpc",
+] as const;
 
 const CATEGORY_ALIASES: Record<string, string> = {
   query: "query",
@@ -28,6 +38,7 @@ const CATEGORY_ALIASES: Record<string, string> = {
   extensions: "extensions",
   extension: "extensions",
   ext: "extensions",
+  rpc: "rpc",
 };
 
 const NAMED_COMMANDS = ["chain", "account", "inspect", "hash", "sign", "parachain", "completions"];
@@ -285,6 +296,11 @@ async function completeDotpath(
       );
     }
 
+    // RPC methods are also flat: <category>.<method_name>
+    if (category === "rpc") {
+      return completeRpcCategory(first, numComplete, endsWithDot, currentWord, chainFromFlag);
+    }
+
     if (numComplete === 1 && endsWithDot) {
       // "category." → pallet names
       const chainName = chainFromFlag;
@@ -363,6 +379,16 @@ async function completeDotpath(
           endsWithDot,
           currentWord,
           config,
+          chainName,
+        );
+      }
+
+      if (category === "rpc") {
+        return completeRpcCategory(
+          `${first}.${completeSegments[1]!}`,
+          numComplete - 1,
+          endsWithDot,
+          currentWord,
           chainName,
         );
       }
@@ -471,6 +497,39 @@ async function completeExtensionsCategory(
   if (!chainName) return [];
   const names = await loadExtensionIdentifiers(config, chainName);
   if (!names) return [];
+
+  if (numComplete === 1 && endsWithDot) {
+    const candidates = names.map((n) => `${prefix}.${n}`);
+    return filterPrefix(candidates, currentWord.slice(0, -1));
+  }
+
+  if (numComplete === 1 && !endsWithDot) {
+    const candidates = names.map((n) => `${prefix}.${n}`);
+    return filterPrefix(candidates, currentWord);
+  }
+
+  return [];
+}
+
+/**
+ * Complete JSON-RPC method names for the `rpc` category.
+ * Flat: `[chain.]rpc.<method>`. Sources candidates from the cached
+ * `rpc_methods` list; falls back to the curated registry when no cache exists.
+ */
+async function completeRpcCategory(
+  prefix: string,
+  numComplete: number,
+  endsWithDot: boolean,
+  currentWord: string,
+  chainNameOverride?: string,
+): Promise<string[]> {
+  let names: string[];
+  if (chainNameOverride) {
+    const cached = await loadRpcMethods(chainNameOverride);
+    names = cached?.methods ?? Object.keys(RPC_REGISTRY);
+  } else {
+    names = Object.keys(RPC_REGISTRY);
+  }
 
   if (numComplete === 1 && endsWithDot) {
     const candidates = names.map((n) => `${prefix}.${n}`);

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -27,6 +27,16 @@ export function getMetadataFingerprintPath(chainName: string): string {
   return join(getChainDir(chainName), "metadata.fingerprint.json");
 }
 
+export function getRpcMethodsPath(chainName: string): string {
+  return join(getChainDir(chainName), "rpc-methods.json");
+}
+
+export interface RpcMethodsCache {
+  methods: string[];
+  version: number;
+  fetchedAt: string;
+}
+
 function getConfigPath(): string {
   return join(getConfigDir(), "config.json");
 }
@@ -106,6 +116,40 @@ export async function loadMetadataFingerprint(
   } catch {
     return null;
   }
+}
+
+export async function loadRpcMethods(chainName: string): Promise<RpcMethodsCache | null> {
+  const path = getRpcMethodsPath(chainName);
+  if (!(await fileExists(path))) return null;
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf-8"));
+    if (
+      parsed &&
+      Array.isArray(parsed.methods) &&
+      typeof parsed.version === "number" &&
+      typeof parsed.fetchedAt === "string"
+    ) {
+      return parsed as RpcMethodsCache;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveRpcMethods(
+  chainName: string,
+  methods: string[],
+  version: number,
+): Promise<void> {
+  const dir = getChainDir(chainName);
+  await ensureDir(dir);
+  const cache: RpcMethodsCache = {
+    methods,
+    version,
+    fetchedAt: new Date().toISOString(),
+  };
+  await writeFile(getRpcMethodsPath(chainName), `${JSON.stringify(cache, null, 2)}\n`);
 }
 
 export async function removeChainData(chainName: string): Promise<void> {

--- a/src/core/rpc.ts
+++ b/src/core/rpc.ts
@@ -1,0 +1,78 @@
+import { createClient as createSubstrateClient } from "@polkadot-api/substrate-client";
+import { getWsProvider } from "polkadot-api/ws";
+import { ConnectionError } from "../utils/errors.ts";
+
+export interface RpcMethodsResponse {
+  methods: string[];
+  version: number;
+}
+
+function suppressProviderNoise(): () => void {
+  const origError = console.error;
+  console.error = (...args: unknown[]) => {
+    if (typeof args[0] === "string" && args[0].includes("Unable to connect")) return;
+    origError(...args);
+  };
+  return () => {
+    console.error = origError;
+  };
+}
+
+/**
+ * Send a single raw JSON-RPC request to a node and return the result.
+ *
+ * Opens a one-shot sidecar WebSocket provider — does not share the connection
+ * with the metadata-aware polkadot-api client. This is intentional: the chainHead
+ * follow stream that the high-level client maintains is unrelated to legacy
+ * one-shot RPC calls and would only complicate cleanup.
+ */
+export async function rpcRequest<T>(
+  rpcUrl: string | string[],
+  method: string,
+  params: unknown[],
+  timeoutMs = 30_000,
+): Promise<T> {
+  const restoreConsole = suppressProviderNoise();
+  const provider = getWsProvider(rpcUrl, { timeout: 10_000 });
+  const client = createSubstrateClient(provider);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await client.request<T>(method, params, controller.signal);
+  } catch (err) {
+    if (err instanceof Error && /Unable to connect/i.test(err.message)) {
+      throw new ConnectionError(
+        `Could not reach RPC ${Array.isArray(rpcUrl) ? rpcUrl.join(", ") : rpcUrl}: ${err.message}`,
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+    try {
+      client.destroy();
+    } catch {
+      // benign teardown race
+    }
+    setTimeout(restoreConsole, 100);
+  }
+}
+
+/**
+ * Discover the JSON-RPC methods this node exposes via the standard
+ * `rpc_methods` endpoint. Returns `{methods, version}` per the spec.
+ */
+export async function fetchRpcMethods(rpcUrl: string | string[]): Promise<RpcMethodsResponse> {
+  const result = await rpcRequest<{ methods: string[]; version?: number }>(
+    rpcUrl,
+    "rpc_methods",
+    [],
+  );
+  if (!result || !Array.isArray(result.methods)) {
+    throw new ConnectionError(
+      "Node returned an unexpected response for rpc_methods (no methods array).",
+    );
+  }
+  return { methods: result.methods, version: result.version ?? 1 };
+}

--- a/src/data/rpc-registry.test.ts
+++ b/src/data/rpc-registry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { inferFamily, RPC_REGISTRY } from "./rpc-registry.ts";
+
+describe("RPC_REGISTRY", () => {
+  test("every entry has a family and description", () => {
+    for (const [method, info] of Object.entries(RPC_REGISTRY)) {
+      expect(info.family, `${method} missing family`).toBeTruthy();
+      expect(info.description, `${method} missing description`).toBeTruthy();
+      expect(info.description.length, `${method} description too short`).toBeGreaterThan(5);
+    }
+  });
+
+  test("dangerous methods include state-changing flavors", () => {
+    expect(RPC_REGISTRY.author_insertKey?.dangerous).toBe(true);
+    expect(RPC_REGISTRY.author_rotateKeys?.dangerous).toBe(true);
+    expect(RPC_REGISTRY.author_submitExtrinsic?.dangerous).toBe(true);
+    expect(RPC_REGISTRY.dev_newBlock?.dangerous).toBe(true);
+    expect(RPC_REGISTRY.dev_setHead?.dangerous).toBe(true);
+    expect(RPC_REGISTRY.system_addLogFilter?.dangerous).toBe(true);
+    expect(RPC_REGISTRY.offchain_localStorageSet?.dangerous).toBe(true);
+  });
+
+  test("read-only methods are not flagged dangerous", () => {
+    expect(RPC_REGISTRY.system_health?.dangerous).toBeFalsy();
+    expect(RPC_REGISTRY.chain_getBlock?.dangerous).toBeFalsy();
+    expect(RPC_REGISTRY.payment_queryInfo?.dangerous).toBeFalsy();
+    expect(RPC_REGISTRY.rpc_methods?.dangerous).toBeFalsy();
+  });
+
+  test("subscription methods are flagged", () => {
+    expect(RPC_REGISTRY.chain_subscribeAllHeads?.subscription).toBe(true);
+    expect(RPC_REGISTRY.chain_subscribeFinalizedHeads?.subscription).toBe(true);
+    expect(RPC_REGISTRY.chain_subscribeNewHeads?.subscription).toBe(true);
+    expect(RPC_REGISTRY.state_subscribeStorage?.subscription).toBe(true);
+    expect(RPC_REGISTRY.chainHead_v1_follow?.subscription).toBe(true);
+    expect(RPC_REGISTRY.transaction_v1_broadcast?.subscription).toBe(true);
+  });
+
+  test("required args precede optional args (so positional parsing is unambiguous)", () => {
+    for (const [method, info] of Object.entries(RPC_REGISTRY)) {
+      let seenOptional = false;
+      for (const arg of info.args) {
+        if (arg.optional) {
+          seenOptional = true;
+        } else if (seenOptional) {
+          throw new Error(`${method}: required arg "${arg.name}" follows an optional arg`);
+        }
+      }
+    }
+  });
+});
+
+describe("inferFamily", () => {
+  test("maps standard prefixes by underscore", () => {
+    expect(inferFamily("system_health")).toBe("system");
+    expect(inferFamily("chain_getBlock")).toBe("chain");
+    expect(inferFamily("state_getStorage")).toBe("state");
+    expect(inferFamily("author_pendingExtrinsics")).toBe("author");
+    expect(inferFamily("payment_queryInfo")).toBe("payment");
+    expect(inferFamily("babe_epochAuthorship")).toBe("babe");
+    expect(inferFamily("grandpa_proveFinality")).toBe("grandpa");
+    expect(inferFamily("beefy_getFinalizedHead")).toBe("beefy");
+    expect(inferFamily("mmr_root")).toBe("mmr");
+    expect(inferFamily("offchain_localStorageGet")).toBe("offchain");
+    expect(inferFamily("dev_newBlock")).toBe("dev");
+  });
+
+  test("maps new-spec prefixes", () => {
+    expect(inferFamily("chainHead_v1_follow")).toBe("chainHead");
+    expect(inferFamily("chainSpec_v1_chainName")).toBe("chainSpec");
+    expect(inferFamily("transaction_v1_broadcast")).toBe("transaction");
+    expect(inferFamily("archive_v1_finalizedHeight")).toBe("archive");
+  });
+
+  test("rpc_methods maps to the spec family", () => {
+    expect(inferFamily("rpc_methods")).toBe("spec");
+  });
+
+  test("unknown prefixes fall back to other", () => {
+    expect(inferFamily("custompallet_foo")).toBe("other");
+    expect(inferFamily("nounderscore")).toBe("other");
+  });
+});

--- a/src/data/rpc-registry.ts
+++ b/src/data/rpc-registry.ts
@@ -1,0 +1,536 @@
+/**
+ * Hand-curated metadata for well-known JSON-RPC methods. Used to render
+ * `--help`, group `--list` output, and tag dangerous calls. Methods not in
+ * this registry still work — they fall back to raw passthrough.
+ *
+ * The full set of methods a node exposes is discovered at runtime via
+ * `rpc_methods` and cached per chain.
+ */
+
+export type RpcFamily =
+  | "system"
+  | "chain"
+  | "state"
+  | "author"
+  | "payment"
+  | "babe"
+  | "grandpa"
+  | "beefy"
+  | "mmr"
+  | "offchain"
+  | "dev"
+  | "spec"
+  | "chainHead"
+  | "chainSpec"
+  | "transaction"
+  | "archive"
+  | "other";
+
+export interface RpcArg {
+  name: string;
+  type: string;
+  optional?: boolean;
+  description?: string;
+}
+
+export interface RpcMethodInfo {
+  description: string;
+  family: RpcFamily;
+  args: RpcArg[];
+  /** Mutates node/keystore/chain state. Tagged WRITE in --help. */
+  dangerous?: boolean;
+  /** Subscription method — not callable as a one-shot. */
+  subscription?: boolean;
+}
+
+export const RPC_REGISTRY: Record<string, RpcMethodInfo> = {
+  // ---------------- system ----------------
+  system_health: {
+    description: "Node sync state (peers, isSyncing, shouldHavePeers).",
+    family: "system",
+    args: [],
+  },
+  system_syncState: {
+    description: "Block-level sync progress (startingBlock, currentBlock, highestBlock).",
+    family: "system",
+    args: [],
+  },
+  system_version: {
+    description: "Node software version string.",
+    family: "system",
+    args: [],
+  },
+  system_name: {
+    description: "Node implementation name.",
+    family: "system",
+    args: [],
+  },
+  system_chain: {
+    description: "Chain name as reported by the node.",
+    family: "system",
+    args: [],
+  },
+  system_chainType: {
+    description: "Chain type (Live, Development, Local).",
+    family: "system",
+    args: [],
+  },
+  system_properties: {
+    description: "Chain properties (ss58Format, tokenDecimals, tokenSymbol).",
+    family: "system",
+    args: [],
+  },
+  system_peers: {
+    description: "Connected peer details (peerId, roles, bestHash, bestNumber).",
+    family: "system",
+    args: [],
+  },
+  system_localPeerId: {
+    description: "Base58 PeerId of this node.",
+    family: "system",
+    args: [],
+  },
+  system_localListenAddresses: {
+    description: "Multiaddrs this node listens on.",
+    family: "system",
+    args: [],
+  },
+  system_nodeRoles: {
+    description: "Role(s) of the node (Authority, Full, Light, …).",
+    family: "system",
+    args: [],
+  },
+  system_addLogFilter: {
+    description: "Add a tracing/log filter directive at runtime.",
+    family: "system",
+    args: [{ name: "directives", type: "string" }],
+    dangerous: true,
+  },
+  system_resetLogFilter: {
+    description: "Reset log filter to the default set at startup.",
+    family: "system",
+    args: [],
+    dangerous: true,
+  },
+  system_accountNextIndex: {
+    description: "Next nonce for an account, including pending mempool extrinsics.",
+    family: "system",
+    args: [{ name: "address", type: "AccountId" }],
+  },
+  system_dryRun: {
+    description: "Dry-run an extrinsic, returning its ApplyExtrinsicResult.",
+    family: "system",
+    args: [
+      { name: "extrinsic", type: "hex" },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+
+  // ---------------- chain ----------------
+  chain_getBlock: {
+    description: "Full block (header + extrinsics) by hash.",
+    family: "chain",
+    args: [{ name: "blockHash", type: "H256", optional: true, description: "latest if omitted" }],
+  },
+  chain_getBlockHash: {
+    description: "Block hash by number, or latest if omitted.",
+    family: "chain",
+    args: [{ name: "blockNumber", type: "u32", optional: true }],
+  },
+  chain_getFinalizedHead: {
+    description: "Hash of the latest finalized head.",
+    family: "chain",
+    args: [],
+  },
+  chain_getHeader: {
+    description: "Block header by hash, or latest if omitted.",
+    family: "chain",
+    args: [{ name: "blockHash", type: "H256", optional: true }],
+  },
+  chain_subscribeAllHeads: {
+    description: "Subscribe to all imported headers.",
+    family: "chain",
+    args: [],
+    subscription: true,
+  },
+  chain_subscribeFinalizedHeads: {
+    description: "Subscribe to finalized-head changes.",
+    family: "chain",
+    args: [],
+    subscription: true,
+  },
+  chain_subscribeNewHeads: {
+    description: "Subscribe to best-block-head changes.",
+    family: "chain",
+    args: [],
+    subscription: true,
+  },
+
+  // ---------------- state ----------------
+  state_call: {
+    description: "Invoke a runtime API method by name with raw SCALE-encoded arguments.",
+    family: "state",
+    args: [
+      { name: "method", type: "string", description: "e.g. Core_version" },
+      { name: "data", type: "hex", description: "SCALE-encoded args (0x for none)" },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+  state_getMetadata: {
+    description: "Raw SCALE-encoded runtime metadata at a block.",
+    family: "state",
+    args: [{ name: "at", type: "H256", optional: true }],
+  },
+  state_getRuntimeVersion: {
+    description: "Runtime version at a block.",
+    family: "state",
+    args: [{ name: "at", type: "H256", optional: true }],
+  },
+  state_getStorage: {
+    description: "Raw SCALE-encoded storage value at a key.",
+    family: "state",
+    args: [
+      { name: "key", type: "StorageKey" },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+  state_getStorageHash: {
+    description: "Blake2 hash of the value at a storage key.",
+    family: "state",
+    args: [
+      { name: "key", type: "StorageKey" },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+  state_getStorageSize: {
+    description: "Byte length of the value at a storage key.",
+    family: "state",
+    args: [
+      { name: "key", type: "StorageKey" },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+  state_getKeysPaged: {
+    description: "Paginated key iteration under a prefix.",
+    family: "state",
+    args: [
+      { name: "prefix", type: "StorageKey" },
+      { name: "count", type: "u32" },
+      { name: "startKey", type: "StorageKey", optional: true },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+  state_queryStorageAt: {
+    description: "Read multiple keys at a single block.",
+    family: "state",
+    args: [
+      { name: "keys", type: "StorageKey[]" },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+  state_traceBlock: {
+    description: "Per-block storage access trace (heavy: archival/debug nodes only).",
+    family: "state",
+    args: [
+      { name: "blockHash", type: "H256" },
+      { name: "targets", type: "string", optional: true },
+      { name: "storageKeys", type: "string", optional: true },
+      { name: "methods", type: "string", optional: true },
+    ],
+  },
+  state_subscribeRuntimeVersion: {
+    description: "Subscribe to runtime upgrades.",
+    family: "state",
+    args: [],
+    subscription: true,
+  },
+  state_subscribeStorage: {
+    description: "Subscribe to changes for a set of keys.",
+    family: "state",
+    args: [{ name: "keys", type: "StorageKey[]" }],
+    subscription: true,
+  },
+
+  // ---------------- author ----------------
+  author_pendingExtrinsics: {
+    description: "Mempool snapshot — encoded extrinsics waiting to be included.",
+    family: "author",
+    args: [],
+  },
+  author_submitExtrinsic: {
+    description: "Submit a signed extrinsic to the mempool. Returns the tx hash.",
+    family: "author",
+    args: [{ name: "extrinsic", type: "hex" }],
+    dangerous: true,
+  },
+  author_removeExtrinsic: {
+    description: "Remove specific extrinsics from the mempool by hash.",
+    family: "author",
+    args: [{ name: "bytesOrHash", type: "ExtrinsicOrHash[]" }],
+    dangerous: true,
+  },
+  author_hasKey: {
+    description: "Whether the keystore has the public key for a given key type.",
+    family: "author",
+    args: [
+      { name: "publicKey", type: "hex" },
+      { name: "keyType", type: "string", description: "e.g. babe, gran, imon" },
+    ],
+  },
+  author_hasSessionKeys: {
+    description: "Whether the keystore has all keys for a session-keys blob.",
+    family: "author",
+    args: [{ name: "sessionKeys", type: "hex" }],
+  },
+  author_rotateKeys: {
+    description: "Generate a new set of session keys and return the public-keys blob.",
+    family: "author",
+    args: [],
+    dangerous: true,
+  },
+  author_insertKey: {
+    description: "Insert a key into the node keystore.",
+    family: "author",
+    args: [
+      { name: "keyType", type: "string" },
+      { name: "suri", type: "string" },
+      { name: "publicKey", type: "hex" },
+    ],
+    dangerous: true,
+  },
+  author_submitAndWatchExtrinsic: {
+    description: "Submit an extrinsic and subscribe to its status updates.",
+    family: "author",
+    args: [{ name: "extrinsic", type: "hex" }],
+    dangerous: true,
+    subscription: true,
+  },
+
+  // ---------------- payment ----------------
+  payment_queryInfo: {
+    description: "Pre-submission fee estimate (weight, partialFee, class).",
+    family: "payment",
+    args: [
+      { name: "extrinsic", type: "hex" },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+  payment_queryFeeDetails: {
+    description: "Fee breakdown (baseFee, lenFee, adjustedWeightFee, tip).",
+    family: "payment",
+    args: [
+      { name: "extrinsic", type: "hex" },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+
+  // ---------------- consensus / proofs ----------------
+  babe_epochAuthorship: {
+    description: "Slots this node is allowed to author in the current epoch.",
+    family: "babe",
+    args: [],
+  },
+  grandpa_proveFinality: {
+    description: "Finality proof up to a block (for light clients).",
+    family: "grandpa",
+    args: [{ name: "blockNumber", type: "u32" }],
+  },
+  grandpa_roundState: {
+    description: "GRANDPA round state (best round, total weight, voters).",
+    family: "grandpa",
+    args: [],
+  },
+  grandpa_subscribeJustifications: {
+    description: "Subscribe to GRANDPA justifications.",
+    family: "grandpa",
+    args: [],
+    subscription: true,
+  },
+  beefy_getFinalizedHead: {
+    description: "Latest BEEFY-finalized block hash.",
+    family: "beefy",
+    args: [],
+  },
+  beefy_subscribeJustifications: {
+    description: "Subscribe to BEEFY signed commitments.",
+    family: "beefy",
+    args: [],
+    subscription: true,
+  },
+  mmr_root: {
+    description: "MMR root at a block.",
+    family: "mmr",
+    args: [{ name: "at", type: "H256", optional: true }],
+  },
+  mmr_generateProof: {
+    description: "Generate an MMR proof for given leaf indices.",
+    family: "mmr",
+    args: [
+      { name: "blockNumbers", type: "u32[]" },
+      { name: "bestKnownBlockNumber", type: "u32", optional: true },
+      { name: "at", type: "H256", optional: true },
+    ],
+  },
+  mmr_verifyProof: {
+    description: "Verify an MMR proof.",
+    family: "mmr",
+    args: [{ name: "proof", type: "MmrLeavesProof" }],
+  },
+
+  // ---------------- offchain ----------------
+  offchain_localStorageGet: {
+    description: "Read from offchain-worker local storage (PERSISTENT or LOCAL kind).",
+    family: "offchain",
+    args: [
+      { name: "kind", type: "string", description: "PERSISTENT or LOCAL" },
+      { name: "key", type: "hex" },
+    ],
+  },
+  offchain_localStorageSet: {
+    description: "Write to offchain-worker local storage.",
+    family: "offchain",
+    args: [
+      { name: "kind", type: "string" },
+      { name: "key", type: "hex" },
+      { name: "value", type: "hex" },
+    ],
+    dangerous: true,
+  },
+
+  // ---------------- dev ----------------
+  dev_newBlock: {
+    description: "Manually trigger block production (manual-seal dev nodes).",
+    family: "dev",
+    args: [
+      {
+        name: "params",
+        type: "json",
+        optional: true,
+        description: "{ create_empty?: bool, finalize?: bool }",
+      },
+    ],
+    dangerous: true,
+  },
+  dev_setHead: {
+    description: "Set the chain head to a specific block (manual-seal dev nodes).",
+    family: "dev",
+    args: [{ name: "blockHash", type: "H256" }],
+    dangerous: true,
+  },
+
+  // ---------------- discovery ----------------
+  rpc_methods: {
+    description: "List of JSON-RPC methods this node exposes.",
+    family: "spec",
+    args: [],
+  },
+
+  // ---------------- new-spec: chainSpec ----------------
+  chainSpec_v1_chainName: {
+    description: "Chain name from the chain spec (no SCALE).",
+    family: "chainSpec",
+    args: [],
+  },
+  chainSpec_v1_genesisHash: {
+    description: "Genesis block hash.",
+    family: "chainSpec",
+    args: [],
+  },
+  chainSpec_v1_properties: {
+    description: "Chain properties from the chain spec.",
+    family: "chainSpec",
+    args: [],
+  },
+
+  // ---------------- new-spec: archive ----------------
+  archive_v1_finalizedHeight: {
+    description: "Latest finalized block number this archive node has.",
+    family: "archive",
+    args: [],
+  },
+  archive_v1_genesisHash: {
+    description: "Genesis block hash from the archive node.",
+    family: "archive",
+    args: [],
+  },
+  archive_v1_hashByHeight: {
+    description: "Block hashes at a height (canonical + forks).",
+    family: "archive",
+    args: [{ name: "height", type: "u32" }],
+  },
+  archive_v1_header: {
+    description: "Header for an archived block.",
+    family: "archive",
+    args: [{ name: "blockHash", type: "H256" }],
+  },
+  archive_v1_body: {
+    description: "Block body (extrinsics) for an archived block.",
+    family: "archive",
+    args: [{ name: "blockHash", type: "H256" }],
+  },
+  archive_v1_call: {
+    description: "Invoke a runtime API at an archived block.",
+    family: "archive",
+    args: [
+      { name: "blockHash", type: "H256" },
+      { name: "function", type: "string" },
+      { name: "callParameters", type: "hex" },
+    ],
+  },
+  archive_v1_storage: {
+    description: "Read storage at an archived block.",
+    family: "archive",
+    args: [
+      { name: "blockHash", type: "H256" },
+      { name: "items", type: "StorageItemInput[]" },
+      { name: "childTrie", type: "string", optional: true },
+    ],
+    subscription: true,
+  },
+
+  // ---------------- new-spec: chainHead / transaction (subscription-only) ----------------
+  chainHead_v1_follow: {
+    description: "Pin chainHead and stream block events. Requires a follow session.",
+    family: "chainHead",
+    args: [{ name: "withRuntime", type: "bool" }],
+    subscription: true,
+  },
+  transaction_v1_broadcast: {
+    description: "Broadcast a signed extrinsic and watch its status.",
+    family: "transaction",
+    args: [{ name: "extrinsic", type: "hex" }],
+    dangerous: true,
+    subscription: true,
+  },
+};
+
+/** Detect family from a method name when it isn't in the registry. */
+export function inferFamily(method: string): RpcFamily {
+  const prefix = method.split("_")[0];
+  switch (prefix) {
+    case "system":
+    case "chain":
+    case "state":
+    case "author":
+    case "payment":
+    case "babe":
+    case "grandpa":
+    case "beefy":
+    case "mmr":
+    case "offchain":
+    case "dev":
+      return prefix;
+    case "rpc":
+      return "spec";
+    case "chainHead":
+      return "chainHead";
+    case "chainSpec":
+      return "chainSpec";
+    case "transaction":
+      return "transaction";
+    case "archive":
+      return "archive";
+    default:
+      return "other";
+  }
+}

--- a/src/utils/parse-dot-path.test.ts
+++ b/src/utils/parse-dot-path.test.ts
@@ -253,6 +253,40 @@ describe("parseDotPath", () => {
     });
   });
 
+  // --- rpc category (flat: identifier in `pallet` slot, like extensions) ---
+  test("rpc → category only", () => {
+    expect(parseDotPath("rpc", knownChains)).toEqual({ category: "rpc" });
+  });
+
+  test("rpc.system_health → category + method", () => {
+    expect(parseDotPath("rpc.system_health", knownChains)).toEqual({
+      category: "rpc",
+      pallet: "system_health",
+    });
+  });
+
+  test("rpc.chain_getBlock → underscored method as a single segment", () => {
+    expect(parseDotPath("rpc.chain_getBlock", knownChains)).toEqual({
+      category: "rpc",
+      pallet: "chain_getBlock",
+    });
+  });
+
+  test("polkadot.rpc.system_health → chain + category + method", () => {
+    expect(parseDotPath("polkadot.rpc.system_health", knownChains)).toEqual({
+      chain: "polkadot",
+      category: "rpc",
+      pallet: "system_health",
+    });
+  });
+
+  test("polkadot.rpc → chain + category", () => {
+    expect(parseDotPath("polkadot.rpc", knownChains)).toEqual({
+      chain: "polkadot",
+      category: "rpc",
+    });
+  });
+
   // --- Hyphenated chain names ---
   test("polkadot-asset-hub.query → hyphenated chain name (not split on dots)", () => {
     // Note: "polkadot-asset-hub" has no dots, so it works with split on "."

--- a/src/utils/parse-dot-path.ts
+++ b/src/utils/parse-dot-path.ts
@@ -1,4 +1,12 @@
-export type DotCategory = "query" | "tx" | "const" | "events" | "errors" | "apis" | "extensions";
+export type DotCategory =
+  | "query"
+  | "tx"
+  | "const"
+  | "events"
+  | "errors"
+  | "apis"
+  | "extensions"
+  | "rpc";
 
 export interface ParsedDotPath {
   chain?: string;
@@ -22,6 +30,7 @@ const CATEGORY_ALIASES: Record<string, DotCategory> = {
   extensions: "extensions",
   extension: "extensions",
   ext: "extensions",
+  rpc: "rpc",
 };
 
 function matchCategory(segment: string): DotCategory | undefined {
@@ -49,7 +58,7 @@ export function parseDotPath(input: string, knownChains: string[] = []): ParsedD
       const cat = matchCategory(parts[0]!);
       if (cat) return { category: cat };
       throw new Error(
-        `Unknown command "${parts[0]}". Expected a category (query, tx, const, events, errors, apis, extensions) or a named command.`,
+        `Unknown command "${parts[0]}". Expected a category (query, tx, const, events, errors, apis, extensions, rpc) or a named command.`,
       );
     }
 


### PR DESCRIPTION
Closes #196.

## Summary

- New `rpc` dotpath category exposes the node's JSON-RPC surface (`system_*`, `chain_*`, `state_*`, `author_*`, `payment_*`, `babe_*`/`grandpa_*`/`mmr_*`/`beefy_*`, `dev_*`, plus the new spec `chainSpec_v1_*` / `archive_v1_*` / `rpc_methods`) — previously unreachable from this CLI because it lives outside runtime metadata.
- Methods are discovered per-chain via the standard `rpc_methods` JSON-RPC call and cached at `~/.polkadot/chains/<chain>/rpc-methods.json`. Tab completion sources from the cache.
- ~50 well-known methods carry curated metadata (description, named args, `⚠️ WRITE` tag for state-changing calls); unknown methods work via raw passthrough.
- Subscription methods (`*_subscribe*`, `chainHead_v1_follow`, `transaction_v1_*`) appear in completion but error out as one-shots with a helpful message.
- `dot chain add` / `dot chain update` now also fetch + cache the method list; `dot chain info` shows a per-family breakdown.

## UX

```
dot polkadot.rpc                                    # list, grouped by family
dot polkadot.rpc.system_health                      # call a method
dot polkadot.rpc.chain_getBlockHash 1000            # positional args
dot polkadot.rpc.author_insertKey --help            # curated description + args
dot polkadot.rpc --refresh                          # re-discover after node upgrade
dot polkadot.rpc.<TAB>                              # complete from cache
```

The category is **flat** — `[chain.]rpc.<method_name>`, no pallet level. Underscored method names (`chain_getBlock`) sit in a single dotpath segment.

## Implementation

- `src/utils/parse-dot-path.ts` — `rpc` added as a category alias (parser already supports flat categories via the `extensions` precedent)
- `src/commands/rpc.ts` (new) — `handleRpc()` with list / `--help` / run / `--refresh` modes; validates against the cached method list, rejects subscriptions, falls back to raw passthrough for uncurated methods
- `src/core/rpc.ts` (new) — thin `rpcRequest()` and `fetchRpcMethods()` over `@polkadot-api/substrate-client` (sidecar provider, doesn't share the metadata-aware client connection)
- `src/data/rpc-registry.ts` (new) — curated `{description, args, family, dangerous, subscription}` for ~50 methods + `inferFamily()`
- `src/config/store.ts` — `loadRpcMethods` / `saveRpcMethods` / `getRpcMethodsPath`
- `src/completions/complete.ts` — `completeRpcCategory` modelled on `completeExtensionsCategory`
- `src/cli.ts` — dispatch branch, `--refresh` option, fixes flat-category arg absorption (positional rpc args were being mis-absorbed as a sub-item)
- `src/commands/chain.ts` — `refreshRpcMethods` helper (best-effort, non-fatal); wires into `chain add` / `chain update` / `chain update --all`; `chain info` family breakdown

## Tests

- `src/commands/rpc.test.ts` (10 tests) — `--help`, list mode, JSON output, validation, subscription rejection, sub-item rejection, completions
- `src/data/rpc-registry.test.ts` (9 tests) — registry invariants (every entry has family + description, dangerous/subscription flags consistent, required args precede optional), `inferFamily` mapping
- `src/utils/parse-dot-path.test.ts` (+5 tests) — `rpc.<method>`, `chain.rpc.<method>`, underscored method names

**1485 / 1485 passing.** Coverage delta: −0.32 pp Funcs, −0.52 pp Lines (new `loadRpcMethods`/`saveRpcMethods` are file I/O wrappers; per the existing repo convention they're tested via subprocess rather than direct in-process calls — `bun test --concurrent` races on `DOT_HOME` mutation, see the comment in `accounts-store.test.ts`). New `rpc-registry.ts` is at 100 / 100.

## Documentation

- `README.md` — added "Raw JSON-RPC" section between Transaction extensions and Submit extrinsics; feature entry; categories list
- `docs/content/_index.md` — same section in the docs site
- `dot-cli/SKILL.md` — extended trigger keywords (JSON-RPC, `system_health`, `rpc_methods`); added "Raw JSON-RPC" section after Runtime APIs
- `dot-cli/references/scripting-patterns.md` — "Node-level checks via raw RPC" subsection (sync wait loop, block hash, mempool size, fee estimation, capability detection) + a gotcha about underscored method names
- `.changeset/feature-rpc-methods.md` — minor bump

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun test` — 1485 / 1485 passing
- [x] `dot polkadot.rpc.system_health` against polkadot from a fresh `DOT_HOME`
- [x] `dot polkadot.rpc.chain_getBlockHash 1000` returns a block hash
- [x] `dot polkadot.rpc.author_insertKey --help` shows ⚠️ WRITE tag and arg signature
- [x] `dot polkadot.rpc.bogus_method` → suggestion + clear error
- [x] `dot polkadot.rpc.chain_subscribeAllHeads` → "subscription, not callable as a one-shot"
- [x] `dot polkadot.rpc.<TAB>` completes from cache
- [x] `dot chain info polkadot` shows the per-family breakdown
- [x] All README / docs / skill examples runnable from a fresh install (`DOT_HOME=/tmp/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)