### PR TITLE
chore(deps): upgrade verifiablejs to 1.3.0-beta.2

### DIFF
--- a/.changeset/verifiablejs-beta.md
+++ b/.changeset/verifiablejs-beta.md
@@ -1,0 +1,8 @@
+---
+"polkadot-cli": patch
+---
+
+chore(deps): upgrade `verifiablejs` to `1.3.0-beta.2`
+
+Tracks the upstream beta. The CLI only consumes `member_from_entropy`,
+whose signature is unchanged, so `dot verifiable` output is byte-identical.

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@scure/sr25519": "^1.0.0",
         "cac": "^6.7.14",
         "polkadot-api": "^2.0.1",
-        "verifiablejs": "^1.2.0",
+        "verifiablejs": "1.3.0-beta.2",
         "yaml": "^2.8.3",
       },
       "devDependencies": {
@@ -551,7 +551,7 @@
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
-    "verifiablejs": ["verifiablejs@1.2.0", "", {}, "sha512-+VVQo9yZko+w3THKaYvLbjXdfaiw1WJnX12wJEU5jHsHrMkjDrAMWoKYcBvtlHXufJirr8FlT6v2i/0yA3/ivQ=="],
+    "verifiablejs": ["verifiablejs@1.3.0-beta.2", "", {}, "sha512-asQR9sueO6LtUjrErSla3kt0ft2t/8kGrK6Q5HKkACAgLVKqdJ0Uk3QVmFQQx8FjkqxN9biKgL+J1fQowtm+Lw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@scure/sr25519": "^1.0.0",
     "cac": "^6.7.14",
     "polkadot-api": "^2.0.1",
-    "verifiablejs": "^1.2.0",
+    "verifiablejs": "1.3.0-beta.2",
     "yaml": "^2.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Pin `verifiablejs` to `1.3.0-beta.2` (was `^1.2.0`) to track the upstream beta.
- The only symbol the CLI consumes — `member_from_entropy` — has an unchanged signature, so `dot verifiable` output is byte-identical for both unkeyed and `--context candidate` derivations.
- No source-code changes required. The beta does change signatures for other symbols (`members_root`, `validate`, `one_shot`, etc. now take a `ring_exponent`), but none are used here.

## Test plan
- [x] `bun install` — single package change (`verifiablejs@1.3.0-beta.2`)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — 1461 pass / 0 fail
- [x] `bun run build` — clean
- [x] Byte-equality check on `dot verifiable alice` (unkeyed) and `dot verifiable alice --context candidate` — output identical pre/post bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)