### PR TITLE
feat(hash): add twox64/twox128/twox256 algorithms

### DIFF
--- a/.changeset/feature-twox-hash.md
+++ b/.changeset/feature-twox-hash.md
@@ -1,0 +1,22 @@
+---
+"polkadot-cli": minor
+---
+
+feat(hash): add `twox64`, `twox128`, `twox256` algorithms
+
+Substrate uses XXH64-based `twox*` hashes throughout — pallet/storage prefixes
+are `twox128(palletName) ++ twox128(itemName)`, and `Twox64Concat` is a common
+storage-map hasher. Previously `dot hash` only supported the BLAKE2b, Keccak,
+and SHA-2 families, so constructing a raw storage key required an external
+tool.
+
+The three new algorithms are pure-TypeScript (no wasm, no native deps) and
+verified against canonical XXH64 vectors and Substrate prefixes:
+
+- `dot hash twox128 System` → `0x26aa394eea5630e07c48ae0c9558cef7`
+- `dot hash twox128 Balances` → `0xc2261276cc9d1f8598ea4b6a74b15c2f`
+- `dot hash twox64 <key>` / `dot hash twox256 <key>` for the other variants
+
+Combined with `dot [chain.]rpc.state_getStorage 0x<key>`, this is enough to
+read any raw storage value, including the well-known keys (`:code`,
+`:heappages`) that live outside metadata.

--- a/README.md
+++ b/README.md
@@ -1626,7 +1626,7 @@ All existing flags work with file input — `--chain` overrides the file's `chai
 
 ### Compute hashes
 
-Compute cryptographic hashes commonly used in Substrate. Supports BLAKE2b-256, BLAKE2b-128, Keccak-256, and SHA-256.
+Compute cryptographic hashes commonly used in Substrate. Supports BLAKE2b-256, BLAKE2b-128, Keccak-256, SHA-256, and the XXH64-based `twox64` / `twox128` / `twox256` family used to build Substrate storage keys.
 
 ```bash
 # Hash hex-encoded data
@@ -1655,6 +1655,16 @@ dot hash blake2b256 0xdeadbeef --json
 #   "input": "0xdeadbeef",
 #   "hash": "0xf3e925002fed7cc0ded46842569eb5c90c910c091d8d04a1bdf96e0db719fd91"
 # }
+
+# Substrate twox128 — pallet/storage prefix used everywhere in Substrate state
+dot hash twox128 System
+# Output:
+# 0x26aa394eea5630e07c48ae0c9558cef7
+
+# Build a full storage key for `System.Number` and read it raw via JSON-RPC
+PALLET=$(dot hash twox128 System)
+ITEM=$(dot hash twox128 Number)
+dot polkadot.rpc.state_getStorage "${PALLET}${ITEM:2}"
 ```
 
 Run `dot hash` with no arguments to see all available algorithms.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -2130,6 +2130,9 @@ Compute cryptographic hashes commonly used in Substrate. Runs offline — no cha
 | `blake2b128` | 16 bytes | BLAKE2b with 128-bit output |
 | `keccak256` | 32 bytes | Keccak-256 (Ethereum-compatible) |
 | `sha256` | 32 bytes | SHA-256 |
+| `twox64` | 8 bytes | XXH64 with seed 0 (Substrate twox64) |
+| `twox128` | 16 bytes | XXH64 with seeds 0,1 (Substrate pallet/storage prefix) |
+| `twox256` | 32 bytes | XXH64 with seeds 0,1,2,3 (Substrate twox256) |
 
 ### Hash inline data
 
@@ -2173,6 +2176,20 @@ dot hash blake2b256 0xdeadbeef --json
 #   "input": "0xdeadbeef",
 #   "hash": "0xf3e925002fed7cc0ded46842569eb5c90c910c091d8d04a1bdf96e0db719fd91"
 # }
+```
+
+### Build a Substrate storage key with twox
+
+Substrate keys for pallet storage are `twox128(palletName) ++ twox128(itemName) [++ hasher(key)]`. Compose them with `dot hash twox128` and read the raw value via the JSON-RPC passthrough:
+
+```
+dot hash twox128 System
+# Output:
+# 0x26aa394eea5630e07c48ae0c9558cef7
+
+PALLET=$(dot hash twox128 System)
+ITEM=$(dot hash twox128 Number)
+dot polkadot.rpc.state_getStorage "${PALLET}${ITEM:2}"
 ```
 
 Run `dot hash` with no arguments to see all available algorithms and examples.
@@ -2492,7 +2509,7 @@ dot --from <Tab>         # → alice, bob, ..., stored account names
 dot --output <Tab>       # → pretty, json
 dot chain <Tab>          # → add, remove, update, list
 dot account <Tab>        # → create, import, derive, list, remove, ...
-dot hash <Tab>           # → blake2b256, blake2b128, keccak256, sha256
+dot hash <Tab>           # → blake2b256, blake2b128, keccak256, sha256, twox64, twox128, twox256
 ```
 
 Completions are context-aware:

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -519,10 +519,15 @@ dot sign "hello world" --from alice
 #   Signature:  0x4283a3bbae463c39264ca193b1bcce61702794e54e482bc2e46202c85ef6a544...
 #   Enum:       Sr25519(0x4283a3bbae463c39264ca193b1bcce61702794e54e482bc2e46202c8...)
 
-# Compute a hash
+# Compute a hash (algorithms: blake2b256, blake2b128, keccak256, sha256, twox64, twox128, twox256)
 dot hash blake2b256 0xdeadbeef
 # Output:
 # 0xf3e925002fed7cc0ded46842569eb5c90c910c091d8d04a1bdf96e0db719fd91
+
+# Substrate twox128 — pallet/storage prefix (use with `rpc.state_getStorage` to read raw keys)
+dot hash twox128 System
+# Output:
+# 0x26aa394eea5630e07c48ae0c9558cef7
 
 # Execute from a YAML/JSON file
 dot ./transfer.yaml --from alice

--- a/dot-cli/references/scripting-patterns.md
+++ b/dot-cli/references/scripting-patterns.md
@@ -315,6 +315,27 @@ dot polkadot.rpc --json | jq -r '.methods[] | select(.family=="archive") | .meth
 
 The `rpc` category is flat — `[chain.]rpc.<method_name>`, no pallet level. Methods discovered per-chain via `rpc_methods` and cached; refresh with `dot polkadot.rpc --refresh` after a node upgrade. Subscription methods (`*_subscribe*`, `chainHead_v1_*`, `transaction_v1_*`) are not callable as one-shots.
 
+### Build raw storage keys with twox
+
+Pallet storage in Substrate is keyed by `twox128(palletName) ++ twox128(itemName) [++ hasher(key)]`. Compose the prefix with `dot hash twox128` and read the raw SCALE value via `rpc.state_getStorage` — useful for items that aren't in metadata, or for poking around without loading metadata.
+
+```bash
+# Plain storage value (System.Number — current block number)
+PALLET=$(dot hash twox128 System)
+ITEM=$(dot hash twox128 Number)
+dot polkadot.rpc.state_getStorage "${PALLET}${ITEM:2}" --json
+
+# Well-known keys live outside the twox128++twox128 scheme — pass them directly
+dot polkadot.rpc.state_getStorageHash 0x3a636f6465  # `:code` — runtime WASM blake2 hash
+dot polkadot.rpc.state_getStorageSize 0x3a636f6465  # size of the runtime WASM in bytes
+
+# List the first 5 storage keys under a pallet prefix
+PREFIX=$(dot hash twox128 System)
+dot polkadot.rpc.state_getKeysPaged "$PREFIX" 5 --json
+```
+
+`twox64` and `twox256` are also available; `Twox64Concat` map-hasher keys are `twox64(encodedKey) ++ encodedKey` (compose with `dot hash twox64` and shell concatenation).
+
 ### Check pool reserves
 
 ```bash

--- a/src/core/hash.test.ts
+++ b/src/core/hash.test.ts
@@ -38,6 +38,9 @@ describe("isValidAlgorithm", () => {
     expect(isValidAlgorithm("blake2b128")).toBe(true);
     expect(isValidAlgorithm("keccak256")).toBe(true);
     expect(isValidAlgorithm("sha256")).toBe(true);
+    expect(isValidAlgorithm("twox64")).toBe(true);
+    expect(isValidAlgorithm("twox128")).toBe(true);
+    expect(isValidAlgorithm("twox256")).toBe(true);
   });
 
   test("returns false for invalid algorithms", () => {
@@ -54,7 +57,10 @@ describe("getAlgorithmNames", () => {
     expect(names).toContain("blake2b128");
     expect(names).toContain("keccak256");
     expect(names).toContain("sha256");
-    expect(names).toHaveLength(4);
+    expect(names).toContain("twox64");
+    expect(names).toContain("twox128");
+    expect(names).toContain("twox256");
+    expect(names).toHaveLength(7);
   });
 });
 
@@ -75,6 +81,18 @@ describe("output lengths", () => {
 
   test("sha256 outputs 32 bytes", () => {
     expect(computeHash("sha256", empty)).toHaveLength(32);
+  });
+
+  test("twox64 outputs 8 bytes", () => {
+    expect(computeHash("twox64", empty)).toHaveLength(8);
+  });
+
+  test("twox128 outputs 16 bytes", () => {
+    expect(computeHash("twox128", empty)).toHaveLength(16);
+  });
+
+  test("twox256 outputs 32 bytes", () => {
+    expect(computeHash("twox256", empty)).toHaveLength(32);
   });
 });
 
@@ -107,5 +125,32 @@ describe("known test vectors", () => {
   test("blake2b128 of empty input", () => {
     const hash = toHex(computeHash("blake2b128", new Uint8Array([])));
     expect(hash).toBe("0xcae66941d9efbd404e4d88758ea67670");
+  });
+
+  test("twox64 canonical XXH64 vector (Nobody inspects the spammish repetition)", () => {
+    const hash = toHex(
+      computeHash("twox64", new TextEncoder().encode("Nobody inspects the spammish repetition")),
+    );
+    expect(hash).toBe("0xf18b378a3ca8cefb");
+  });
+
+  test("twox128 of pallet 'System' matches Substrate prefix", () => {
+    const hash = toHex(computeHash("twox128", new TextEncoder().encode("System")));
+    expect(hash).toBe("0x26aa394eea5630e07c48ae0c9558cef7");
+  });
+
+  test("twox128 of pallet 'Sudo' matches Substrate prefix", () => {
+    const hash = toHex(computeHash("twox128", new TextEncoder().encode("Sudo")));
+    expect(hash).toBe("0x5c0d1176a568c1f92944340dbfed9e9c");
+  });
+
+  test("twox128 of pallet 'Balances' matches Substrate prefix", () => {
+    const hash = toHex(computeHash("twox128", new TextEncoder().encode("Balances")));
+    expect(hash).toBe("0xc2261276cc9d1f8598ea4b6a74b15c2f");
+  });
+
+  test("twox256 of empty input", () => {
+    const hash = toHex(computeHash("twox256", new Uint8Array([])));
+    expect(hash).toBe("0x99e9d85137db46ef4bbea33613baafd56f963c64b1f3685a4eb4abd67ff6203a");
   });
 });

--- a/src/core/hash.ts
+++ b/src/core/hash.ts
@@ -2,6 +2,7 @@ import { blake2b } from "@noble/hashes/blake2.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { keccak_256 } from "@noble/hashes/sha3.js";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
+import { twox } from "./xxh64.ts";
 
 interface Algorithm {
   compute: (data: Uint8Array) => Uint8Array;
@@ -29,6 +30,21 @@ export const ALGORITHMS: Record<string, Algorithm> = {
     compute: (data) => sha256(data),
     outputLen: 32,
     description: "SHA-256",
+  },
+  twox64: {
+    compute: (data) => twox(data, 64),
+    outputLen: 8,
+    description: "XXH64 with seed 0 (Substrate twox64)",
+  },
+  twox128: {
+    compute: (data) => twox(data, 128),
+    outputLen: 16,
+    description: "XXH64 with seeds 0,1 (Substrate twox128, pallet/storage prefix)",
+  },
+  twox256: {
+    compute: (data) => twox(data, 256),
+    outputLen: 32,
+    description: "XXH64 with seeds 0,1,2,3 (Substrate twox256)",
   },
 };
 

--- a/src/core/xxh64.ts
+++ b/src/core/xxh64.ts
@@ -1,0 +1,118 @@
+const MASK = (1n << 64n) - 1n;
+const P1 = 11400714785074694791n;
+const P2 = 14029467366897019727n;
+const P3 = 1609587929392839161n;
+const P4 = 9650029242287828579n;
+const P5 = 2870177450012600261n;
+
+function rotl(v: bigint, r: bigint): bigint {
+  return ((v << r) | (v >> (64n - r))) & MASK;
+}
+
+function round(acc: bigint, val: bigint): bigint {
+  acc = (acc + val * P2) & MASK;
+  acc = rotl(acc, 31n);
+  return (acc * P1) & MASK;
+}
+
+function mergeRound(h: bigint, val: bigint): bigint {
+  const k = round(0n, val);
+  return ((h ^ k) * P1 + P4) & MASK;
+}
+
+function readU64LE(data: Uint8Array, p: number): bigint {
+  return (
+    BigInt(data[p]!) |
+    (BigInt(data[p + 1]!) << 8n) |
+    (BigInt(data[p + 2]!) << 16n) |
+    (BigInt(data[p + 3]!) << 24n) |
+    (BigInt(data[p + 4]!) << 32n) |
+    (BigInt(data[p + 5]!) << 40n) |
+    (BigInt(data[p + 6]!) << 48n) |
+    (BigInt(data[p + 7]!) << 56n)
+  );
+}
+
+function readU32LE(data: Uint8Array, p: number): bigint {
+  return (
+    BigInt(data[p]!) |
+    (BigInt(data[p + 1]!) << 8n) |
+    (BigInt(data[p + 2]!) << 16n) |
+    (BigInt(data[p + 3]!) << 24n)
+  );
+}
+
+export function xxh64(input: Uint8Array, seed: bigint = 0n): bigint {
+  const len = input.length;
+  let p = 0;
+  let h: bigint;
+
+  if (len >= 32) {
+    let v1 = (seed + P1 + P2) & MASK;
+    let v2 = (seed + P2) & MASK;
+    let v3 = seed & MASK;
+    let v4 = (seed - P1) & MASK;
+
+    while (p <= len - 32) {
+      v1 = round(v1, readU64LE(input, p));
+      p += 8;
+      v2 = round(v2, readU64LE(input, p));
+      p += 8;
+      v3 = round(v3, readU64LE(input, p));
+      p += 8;
+      v4 = round(v4, readU64LE(input, p));
+      p += 8;
+    }
+
+    h = (rotl(v1, 1n) + rotl(v2, 7n) + rotl(v3, 12n) + rotl(v4, 18n)) & MASK;
+    h = mergeRound(h, v1);
+    h = mergeRound(h, v2);
+    h = mergeRound(h, v3);
+    h = mergeRound(h, v4);
+  } else {
+    h = (seed + P5) & MASK;
+  }
+
+  h = (h + BigInt(len)) & MASK;
+
+  while (p + 8 <= len) {
+    const k = round(0n, readU64LE(input, p));
+    h = (rotl(h ^ k, 27n) * P1 + P4) & MASK;
+    p += 8;
+  }
+
+  if (p + 4 <= len) {
+    const k = (readU32LE(input, p) * P1) & MASK;
+    h = (rotl(h ^ k, 23n) * P2 + P3) & MASK;
+    p += 4;
+  }
+
+  while (p < len) {
+    const k = (BigInt(input[p]!) * P5) & MASK;
+    h = (rotl(h ^ k, 11n) * P1) & MASK;
+    p++;
+  }
+
+  h ^= h >> 33n;
+  h = (h * P2) & MASK;
+  h ^= h >> 29n;
+  h = (h * P3) & MASK;
+  h ^= h >> 32n;
+
+  return h;
+}
+
+function u64ToLEBytes(v: bigint, out: Uint8Array, offset: number): void {
+  for (let i = 0; i < 8; i++) {
+    out[offset + i] = Number((v >> BigInt(i * 8)) & 0xffn);
+  }
+}
+
+export function twox(input: Uint8Array, bits: 64 | 128 | 256): Uint8Array {
+  const lanes = bits / 64;
+  const out = new Uint8Array(bits / 8);
+  for (let i = 0; i < lanes; i++) {
+    u64ToLEBytes(xxh64(input, BigInt(i)), out, i * 8);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

- Adds `twox64`, `twox128`, `twox256` to `dot hash` — pure-TS XXH64 (no wasm, no native deps), the XXH64-based family Substrate uses throughout (pallet/storage prefixes and `Twox64Concat` map hasher).
- Verified against canonical XXH64 vectors and known Substrate prefixes (`twox128("System") == 0x26aa394eea5630e07c48ae0c9558cef7`, etc.).
- Closes the loop with `dot [chain.]rpc.state_getStorage 0x<key>` — users can now construct a raw storage key and read its value without external tooling.

A dedicated `dot [chain.]storage.*` subcommand for the raw `state_*` family is filed as #213 for follow-up.

## Files

- `src/core/xxh64.ts` — new, pure-TS XXH64 + `twox(bits)` helper.
- `src/core/hash.ts` — three new entries in `ALGORITHMS`.
- `src/core/hash.test.ts` — 9 new test cases (canonical XXH64 vector + Substrate prefixes + lengths + names).
- `README.md`, `docs/content/_index.md`, `dot-cli/SKILL.md`, `dot-cli/references/scripting-patterns.md` — all updated with a worked `twox128 → state_getStorage` example.
- `.changeset/feature-twox-hash.md` — `minor` bump.

Coverage: `src/core/hash.ts` 97.87% → 98.41% lines; `src/core/xxh64.ts` 100%.

## Test plan

- [x] `bun test src/core/hash.test.ts src/commands/hash.test.ts` — 44/44 pass.
- [x] `dot hash twox128 System` → `0x26aa394eea5630e07c48ae0c9558cef7` (Substrate canonical).
- [x] `dot hash twox64 "Nobody inspects the spammish repetition"` matches the published XXH64 reference.
- [x] Composed `System.Number` storage key → `dot polkadot.rpc.state_getStorage` returns a valid SCALE-encoded block number against a live polkadot endpoint.
- [x] Live `state_getStorageHash 0x3a636f6465` and `state_getStorageSize 0x3a636f6465` for `:code` — confirmed runtime hash + size against polkadot.
- [x] `dot polkadot.rpc.state_getKeysPaged $(dot hash twox128 System) 5` — first 5 System pallet keys returned.
- [x] Pre-commit hook (biome + tsc + bun test) ran clean for the diff in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)