### PR TITLE
fix(query, apis): honor `--at <block>` for historical reads

### DIFF
--- a/.changeset/at-unavailable-block-hint.md
+++ b/.changeset/at-unavailable-block-hint.md
@@ -1,0 +1,25 @@
+---
+"polkadot-cli": patch
+---
+
+fix(errors): friendlier message when `--at <block>` is not available
+
+When `--at` points at a block the connected RPC can't serve — most often
+an old hash against a non-archive node — papi raises
+`BlockHashNotFoundError` / `StorageError: UnknownBlock` / "is not pinned"
+rejections. These now get caught at the `query.*` / `apis.*` / `tx.*`
+call sites and re-surfaced as a clean `CliError` with a copy-pasteable
+hint:
+
+```
+Error: Block 0x… is not pinned (storage)
+
+⚠ 0x… is not available on the current RPC endpoint.
+   Public nodes serve only recent (pinned) blocks via chainHead_v1_*.
+   For deep historical reads, point --rpc at an archive endpoint, e.g.:
+     dot ... --at 0x… --rpc wss://<archive-endpoint>
+```
+
+Note: papi's substrate-client may still emit its own internal stack
+trace ahead of the clean message; suppressing that is a separate
+follow-up.

--- a/.changeset/bug-at-flag.md
+++ b/.changeset/bug-at-flag.md
@@ -1,0 +1,35 @@
+---
+"polkadot-cli": minor
+---
+
+fix(query, apis): honor `--at <block>` for historical reads
+
+`--at` was declared on the global command but only ever wired into `tx`
+submission. `query.*` and `apis.*` accepted the flag silently and read
+current head anyway, making historical state reads and per-block runtime
+API replays impossible from the high-level wrappers.
+
+papi v2 supports historical reads natively via the trailing `PullOptions`
+argument on storage and runtime calls (`{ at: "best" | "finalized" |
+<hash> }`). The fix threads the flag through.
+
+- `dot polkadot.query.System.Number --at best`
+- `dot polkadot.query.System.Number --at finalized`
+- `dot polkadot.query.System.Number --at 0x<hash>`
+- `dot polkadot.apis.Core.version --at 0x<hash>`
+
+Behavior matrix:
+
+| Command | `--at best` | `--at finalized` | `--at 0x<hash>` |
+|---|---|---|---|
+| `query.*` | ✓ | ✓ | ✓ |
+| `apis.*`  | ✓ | ✓ | ✓ |
+| `tx.*`    | rejected (papi v2 constraint) | ✓ | ✓ |
+
+Also fixes a pre-existing CAC/mri argv-parsing bug where 0x-hex block
+hashes passed to `--at` were silently coerced to JS Numbers, losing
+precision. `--at` is now read from raw argv to keep the original string
+intact.
+
+papi v2's `chainHead_v1_*` JSON-RPC only serves pinned (recent) blocks.
+For deep historical reads, point `--rpc` at an archive endpoint.

--- a/README.md
+++ b/README.md
@@ -683,8 +683,15 @@ Anything else errors before any network call. Tx submission rejects `"best"`.
 
 > **Archive-only blocks**: papi v2 talks to the `chainHead_v1_*` JSON-RPC API,
 > which only serves *pinned* (recent) blocks. Querying a hash older than a
-> few minutes against a non-archive node returns `Block … is not pinned`.
-> Point `--rpc` at an archive endpoint for deep historical reads.
+> few minutes against a non-archive node fails with a clean error that
+> includes a copy-pasteable `--rpc wss://<archive-endpoint>` hint:
+>
+> ```
+> ⚠ 0x… is not available on the current RPC endpoint.
+>    Public nodes serve only recent (pinned) blocks via chainHead_v1_*.
+>    For deep historical reads, point --rpc at an archive endpoint, e.g.:
+>      dot ... --at 0x… --rpc wss://<archive-endpoint>
+> ```
 
 ### Look up constants
 

--- a/README.md
+++ b/README.md
@@ -659,6 +659,33 @@ dot polkadot-asset-hub.query.Assets.Metadata 1984
 # }
 ```
 
+#### Historical reads — `--at <block>`
+
+Storage queries default to the latest finalized head. Pass `--at` to read
+state at a specific block hash, the chain head (`best`), or `finalized`
+(explicit). Accepted on both `query.*` and `apis.*` runtime calls.
+
+```bash
+# Read at the current best (non-finalized) head — useful for low-latency reads
+dot polkadot.query.System.Number --at best
+
+# Read at the last finalized block — same as the default, but explicit
+dot polkadot.query.System.Number --at finalized
+
+# Pin a finalized hash and read multiple items at that exact block
+HASH=$(dot polkadot.rpc.chain_getFinalizedHead | tr -d '"')
+dot polkadot.query.System.Number --at "$HASH"
+dot polkadot.apis.Core.version --at "$HASH" --json | jq .spec_version
+```
+
+`--at` accepts a 32-byte `0x…` block hash, `"best"`, or `"finalized"`.
+Anything else errors before any network call. Tx submission rejects `"best"`.
+
+> **Archive-only blocks**: papi v2 talks to the `chainHead_v1_*` JSON-RPC API,
+> which only serves *pinned* (recent) blocks. Querying a hash older than a
+> few minutes against a non-archive node returns `Block … is not pinned`.
+> Point `--rpc` at an archive endpoint for deep historical reads.
+
 ### Look up constants
 
 ```bash
@@ -1340,7 +1367,7 @@ Override low-level transaction parameters. Useful for rapid-fire submission (cus
 | `--nonce <n>` | non-negative integer | Override the auto-detected nonce |
 | `--tip <amount>` | non-negative integer (planck) | Priority tip for the transaction pool |
 | `--mortality <spec>` | `immortal` or period (min 4) | Transaction mortality window |
-| `--at <block>` | 0x-prefixed block hash | Block hash to validate against (defaults to finalized) |
+| `--at <block>` | 0x-prefixed block hash, `"best"`, or `"finalized"` | Block to read/validate against (defaults to finalized). Also honored on `query.*` and `apis.*` for historical reads; tx submission rejects `"best"`. |
 
 ```bash
 # Fire-and-forget: submit two txs in rapid succession with manual nonces

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -894,6 +894,33 @@ dot polkadot-asset-hub.query.Assets.Metadata 1984
 # }
 ```
 
+### Historical reads — `--at <block>`
+
+Storage queries default to the latest finalized head. Pass `--at` to read
+state at a specific block hash, the chain head (`best`), or `finalized`
+(explicit). Accepted on both `query.*` and `apis.*` runtime calls.
+
+```
+# Read at the current best (non-finalized) head
+dot polkadot.query.System.Number --at best
+
+# Read at the last finalized block — same as the default, but explicit
+dot polkadot.query.System.Number --at finalized
+
+# Pin a finalized hash and read multiple items at that exact block
+HASH=$(dot polkadot.rpc.chain_getFinalizedHead | tr -d '"')
+dot polkadot.query.System.Number --at "$HASH"
+dot polkadot.apis.Core.version --at "$HASH" --json | jq .spec_version
+```
+
+`--at` accepts a 32-byte `0x…` block hash, `"best"`, or `"finalized"`.
+Anything else errors before any network call. Tx submission rejects `"best"`.
+
+> **Archive-only blocks**: papi v2 talks to the `chainHead_v1_*` JSON-RPC API,
+> which only serves *pinned* (recent) blocks. Querying a hash older than a
+> few minutes against a non-archive node returns `Block … is not pinned`.
+> Point `--rpc` at an archive endpoint for deep historical reads.
+
 ## Constants
 
 Look up runtime constants using dot-path syntax: `dot const.Pallet.Constant`. Use `dot const` to list pallets with constants, or `dot const.Pallet` to list a pallet's constants.
@@ -1734,7 +1761,7 @@ Override low-level transaction parameters. Useful for rapid-fire submission (cus
 | `--nonce <n>` | non-negative integer | Override the auto-detected nonce |
 | `--tip <amount>` | non-negative integer (planck) | Priority tip for the transaction pool |
 | `--mortality <spec>` | `immortal` or period (min 4) | Transaction mortality window |
-| `--at <block>` | 0x-prefixed block hash | Block hash to validate against (defaults to finalized) |
+| `--at <block>` | 0x-prefixed block hash, `"best"`, or `"finalized"` | Block to read/validate against (defaults to finalized). Also honored on `query.*` and `apis.*` for historical reads; tx submission rejects `"best"`. |
 
 ```
 # Fire-and-forget: submit two txs in rapid succession with manual nonces

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -918,8 +918,15 @@ Anything else errors before any network call. Tx submission rejects `"best"`.
 
 > **Archive-only blocks**: papi v2 talks to the `chainHead_v1_*` JSON-RPC API,
 > which only serves *pinned* (recent) blocks. Querying a hash older than a
-> few minutes against a non-archive node returns `Block … is not pinned`.
-> Point `--rpc` at an archive endpoint for deep historical reads.
+> few minutes against a non-archive node fails with a clean error that
+> includes a copy-pasteable `--rpc wss://<archive-endpoint>` hint:
+>
+> ```
+> ⚠ 0x… is not available on the current RPC endpoint.
+>    Public nodes serve only recent (pinned) blocks via chainHead_v1_*.
+>    For deep historical reads, point --rpc at an archive endpoint, e.g.:
+>      dot ... --at 0x… --rpc wss://<archive-endpoint>
+> ```
 
 ## Constants
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -138,7 +138,9 @@ dot polkadot.apis.Core.version --at "$HASH" --json | jq .spec_version
 ```
 
 papi v2's `chainHead_v1_*` JSON-RPC only serves *pinned* (recent) blocks. For
-deep historical reads, point `--rpc` at an archive node.
+deep historical reads, point `--rpc` at an archive node. If `--at <hash>` hits
+an unavailable block, the CLI surfaces a clean error with a copy-pasteable
+`--rpc wss://<archive>` example — exit code 1.
 
 ### Handling `undefined` — Critical for Scripting
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -126,7 +126,19 @@ dot polkadot.query.System.Number --json
 # 31014744
 ```
 
-Queries always read the latest finalized head — **historical state reads are not supported**. `--at <block>` is a tx-submission flag, not a query flag.
+Queries default to the latest finalized head. Pass `--at <block-hash|best|finalized>` for historical or non-finalized state reads. Also applies to `apis.*` runtime calls. Tx submission accepts only a block hash or `finalized` — not `best`.
+
+```bash
+# Read at the chain head (best, non-finalized) or pin to the latest finalized block
+dot polkadot.query.System.Number --at best
+HASH=$(dot polkadot.rpc.chain_getFinalizedHead | tr -d '"')
+dot polkadot.query.System.Number --at "$HASH"
+# Same flag on runtime APIs
+dot polkadot.apis.Core.version --at "$HASH" --json | jq .spec_version
+```
+
+papi v2's `chainHead_v1_*` JSON-RPC only serves *pinned* (recent) blocks. For
+deep historical reads, point `--rpc` at an archive node.
 
 ### Handling `undefined` — Critical for Scripting
 
@@ -547,7 +559,7 @@ dot polkadot.tx.System.remark 0xdeadbeef --to-yaml
 | `--dry-run` | tx | Estimate fees without submitting |
 | `--dump` | query | Dump all entries of a storage map |
 | `--ext <json>` | tx | Custom signed extension values |
-| `--at <block>` | tx | Submit at a specific block hash (32-byte `0x…`); defaults to finalized. Not supported on queries. |
+| `--at <block>` | tx, query, apis | Block hash, `"best"`, or `"finalized"` to read/validate against. Defaults to finalized. Tx submission rejects `"best"`. |
 
 ## Common Errors
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,7 +93,10 @@ if (process.argv[2] === "__complete") {
     .option("--nonce <n>", "Custom nonce for manual tx sequencing (for tx)")
     .option("--tip <amount>", "Tip to prioritize transaction (for tx)")
     .option("--mortality <spec>", '"immortal" or period number (for tx)')
-    .option("--at <block>", 'Block hash, "best", or "finalized" to validate against (for tx)')
+    .option(
+      "--at <block>",
+      'Block hash, "best", or "finalized" to read/validate against (tx, query, apis)',
+    )
     .option("--unsigned", "Submit as unsigned/bare transaction (no signer required, for tx)")
     .option("--refresh", "Refresh the cached RPC method list from the node (for rpc)")
     .action(
@@ -128,6 +131,10 @@ if (process.argv[2] === "__complete") {
           return;
         }
 
+        // Read --at from raw argv to bypass CAC/mri's numeric coercion of
+        // hex block hashes. opts.at is unreliable for hex strings.
+        const atRaw = readAtFromArgv(process.argv);
+
         // --- File-based command input ---
         if (isFilePath(dotpath)) {
           // Collect all --var flags from process.argv (CAC only keeps the last)
@@ -160,7 +167,7 @@ if (process.argv[2] === "__complete") {
                 nonce: opts.nonce,
                 tip: opts.tip,
                 mortality: opts.mortality,
-                at: opts.at,
+                at: atRaw,
                 parsedArgs: cmd.args,
               });
               break;
@@ -168,6 +175,7 @@ if (process.argv[2] === "__complete") {
               await handleQuery(target, args, {
                 ...handlerOpts,
                 dump: opts.dump,
+                at: atRaw,
                 parsedArgs: cmd.args,
               });
               break;
@@ -177,6 +185,7 @@ if (process.argv[2] === "__complete") {
             case "apis":
               await handleApis(target, args, {
                 ...handlerOpts,
+                at: atRaw,
                 parsedArgs: cmd.args,
               });
               break;
@@ -239,7 +248,7 @@ if (process.argv[2] === "__complete") {
 
         switch (parsed.category) {
           case "query":
-            await handleQuery(target, args, { ...handlerOpts, dump: opts.dump });
+            await handleQuery(target, args, { ...handlerOpts, dump: opts.dump, at: atRaw });
             break;
           case "tx": {
             // Handle raw hex: if pallet starts with 0x, it's a raw call hex
@@ -257,7 +266,7 @@ if (process.argv[2] === "__complete") {
               nonce: opts.nonce,
               tip: opts.tip,
               mortality: opts.mortality,
-              at: opts.at,
+              at: atRaw,
             };
             if (parsed.pallet && /^0x[0-9a-fA-F]+$/.test(parsed.pallet)) {
               await handleTx(parsed.pallet, args, txOpts);
@@ -276,7 +285,7 @@ if (process.argv[2] === "__complete") {
             await handleErrors(target, handlerOpts);
             break;
           case "apis":
-            await handleApis(target, args, handlerOpts);
+            await handleApis(target, args, { ...handlerOpts, at: atRaw });
             break;
           case "extensions": {
             if (parsed.item) {
@@ -312,6 +321,19 @@ if (process.argv[2] === "__complete") {
 
   cli.option("--help, -h", "Display this message");
   cli.version(version);
+
+  /**
+   * Read `--at <value>` from raw argv. CAC delegates to mri, which silently
+   * coerces 0x-hex block hashes to JS Numbers and loses precision. Falling
+   * back to argv keeps the original string intact.
+   */
+  function readAtFromArgv(argv: string[]): string | undefined {
+    for (let i = 0; i < argv.length; i++) {
+      if (argv[i] === "--at" && i + 1 < argv.length) return argv[i + 1];
+      if (argv[i]!.startsWith("--at=")) return argv[i]!.slice(5);
+    }
+    return undefined;
+  }
 
   /** Collect all --var KEY=VALUE flags from argv (CAC only keeps the last for repeated options) */
   function collectVarFlags(argv: string[]): Record<string, string> {

--- a/src/commands/apis.test.ts
+++ b/src/commands/apis.test.ts
@@ -1,0 +1,41 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, linkSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../config/types.ts";
+import { runCli } from "./__fixtures__/run-cli.ts";
+
+// ---------------------------------------------------------------------------
+// Ensure metadata + config exist in real $HOME for in-process tests.
+// Mirrors the setup in query.test.ts so the fixture chain is available.
+// ---------------------------------------------------------------------------
+const FIXTURE_METADATA = join(import.meta.dir, "__fixtures__/polkadot-metadata.bin");
+const DOT_DIR = join(homedir(), ".polkadot");
+
+beforeAll(() => {
+  const metaDir = join(DOT_DIR, "chains", "polkadot");
+  const metaPath = join(metaDir, "metadata.bin");
+  if (!existsSync(metaPath)) {
+    mkdirSync(metaDir, { recursive: true });
+    linkSync(FIXTURE_METADATA, metaPath);
+  }
+  const configPath = join(DOT_DIR, "config.json");
+  if (!existsSync(configPath)) {
+    writeFileSync(configPath, JSON.stringify(DEFAULT_CONFIG));
+  }
+});
+
+// @ts-expect-error Bun supports describe(label, options, fn) at runtime
+describe("dot apis --at", { timeout: 15_000 }, () => {
+  test("--at best is accepted and threads through to the runtime API call", async () => {
+    const { exitCode, stdout } = await runCli(["apis.Core.version", "--at", "best"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBeTruthy();
+  }, 15_000);
+
+  test("--at with invalid value errors before hitting the network", async () => {
+    const { exitCode, stderr } = await runCli(["apis.Core.version", "--at", "latest"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Invalid --at");
+  });
+});

--- a/src/commands/apis.test.ts
+++ b/src/commands/apis.test.ts
@@ -38,4 +38,12 @@ describe("dot apis --at", { timeout: 15_000 }, () => {
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Invalid --at");
   });
+
+  test("--at with a never-pinned hash produces a clean archive-endpoint hint", async () => {
+    const fakeHash = `0x${"ab".repeat(32)}`;
+    const { exitCode, stderr } = await runCli(["apis.Core.version", "--at", fakeHash]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("archive endpoint");
+    expect(stderr).toContain("--rpc wss://<archive-endpoint>");
+  }, 15_000);
 });

--- a/src/commands/apis.ts
+++ b/src/commands/apis.ts
@@ -8,6 +8,7 @@ import {
   getOrFetchMetadata,
   getRuntimeApiNames,
   listRuntimeApis,
+  withBlockAvailabilityHint,
 } from "../core/metadata.ts";
 import {
   BOLD,
@@ -158,7 +159,9 @@ export async function handleApis(
     const pullOpts = atArg !== undefined ? [{ at: atArg }] : [];
 
     const unsafeApi = clientHandle.client.getUnsafeApi();
-    const result = await (unsafeApi as any).apis[api.name][method.name](...parsedArgs, ...pullOpts);
+    const result = await withBlockAvailabilityHint(opts.at, () =>
+      (unsafeApi as any).apis[api.name][method.name](...parsedArgs, ...pullOpts),
+    );
 
     const format = isJsonOutput(opts) ? "json" : (opts.output ?? "pretty");
     printResult(result, format);

--- a/src/commands/apis.ts
+++ b/src/commands/apis.ts
@@ -24,7 +24,7 @@ import {
 } from "../core/output.ts";
 import { suggestMessage } from "../utils/fuzzy-match.ts";
 import { loadMeta } from "./focused-inspect.ts";
-import { parseTypedArg } from "./tx.ts";
+import { parseAtForRead, parseTypedArg } from "./tx.ts";
 
 export async function handleApis(
   target: string | undefined,
@@ -34,6 +34,7 @@ export async function handleApis(
     rpc?: string;
     output?: string;
     json?: boolean;
+    at?: string;
     /** Pre-parsed args from a file */
     parsedArgs?: unknown;
   },
@@ -153,9 +154,11 @@ export async function handleApis(
                 : String(opts.parsedArgs),
             ];
     const parsedArgs = await parseRuntimeApiArgs(meta, method, effectiveArgs);
+    const atArg = parseAtForRead(opts.at);
+    const pullOpts = atArg !== undefined ? [{ at: atArg }] : [];
 
     const unsafeApi = clientHandle.client.getUnsafeApi();
-    const result = await (unsafeApi as any).apis[api.name][method.name](...parsedArgs);
+    const result = await (unsafeApi as any).apis[api.name][method.name](...parsedArgs, ...pullOpts);
 
     const format = isJsonOutput(opts) ? "json" : (opts.output ?? "pretty");
     printResult(result, format);

--- a/src/commands/query.test.ts
+++ b/src/commands/query.test.ts
@@ -233,6 +233,14 @@ describe("dot query", { timeout: 15_000 }, () => {
     const { stderr } = await runCli(["query.System.Number", "--at", fakeHash]);
     expect(stderr).not.toContain("Invalid --at");
   }, 15_000);
+
+  test("--at with a never-pinned hash produces a clean archive-endpoint hint", async () => {
+    const fakeHash = `0x${"ab".repeat(32)}`;
+    const { exitCode, stderr } = await runCli(["query.System.Number", "--at", fakeHash]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("archive endpoint");
+    expect(stderr).toContain("--rpc wss://<archive-endpoint>");
+  }, 15_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/query.test.ts
+++ b/src/commands/query.test.ts
@@ -211,6 +211,28 @@ describe("dot query", { timeout: 15_000 }, () => {
     expect(() => JSON.parse(jsonFlag.stdout)).not.toThrow();
     expect(() => JSON.parse(outputJson.stdout)).not.toThrow();
   }, 15_000);
+
+  test("--at best is accepted and threads through to papi", async () => {
+    const { exitCode, stdout } = await runCli(["query.System.Number", "--at", "best"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBeTruthy();
+  }, 15_000);
+
+  test("--at with invalid value errors before hitting the network", async () => {
+    const { exitCode, stderr } = await runCli(["query.System.Number", "--at", "latest"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Invalid --at");
+  });
+
+  test("--at with a 0x-hex block hash is not coerced to Number by CAC", async () => {
+    // Regression: CAC/mri silently parses 0x-hex as Number and loses precision.
+    // We sidestep this by reading --at from raw argv. The block hash here is
+    // syntactically valid but doesn't resolve, so we just assert the parser
+    // didn't reject it with "Invalid --at" (which would mean it saw a number).
+    const fakeHash = `0x${"ab".repeat(32)}`;
+    const { stderr } = await runCli(["query.System.Number", "--at", fakeHash]);
+    expect(stderr).not.toContain("Invalid --at");
+  }, 15_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -25,7 +25,7 @@ import { prettyTypeById } from "../core/pretty-type.ts";
 import { suggestMessage } from "../utils/fuzzy-match.ts";
 import { parseValue } from "../utils/parse-value.ts";
 import { loadMeta, resolvePallet, showItemHelp } from "./focused-inspect.ts";
-import { parseStructArgs, parseTypedArg } from "./tx.ts";
+import { parseAtForRead, parseStructArgs, parseTypedArg } from "./tx.ts";
 
 export async function handleQuery(
   target: string | undefined,
@@ -36,6 +36,7 @@ export async function handleQuery(
     output?: string;
     json?: boolean;
     dump?: boolean;
+    at?: string;
     /** Pre-parsed args from a file */
     parsedArgs?: unknown;
   },
@@ -166,6 +167,8 @@ export async function handleQuery(
                 : String(opts.parsedArgs),
             ];
     const parsedKeys = await parseStorageKeys(meta, palletInfo.name, storageItem, effectiveKeys);
+    const atArg = parseAtForRead(opts.at);
+    const pullOpts = atArg !== undefined ? [{ at: atArg }] : [];
     const format = isJsonOutput(opts) ? "json" : (opts.output ?? "pretty");
 
     // Determine expected key count for maps
@@ -187,7 +190,7 @@ export async function handleQuery(
       const entries: Array<{ keyArgs: any; value: any }> = await withStalenessSuggestion(
         chainName,
         clientHandle,
-        () => storageApi.getEntries(...parsedKeys),
+        () => storageApi.getEntries(...parsedKeys, ...pullOpts),
       );
 
       const rows = entries.map((e: any) => ({
@@ -199,7 +202,7 @@ export async function handleQuery(
     } else {
       // Full key → single value lookup
       const result = await withStalenessSuggestion(chainName, clientHandle, () =>
-        storageApi.getValue(...parsedKeys),
+        storageApi.getValue(...parsedKeys, ...pullOpts),
       );
       const text = format === "json" ? formatJson(result) : formatPretty(result);
       await writeStdout(`${text}\n`);

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -7,6 +7,7 @@ import {
   getOrFetchMetadata,
   getPalletNames,
   listPallets,
+  withBlockAvailabilityHint,
   withStalenessSuggestion,
 } from "../core/metadata.ts";
 import {
@@ -190,7 +191,10 @@ export async function handleQuery(
       const entries: Array<{ keyArgs: any; value: any }> = await withStalenessSuggestion(
         chainName,
         clientHandle,
-        () => storageApi.getEntries(...parsedKeys, ...pullOpts),
+        () =>
+          withBlockAvailabilityHint(opts.at, () =>
+            storageApi.getEntries(...parsedKeys, ...pullOpts),
+          ),
       );
 
       const rows = entries.map((e: any) => ({
@@ -202,7 +206,7 @@ export async function handleQuery(
     } else {
       // Full key → single value lookup
       const result = await withStalenessSuggestion(chainName, clientHandle, () =>
-        storageApi.getValue(...parsedKeys, ...pullOpts),
+        withBlockAvailabilityHint(opts.at, () => storageApi.getValue(...parsedKeys, ...pullOpts)),
       );
       const text = format === "json" ? formatJson(result) : formatPretty(result);
       await writeStdout(`${text}\n`);

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -21,6 +21,7 @@ import {
   NO_DEFAULT,
   normalizeValue,
   parseAssetOption,
+  parseAtForRead,
   parseAtOption,
   parseCallArgs,
   parseEnumShorthand,
@@ -203,6 +204,34 @@ describe("parseAtOption", () => {
   test("invalid value throws", () => {
     expect(() => parseAtOption("0x123")).toThrow("Invalid --at");
     expect(() => parseAtOption("latest")).toThrow("Invalid --at");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAtForRead — permissive variant for query / apis (papi PullOptions)
+// ---------------------------------------------------------------------------
+
+describe("parseAtForRead", () => {
+  test("undefined returns undefined", () => {
+    expect(parseAtForRead(undefined)).toBeUndefined();
+  });
+
+  test('"best" passes through (papi reads allow it)', () => {
+    expect(parseAtForRead("best")).toBe("best");
+  });
+
+  test('"finalized" passes through verbatim (not collapsed)', () => {
+    expect(parseAtForRead("finalized")).toBe("finalized");
+  });
+
+  test("valid block hash returns hash", () => {
+    const hash = `0x${"ab".repeat(32)}`;
+    expect(parseAtForRead(hash)).toBe(hash);
+  });
+
+  test("invalid value throws", () => {
+    expect(() => parseAtForRead("0x123")).toThrow("Invalid --at");
+    expect(() => parseAtForRead("latest")).toThrow("Invalid --at");
   });
 });
 

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -19,6 +19,7 @@ import {
   getSignedExtensions,
   listPallets,
   PAPI_BUILTIN_EXTENSIONS,
+  withBlockAvailabilityHint,
   withStalenessSuggestion,
 } from "../core/metadata.ts";
 import {
@@ -469,7 +470,9 @@ export async function handleTx(
       try {
         estimatedFees = String(
           await withStalenessSuggestion(chainName, clientHandle!, () =>
-            tx.getEstimatedFees(signer?.publicKey, txOptions),
+            withBlockAvailabilityHint(opts.at, () =>
+              tx.getEstimatedFees(signer?.publicKey, txOptions),
+            ),
           ),
         );
       } catch (err) {
@@ -546,7 +549,9 @@ export async function handleTx(
 
       if (isJsonOutput(opts)) {
         const result = await withStalenessSuggestion(chainName, clientHandle!, () =>
-          watchTransactionJson(observable, waitLevel, { unsigned: true }),
+          withBlockAvailabilityHint(opts.at, () =>
+            watchTransactionJson(observable, waitLevel, { unsigned: true }),
+          ),
         );
         const rpcUrl = primaryRpc(opts.rpc ?? chainConfig.rpc);
         if (result.type === "broadcasted") {
@@ -583,7 +588,9 @@ export async function handleTx(
       }
 
       const result = await withStalenessSuggestion(chainName, clientHandle!, () =>
-        watchTransaction(observable, waitLevel, { unsigned: true }),
+        withBlockAvailabilityHint(opts.at, () =>
+          watchTransaction(observable, waitLevel, { unsigned: true }),
+        ),
       );
 
       console.log();
@@ -647,7 +654,9 @@ export async function handleTx(
     // JSON output: NDJSON stream
     if (isJsonOutput(opts)) {
       const result = await withStalenessSuggestion(chainName, clientHandle!, () =>
-        watchTransactionJson(tx.signSubmitAndWatch(signer, txOptions), waitLevel),
+        withBlockAvailabilityHint(opts.at, () =>
+          watchTransactionJson(tx.signSubmitAndWatch(signer, txOptions), waitLevel),
+        ),
       );
       const rpcUrl = primaryRpc(opts.rpc ?? chainConfig.rpc);
       if (result.type === "broadcasted") {
@@ -684,7 +693,9 @@ export async function handleTx(
     }
 
     const result = await withStalenessSuggestion(chainName, clientHandle!, () =>
-      watchTransaction(tx.signSubmitAndWatch(signer, txOptions), waitLevel),
+      withBlockAvailabilityHint(opts.at, () =>
+        watchTransaction(tx.signSubmitAndWatch(signer, txOptions), waitLevel),
+      ),
     );
 
     console.log();

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -132,6 +132,18 @@ export function parseAtOption(raw: string | undefined): string | undefined {
   );
 }
 
+// Storage reads / runtime API calls go through papi's `PullOptions`, which
+// accepts "best" — unlike tx submission. Keep the two parsers separate so
+// each call site is explicit about which semantics apply.
+export function parseAtForRead(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === "best" || raw === "finalized") return raw;
+  if (/^0x[0-9a-fA-F]{64}$/.test(raw)) return raw;
+  throw new CliError(
+    `Invalid --at value "${raw}". Use "best", "finalized", or a 0x-prefixed 32-byte block hash.`,
+  );
+}
+
 export async function handleTx(
   target: string | undefined,
   args: string[],

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -12,6 +12,7 @@ import {
   CliError,
   ConnectionError,
   formatRuntimeError,
+  isBlockUnavailableError,
   isLikelyStaleMetadataError,
   MetadataError,
 } from "../utils/errors.ts";
@@ -222,6 +223,32 @@ export async function withStalenessSuggestion<T>(
       `${original}\n\n` +
         `⚠ Local metadata for "${chainName}" is out of date (${versionNote}).\n` +
         `   Run: dot chain update ${chainName}`,
+    );
+  }
+}
+
+// Catch papi errors raised when --at <hash> points at a block the RPC can't
+// serve and re-throw as a CliError that tells the user to use an archive node.
+// Pure error-shape detection — no extra RPC roundtrip, so this composes cheaply
+// inside the staleness wrapper at call sites.
+export async function withBlockAvailabilityHint<T>(
+  atRaw: string | undefined,
+  task: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await task();
+  } catch (err) {
+    if (!isBlockUnavailableError(err)) throw err;
+    const original = err instanceof Error ? err.message : String(err);
+    const isExplicitHash = atRaw && atRaw !== "best" && atRaw !== "finalized";
+    const target = isExplicitHash ? atRaw : "the requested block";
+    const exampleAt = isExplicitHash ? atRaw : "<hash>";
+    throw new CliError(
+      `${original}\n\n` +
+        `⚠ ${target} is not available on the current RPC endpoint.\n` +
+        `   Public nodes serve only recent (pinned) blocks via chainHead_v1_*.\n` +
+        `   For deep historical reads, point --rpc at an archive endpoint, e.g.:\n` +
+        `     dot ... --at ${exampleAt} --rpc wss://<archive-endpoint>`,
     );
   }
 }

--- a/src/core/staleness.test.ts
+++ b/src/core/staleness.test.ts
@@ -4,8 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getMetadataFingerprintPath, loadMetadataFingerprint } from "../config/store.ts";
 import { withDotHome } from "../test-helpers/with-dot-home.ts";
+import { CliError } from "../utils/errors.ts";
 import type { ClientHandle } from "./client.ts";
-import { withStalenessSuggestion } from "./metadata.ts";
+import { withBlockAvailabilityHint, withStalenessSuggestion } from "./metadata.ts";
 
 interface MockClient {
   client: { _request: <T>(method: string, params: unknown[]) => Promise<T> };
@@ -271,5 +272,63 @@ describe("withStalenessSuggestion", () => {
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
+  });
+});
+
+describe("withBlockAvailabilityHint", () => {
+  test("returns the task result on success", async () => {
+    expect(await withBlockAvailabilityHint("finalized", async () => 42)).toBe(42);
+  });
+
+  test("propagates non-matching errors unchanged", async () => {
+    await expect(
+      withBlockAvailabilityHint("finalized", async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    ).rejects.toThrow("ECONNREFUSED");
+  });
+
+  test("wraps 'is not pinned' into a CliError with the archive hint", async () => {
+    let captured: Error | undefined;
+    try {
+      await withBlockAvailabilityHint("0xabc", async () => {
+        throw new Error("Block 0xabc is not pinned (storage)");
+      });
+    } catch (err) {
+      captured = err as Error;
+    }
+    expect(captured).toBeInstanceOf(CliError);
+    expect(captured!.message).toContain("0xabc is not available");
+    expect(captured!.message).toContain("archive endpoint");
+    expect(captured!.message).toContain("--rpc wss://<archive-endpoint>");
+  });
+
+  test("wraps BlockHashNotFoundError shape", async () => {
+    await expect(
+      withBlockAvailabilityHint("0xdead", async () => {
+        throw new Error("Invalid BlockHash: 0xdead");
+      }),
+    ).rejects.toThrow(/archive endpoint/);
+  });
+
+  test("uses generic phrasing for 'best'/'finalized'", async () => {
+    let captured: Error | undefined;
+    try {
+      await withBlockAvailabilityHint("finalized", async () => {
+        throw new Error("Block 0xfff is not pinned (storage)");
+      });
+    } catch (err) {
+      captured = err as Error;
+    }
+    expect(captured!.message).toContain("the requested block is not available");
+    expect(captured!.message).toContain("--at <hash>");
+  });
+
+  test("works with undefined atRaw", async () => {
+    await expect(
+      withBlockAvailabilityHint(undefined, async () => {
+        throw new Error("Invalid BlockHash: 0xabc");
+      }),
+    ).rejects.toThrow(/the requested block is not available/);
   });
 });

--- a/src/skill-marketplace.test.ts
+++ b/src/skill-marketplace.test.ts
@@ -109,6 +109,8 @@ describe("Claude Code skill marketplace", () => {
     expect(md).toContain("## Common Errors");
     expect(md).toContain("Complex Arguments");
     expect(md).toMatch(/--at\s*<block>/);
-    expect(md).toContain("historical state reads are not supported");
+    // --at now applies to query/apis too; the historical-reads guidance lives
+    // near the storage examples.
+    expect(md).toMatch(/--at\s*<[^>]+>.*historical/);
   });
 });

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { formatRuntimeError, isLikelyStaleMetadataError, isPapiCleanupError } from "./errors.ts";
+import {
+  formatRuntimeError,
+  isBlockUnavailableError,
+  isLikelyStaleMetadataError,
+  isPapiCleanupError,
+} from "./errors.ts";
 
 describe("isPapiCleanupError", () => {
   test("matches bare 'Not connected'", () => {
@@ -103,5 +108,45 @@ describe("isLikelyStaleMetadataError", () => {
 
   test("matches plain strings (not just Error instances)", () => {
     expect(isLikelyStaleMetadataError("wasm trap: unreachable")).toBe(true);
+  });
+});
+
+describe("isBlockUnavailableError", () => {
+  test("matches BlockHashNotFoundError shape", () => {
+    expect(
+      isBlockUnavailableError(
+        new Error(
+          "Invalid BlockHash: 0x4d7d68d4ad6d0bdfe6c693b88736e1c5a9f2c8eaf2c2c5e8d5b7b6e6f0a1b2c3",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches StorageError UnknownBlock shape", () => {
+    expect(
+      isBlockUnavailableError(
+        new Error("Storage Error: UnknownBlock: Header was not found in the database: 0x4d7d..."),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches the 'is not pinned' wrapper papi raises from chainHead_v1", () => {
+    expect(isBlockUnavailableError(new Error("Block 0xabc is not pinned (storage)"))).toBe(true);
+  });
+
+  test("does not match unrelated errors", () => {
+    expect(isBlockUnavailableError(new Error("ECONNREFUSED"))).toBe(false);
+    expect(isBlockUnavailableError(new Error("Invalid Transaction: BadProof"))).toBe(false);
+    expect(isBlockUnavailableError(new Error("pallet 'Foo' not found"))).toBe(false);
+  });
+
+  test("ignores empty / non-string-y values", () => {
+    expect(isBlockUnavailableError(undefined)).toBe(false);
+    expect(isBlockUnavailableError(null)).toBe(false);
+    expect(isBlockUnavailableError(42)).toBe(false);
+  });
+
+  test("matches plain strings (not just Error instances)", () => {
+    expect(isBlockUnavailableError("Invalid BlockHash: 0xdead")).toBe(true);
   });
 });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -53,6 +53,22 @@ export function isLikelyStaleMetadataError(err: unknown): boolean {
   return STALE_METADATA_PATTERNS.some((re) => re.test(msg));
 }
 
+// Errors papi raises when the requested block is not available on the
+// connected node — typically a hash older than the chainHead_v1_* pinned
+// window, or a hash that never existed. The user fix is to point --rpc at
+// an archive endpoint, which lives in `withBlockAvailabilityHint`.
+const BLOCK_UNAVAILABLE_PATTERNS: RegExp[] = [
+  /is not pinned/i,
+  /Invalid BlockHash/i,
+  /UnknownBlock.*Header was not found/i,
+];
+
+export function isBlockUnavailableError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  if (!msg) return false;
+  return BLOCK_UNAVAILABLE_PATTERNS.some((re) => re.test(msg));
+}
+
 export function formatRuntimeError(err: unknown): string {
   const msg = err instanceof Error ? err.message : String(err);
 


### PR DESCRIPTION
## Summary

- `--at` was declared on the global command but only ever wired into `tx` submission — `query.*` and `apis.*` accepted the flag silently and read current head anyway. Thread the value through to papi's trailing `PullOptions` argument on `storageApi.{getValue,getEntries}` and on runtime API calls.
- Fixed a pre-existing CAC/mri argv bug uncovered while writing executable docs: 0x-hex block hashes passed to `--at` were silently coerced to JS Numbers, losing precision. `--at` is now read from raw argv to keep the string intact (mirrors the existing `collectVarFlags` pattern).
- Added `parseAtForRead` for the permissive read semantics (accepts `"best"` / `"finalized"` / hash); existing strict `parseAtOption` for tx submission is untouched — papi v2 still rejects `"best"` for tx.

## Behavior matrix

| Command | `--at best` | `--at finalized` | `--at 0x<hash>` |
|---|---|---|---|
| `query.*` | ✓ | ✓ | ✓ |
| `apis.*`  | ✓ | ✓ | ✓ |
| `tx.*`    | rejected (papi v2) | ✓ | ✓ |

papi v2's `chainHead_v1_*` JSON-RPC only serves pinned (recent) blocks. For deep historical reads, point `--rpc` at an archive endpoint — docs/SKILL.md call this out.

## Test plan

- [x] `parseAtForRead` unit tests (undefined / "best" / "finalized" / valid hash / invalid)
- [x] `runCli` smoke tests for `--at best` and negative `--at latest` on both `query.System.Number` and `apis.Core.version`
- [x] Regression test that 0x-hex `--at` value is not coerced to Number by CAC
- [x] Existing strict `parseAtOption` tests (tx) still pass — tx semantics unchanged
- [x] Full suite: 1553 pass, 0 fail
- [x] Live-chain manual verification: `--at best`, `--at finalized`, `--at <finalized-hash>` against Polkadot for both `query.System.Number` and `apis.Core.version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)