### PR TITLE
feat(account): show pallet-revive H160 in `dot account inspect`

### DIFF
--- a/.changeset/feature-h160.md
+++ b/.changeset/feature-h160.md
@@ -1,0 +1,41 @@
+---
+"polkadot-cli": minor
+---
+
+feat(account): show pallet-revive H160 in `dot account inspect`
+
+Every Substrate account now also shows its pallet-revive 20-byte H160
+address (EIP-55 checksummed) on the `H160:` line, so developers working
+across SS58 and EVM tooling on Polkadot Hub / Asset Hub can see both
+representations side by side. The same H160 appears under the `h160`
+field of `--output json`.
+
+The mapping is offline and matches current `polkadot-sdk` master:
+
+- **AccountId32 → H160:** if the last 12 bytes are `0xEE`, strip them
+  (the account originated from an Eth address); otherwise
+  `keccak256(accountId32)` and take the last 20 bytes.
+- **H160 → AccountId32:** deterministic fallback `H160 || 0xEE * 12`.
+  The full mapping after `pallet_revive.map_account` lives in on-chain
+  `AddressSuffix` storage and is not recoverable offline.
+
+`dot account inspect` accepts a 20-byte H160 hex value as a new input
+form. It resolves to the fallback AccountId32 and reports
+`Kind: revive H160 fallback`.
+
+```bash
+dot account inspect alice
+#   H160:        0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+
+dot account inspect 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+#   Kind:        revive H160 fallback
+#   Public Key:  0x9621dde636de098b43efb0fa9b61facfe328f99deeeeeeeeeeeeeeeeeeeeeeee
+
+dot account inspect alice --json | jq -r .h160
+# 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+```
+
+Older `stable2412` runtimes used plain `accountId32[..20]` truncation
+instead of the keccak fallback for the forward direction. A
+`--revive-truncate` flag for those is not implemented; this release
+ships only the canonical current-master mapping.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ dot account alice                    # shorthand — unknown subcommands fall th
 
 dot account inspect 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
 dot account inspect 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+
+# pallet-revive H160 — the 20-byte address shape from EVM tooling. Same
+# input slot as SS58 / hex pubkey; resolved to the deterministic fallback
+# AccountId32 (`H160 || 0xEE * 12`).
+dot account inspect 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
 ```
 
 Use `--prefix` to encode the SS58 address with a specific network prefix (default: 42):
@@ -390,6 +395,7 @@ dot account inspect alice --json
 # {
 #   "publicKey": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
 #   "ss58": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+#   "h160": "0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D",
 #   "prefix": 42,
 #   "name": "Alice",
 #   "kind": "dev"
@@ -407,10 +413,38 @@ dot account inspect alice
 #   Kind:        dev
 #   Public Key:  0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
 #   SS58:        5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+#   H160:        0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
 #   Prefix:      42
 ```
 
-The `Kind:` line categorises the account: `dev` (built-in), `signer` (has a secret/env), `watch-only` (raw external address), `pallet sovereign` (derived from a `PalletId`), or `parachain sovereign (child|sibling)` (derived from a parachain ID). For derived sovereigns, an extra `Source:` line shows what the address was derived from. For env-backed signers, an `Env:` line shows the variable; for derived child keys, `Derivation:` shows the path.
+The `Kind:` line categorises the account: `dev` (built-in), `signer` (has a secret/env), `watch-only` (raw external address), `pallet sovereign` (derived from a `PalletId`), `parachain sovereign (child|sibling)` (derived from a parachain ID), or `revive H160 fallback` (a 20-byte input resolved to its deterministic Substrate AccountId32). For derived sovereigns, an extra `Source:` line shows what the address was derived from. For env-backed signers, an `Env:` line shows the variable; for derived child keys, `Derivation:` shows the path.
+
+##### pallet-revive H160 address
+
+Every Substrate account has a corresponding 20-byte H160 address under [pallet-revive](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame/revive) (the new EVM-compatible smart-contracts pallet on Polkadot Hub / Asset Hub). `dot account inspect` always shows it, EIP-55 checksummed, on the `H160:` line. The mapping is offline and prefix-independent:
+
+- **AccountId32 → H160:** if the last 12 bytes are `0xEE`, strip them (the account originated from an Eth address); otherwise `keccak256(accountId32)` and take the last 20 bytes.
+- **H160 → AccountId32:** deterministic fallback is `H160 || 0xEE * 12`. (The full mapping after a successful `pallet_revive.map_account` extrinsic lives in on-chain `AddressSuffix` storage and isn't recoverable offline — that's a chain-state lookup.)
+
+Pass a 20-byte hex value as the inspect input to resolve it back to its fallback Substrate account:
+
+```bash
+dot account inspect 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+# Output:
+# Account Info
+#
+#   Kind:        revive H160 fallback
+#   Public Key:  0x9621dde636de098b43efb0fa9b61facfe328f99deeeeeeeeeeeeeeeeeeeeeeee
+#   SS58:        5FTZ6n1wY3GBqEZ2DWEdspbTarvRnp8DM8x2YXbWubu7JN98
+#   H160:        0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+#   Prefix:      42
+
+# Script-friendly: just the H160 for a given account
+dot account inspect alice --json | jq -r .h160
+# 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+```
+
+Note: `dot` implements the current `pallet-revive` master variant (keccak fallback). Older `stable2412` runtimes used plain `accountId32[..20]` truncation; if you target one, compute it manually until a `--revive-truncate` flag lands.
 
 ##### Stateless sovereign derivation (script-friendly)
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -665,6 +665,7 @@ Convert between SS58 addresses, hex public keys, and account names. Accepts any 
 - **Stored account name** — looks up the public key from the accounts file
 - **SS58 address** — decodes to the underlying public key
 - **Hex public key** (`0x` + 64 hex chars) — encodes to SS58
+- **H160 / EVM address** (`0x` + 40 hex chars) — resolves to the pallet-revive fallback `AccountId32` (`H160 || 0xEE * 12`)
 - **`--pallet-id <id>`** — derives a pallet sovereign address without saving it (script-friendly)
 - **`--parachain <id> --parachain-type <child|sibling>`** — derives a parachain sovereign address without saving it
 
@@ -674,6 +675,7 @@ dot account alice                    # shorthand — unknown subcommands fall th
 
 dot account inspect 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
 dot account inspect 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+dot account inspect 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D   # H160 / EVM input
 ```
 
 Use `--prefix` to encode the SS58 address with a specific network prefix (default: 42):
@@ -694,10 +696,11 @@ dot account inspect alice
 #   Kind:        dev
 #   Public Key:  0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
 #   SS58:        5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+#   H160:        0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
 #   Prefix:      42
 ```
 
-The `Kind:` line categorises the account: `dev`, `signer`, `watch-only`, `pallet sovereign`, or `parachain sovereign (child|sibling)`. For derived sovereigns, an extra `Source:` line shows what the address was derived from (e.g. `PalletId py/trsry (0x70792f7472737279)` or `parachain 1004`). For env-backed signers an `Env:` line shows the variable; for derived child keys, `Derivation:` shows the path.
+The `Kind:` line categorises the account: `dev`, `signer`, `watch-only`, `pallet sovereign`, `parachain sovereign (child|sibling)`, or `revive H160 fallback` (when a 20-byte hex input is resolved to its deterministic Substrate AccountId32). For derived sovereigns, an extra `Source:` line shows what the address was derived from (e.g. `PalletId py/trsry (0x70792f7472737279)` or `parachain 1004`). For env-backed signers an `Env:` line shows the variable; for derived child keys, `Derivation:` shows the path. The `H160:` line is shown for every account — it's the pallet-revive 20-byte address, EIP-55 checksummed and prefix-independent.
 
 JSON output:
 
@@ -707,11 +710,42 @@ dot account inspect alice --json
 # {
 #   "publicKey": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
 #   "ss58": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+#   "h160": "0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D",
 #   "prefix": 42,
 #   "name": "Alice",
 #   "kind": "dev"
 # }
 ```
+
+#### pallet-revive H160 mapping
+
+Every Substrate account has a corresponding 20-byte H160 under [pallet-revive](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame/revive) (the new EVM-compatible smart-contracts pallet on Polkadot Hub / Asset Hub). `dot` computes this offline using the canonical mapping (current `polkadot-sdk` master):
+
+- **AccountId32 → H160:** if the last 12 bytes are `0xEE`, strip them (the account originated from an Eth address); otherwise `keccak256(accountId32)` and take the last 20 bytes.
+- **H160 → AccountId32:** deterministic fallback is `H160 || 0xEE * 12`. The full mapping after a successful `pallet_revive.map_account` extrinsic lives in on-chain `AddressSuffix` storage and isn't recoverable offline — that's a chain-state lookup, not an `inspect` concern.
+
+Resolve an H160 back to its fallback Substrate account by passing it as the inspect input:
+
+```
+dot account inspect 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+# Output:
+# Account Info
+#
+#   Kind:        revive H160 fallback
+#   Public Key:  0x9621dde636de098b43efb0fa9b61facfe328f99deeeeeeeeeeeeeeeeeeeeeeee
+#   SS58:        5FTZ6n1wY3GBqEZ2DWEdspbTarvRnp8DM8x2YXbWubu7JN98
+#   H160:        0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+#   Prefix:      42
+```
+
+Script-friendly extraction:
+
+```
+dot account inspect alice --json | jq -r .h160
+# 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+```
+
+Caveat: older `stable2412` runtimes used plain `accountId32[..20]` truncation for the forward direction instead of the keccak fallback. `dot` implements the current variant; if you target a legacy runtime, compute manually until a `--revive-truncate` flag lands.
 
 #### Stateless sovereign derivation (script-friendly)
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -426,6 +426,37 @@ dot account create new-key
 
 Built-in dev accounts: `alice`, `bob`, `charlie`, `dave`, `eve`, `ferdie`
 
+### Inspecting accounts (and the pallet-revive H160)
+
+`dot account inspect <input>` resolves a name, SS58, hex public key, **or 20-byte H160** and prints the canonical attributes. Every account now also shows its pallet-revive H160 (EIP-55, prefix-independent) — useful when working across SS58 and EVM tooling on Polkadot Hub / Asset Hub:
+
+```bash
+dot account inspect alice
+# Output:
+# Account Info
+#
+#   Name:        Alice
+#   Kind:        dev
+#   Public Key:  0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+#   SS58:        5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+#   H160:        0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+#   Prefix:      42
+
+# Reverse — a 20-byte H160 resolves to the deterministic fallback AccountId32 (H160 || 0xEE * 12)
+dot account inspect 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+# Output:
+#   Kind:        revive H160 fallback
+#   Public Key:  0x9621dde636de098b43efb0fa9b61facfe328f99deeeeeeeeeeeeeeeeeeeeeeee
+#   SS58:        5FTZ6n1wY3GBqEZ2DWEdspbTarvRnp8DM8x2YXbWubu7JN98
+#   H160:        0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+
+# Script: extract just the H160 for a given account
+dot account inspect alice --json | jq -r .h160
+# 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
+```
+
+Mapping rule (offline, matches current `polkadot-sdk` master): if the last 12 bytes of the AccountId32 are `0xEE` the H160 is the first 20 bytes (eth-derived); otherwise `keccak256(accountId32)` and take the last 20. The reverse direction always returns the `H160 || 0xEE * 12` fallback — the full mapping after `pallet_revive.map_account` lives in on-chain `AddressSuffix` storage and isn't recoverable offline. Older `stable2412` runtimes used plain `accountId32[..20]` truncation; if you target one, compute manually.
+
 ### Sovereign Accounts (Parachain & Pallet)
 
 `dot account add` accepts derivation flags that compute a deterministic 32-byte address and store it as a named watch-only account — reusable in `--from`, as tx args, and in `dot account list`. Offline; no chain connection required.

--- a/src/commands/account.test.ts
+++ b/src/commands/account.test.ts
@@ -529,13 +529,15 @@ describe("dot account", { timeout: 15_000 }, () => {
 
   // inspect tests
 
-  test("inspect alice shows public key and SS58", async () => {
+  test("inspect alice shows public key, SS58 and H160", async () => {
     const { stdout, exitCode } = await runCli(["account", "inspect", "alice"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("Account Info");
     expect(stdout).toContain("Alice");
     expect(stdout).toContain("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d");
     expect(stdout).toContain("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    expect(stdout).toContain("H160:");
+    expect(stdout).toContain("0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D");
   });
 
   test("inspect alice (implicit, no inspect keyword) works", async () => {
@@ -596,7 +598,41 @@ describe("dot account", { timeout: 15_000 }, () => {
       "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
     );
     expect(parsed.ss58).toBe("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    expect(parsed.h160).toBe("0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D");
     expect(parsed.prefix).toBe(42);
+  });
+
+  test("inspect H160 resolves to revive fallback AccountId32", async () => {
+    const { stdout, exitCode } = await runCli([
+      "account",
+      "inspect",
+      "0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Account Info");
+    expect(stdout).toContain("revive H160 fallback");
+    // Fallback AccountId32 = H160 || 0xEE * 12 (lowercased in public-key form)
+    expect(stdout).toContain("0x9621dde636de098b43efb0fa9b61facfe328f99deeeeeeeeeeeeeeeeeeeeeeee");
+    // The H160 line echoes the same EIP-55 address back
+    expect(stdout).toContain("H160:");
+    expect(stdout).toContain("0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D");
+  });
+
+  test("inspect H160 with --output json returns fallback fields", async () => {
+    const { stdout, exitCode } = await runCli([
+      "account",
+      "inspect",
+      "0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D",
+      "--output",
+      "json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.kind).toBe("revive H160 fallback");
+    expect(parsed.publicKey).toBe(
+      "0x9621dde636de098b43efb0fa9b61facfe328f99deeeeeeeeeeeeeeeeeeeeeeee",
+    );
+    expect(parsed.h160).toBe("0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D");
   });
 
   test("inspect invalid input errors", async () => {

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from "node:fs/promises";
+import { hexToBytes as nobleHexToBytes } from "@noble/hashes/utils.js";
 import type { CAC } from "cac";
 import { findAccount, loadAccounts, saveAccounts } from "../config/accounts-store.ts";
 import {
@@ -23,6 +24,13 @@ import {
   toSs58,
   tryDerivePublicKey,
 } from "../core/accounts.ts";
+import {
+  accountIdToH160,
+  h160FromHex,
+  h160ToFallbackAccountId,
+  isH160Hex,
+  toEip55,
+} from "../core/h160.ts";
 import {
   BOLD,
   CYAN,
@@ -895,6 +903,7 @@ async function accountInspect(
   let hasSecret = false;
   let storedAccount: StoredAccount | undefined;
   let isDev = false;
+  let isH160Fallback = false;
   // Synthetic source for the stateless-derivation branch — same shape as
   // StoredAccount.source so the JSON/pretty-print branches downstream don't
   // need a separate code path.
@@ -959,14 +968,20 @@ async function accountInspect(
     else if (isHexPublicKey(input!)) {
       publicKeyHex = input!;
     }
-    // 4. Try SS58 decode
+    // 4. H160 (20-byte hex) — revive fallback AccountId32 (H160 || 0xEE * 12)
+    else if (isH160Hex(input!)) {
+      const fallback = h160ToFallbackAccountId(h160FromHex(input!));
+      publicKeyHex = publicKeyToHex(fallback);
+      isH160Fallback = true;
+    }
+    // 5. Try SS58 decode
     else {
       try {
         const decoded = fromSs58(input!);
         publicKeyHex = publicKeyToHex(decoded);
       } catch {
         console.error(
-          `Cannot identify "${input}" as an account name, SS58 address, or hex public key.`,
+          `Cannot identify "${input}" as an account name, SS58 address, hex public key, or H160.`,
         );
         process.exit(1);
       }
@@ -974,6 +989,7 @@ async function accountInspect(
   }
 
   const ss58 = toSs58(publicKeyHex!, prefix);
+  const h160Hex = toEip55(accountIdToH160(nobleHexToBytes(publicKeyHex!.slice(2))));
 
   let privateKeyHex: string | undefined;
   if (opts.showSecret) {
@@ -1010,6 +1026,8 @@ async function accountInspect(
     sourceLine = `parachain ${virtualSource.paraId}`;
   } else if (isDev) {
     kindLabel = "dev";
+  } else if (isH160Fallback) {
+    kindLabel = "revive H160 fallback";
   } else if (storedAccount) {
     const k = classifyAccount(storedAccount);
     if (k === "pallet" && storedAccount.source?.kind === "pallet") {
@@ -1031,7 +1049,12 @@ async function accountInspect(
   }
 
   if (isJsonOutput(opts)) {
-    const result: Record<string, unknown> = { publicKey: publicKeyHex!, ss58, prefix };
+    const result: Record<string, unknown> = {
+      publicKey: publicKeyHex!,
+      ss58,
+      h160: h160Hex,
+      prefix,
+    };
     if (name) result.name = name;
     if (kindLabel) result.kind = kindLabel;
     if (virtualSource?.kind === "pallet") {
@@ -1070,6 +1093,7 @@ async function accountInspect(
     if (kindLabel) console.log(`  ${BOLD}Kind:${RESET}        ${kindLabel}`);
     console.log(`  ${BOLD}Public Key:${RESET}  ${publicKeyHex!}`);
     console.log(`  ${BOLD}SS58:${RESET}        ${ss58}`);
+    console.log(`  ${BOLD}H160:${RESET}        ${h160Hex}`);
     if (sourceLine) console.log(`  ${BOLD}Source:${RESET}      ${sourceLine}`);
     if (derivationLine) console.log(`  ${BOLD}Derivation:${RESET}  ${derivationLine}`);
     if (envLine) console.log(`  ${BOLD}Env:${RESET}         ${envLine}`);

--- a/src/core/h160.test.ts
+++ b/src/core/h160.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
+import {
+  accountIdToH160,
+  h160FromHex,
+  h160ToFallbackAccountId,
+  isH160Hex,
+  toEip55,
+} from "./h160.ts";
+
+const ALICE_ACCOUNT_ID = "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
+const ALICE_H160_EIP55 = "0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D";
+
+test("accountIdToH160: Alice routes through keccak fallback", () => {
+  const h160 = accountIdToH160(hexToBytes(ALICE_ACCOUNT_ID));
+  expect(toEip55(h160)).toBe(ALICE_H160_EIP55);
+});
+
+test("accountIdToH160: eth-derived suffix strips trailing 0xEE*12", () => {
+  const h160 = hexToBytes("aabbccddeeff00112233445566778899aabbccdd");
+  const fallback = h160ToFallbackAccountId(h160);
+  const recovered = accountIdToH160(fallback);
+  expect(bytesToHex(recovered)).toBe(bytesToHex(h160));
+});
+
+test("accountIdToH160: rejects non-32-byte input", () => {
+  expect(() => accountIdToH160(new Uint8Array(31))).toThrow();
+  expect(() => accountIdToH160(new Uint8Array(33))).toThrow();
+});
+
+test("h160ToFallbackAccountId: appends 12 bytes of 0xEE", () => {
+  const h160 = hexToBytes("0102030405060708090a0b0c0d0e0f1011121314");
+  const fallback = h160ToFallbackAccountId(h160);
+  expect(fallback.length).toBe(32);
+  expect(bytesToHex(fallback.slice(0, 20))).toBe(bytesToHex(h160));
+  for (let i = 20; i < 32; i++) {
+    expect(fallback[i]).toBe(0xee);
+  }
+});
+
+test("h160ToFallbackAccountId: rejects non-20-byte input", () => {
+  expect(() => h160ToFallbackAccountId(new Uint8Array(19))).toThrow();
+  expect(() => h160ToFallbackAccountId(new Uint8Array(21))).toThrow();
+});
+
+// EIP-55 canonical vectors (https://eips.ethereum.org/EIPS/eip-55)
+test.each([
+  ["5aaeb6053f3e94c9b9a09f33669435e7ef1beaed", "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"],
+  ["fb6916095ca1df60bb79ce92ce3ea74c37c5d359", "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"],
+  ["dbf03b407c01e7cd3cbea99509d93f8dddc8c6fb", "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"],
+  ["d1220a0cf47c7b9be7a2e6ba89f429762e7b9adb", "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"],
+])("toEip55: %s -> %s", (lower, expected) => {
+  expect(toEip55(hexToBytes(lower))).toBe(expected);
+});
+
+test("toEip55: rejects non-20-byte input", () => {
+  expect(() => toEip55(new Uint8Array(19))).toThrow();
+});
+
+test("isH160Hex: accepts 0x + 40 hex, rejects everything else", () => {
+  expect(isH160Hex("0x9621Dde636de098B43efb0fa9b61FacFE328F99d")).toBe(true);
+  expect(isH160Hex("0x9621dde636de098b43efb0fa9b61facfe328f99d")).toBe(true);
+  expect(isH160Hex("9621dde636de098b43efb0fa9b61facfe328f99d")).toBe(false); // no 0x
+  expect(isH160Hex("0x9621Dde636de098B43efb0fa9b61FacFE328F99")).toBe(false); // 39 hex
+  expect(isH160Hex("0x9621Dde636de098B43efb0fa9b61FacFE328F99dd")).toBe(false); // 41 hex
+  expect(isH160Hex("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d")).toBe(
+    false,
+  );
+});
+
+test("h160FromHex: round-trips through toEip55", () => {
+  const bytes = h160FromHex(ALICE_H160_EIP55);
+  expect(bytes.length).toBe(20);
+  expect(toEip55(bytes)).toBe(ALICE_H160_EIP55);
+});

--- a/src/core/h160.ts
+++ b/src/core/h160.ts
@@ -1,0 +1,65 @@
+import { keccak_256 } from "@noble/hashes/sha3.js";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
+
+const ETH_DERIVED_SUFFIX_BYTE = 0xee;
+const H160_LEN = 20;
+const ACCOUNT_ID_LEN = 32;
+
+function hasEthDerivedSuffix(accountId: Uint8Array): boolean {
+  if (accountId.length !== ACCOUNT_ID_LEN) return false;
+  for (let i = H160_LEN; i < ACCOUNT_ID_LEN; i++) {
+    if (accountId[i] !== ETH_DERIVED_SUFFIX_BYTE) return false;
+  }
+  return true;
+}
+
+// Mirrors pallet-revive's `AccountId32Mapper::to_address` on current master:
+// if the last 12 bytes are 0xEE the account originated from an Eth address
+// (strip suffix), otherwise hash the full 32 bytes with keccak-256 and take the
+// last 20. Older runtimes (pre-stable2503) used plain `accountId[..20]`
+// truncation — not implemented here.
+export function accountIdToH160(accountId: Uint8Array): Uint8Array {
+  if (accountId.length !== ACCOUNT_ID_LEN) {
+    throw new Error(`accountIdToH160 expects 32 bytes, got ${accountId.length}`);
+  }
+  if (hasEthDerivedSuffix(accountId)) {
+    return accountId.slice(0, H160_LEN);
+  }
+  return keccak_256(accountId).slice(ACCOUNT_ID_LEN - H160_LEN);
+}
+
+export function h160ToFallbackAccountId(h160: Uint8Array): Uint8Array {
+  if (h160.length !== H160_LEN) {
+    throw new Error(`h160ToFallbackAccountId expects 20 bytes, got ${h160.length}`);
+  }
+  const out = new Uint8Array(ACCOUNT_ID_LEN);
+  out.set(h160, 0);
+  out.fill(ETH_DERIVED_SUFFIX_BYTE, H160_LEN);
+  return out;
+}
+
+export function toEip55(h160: Uint8Array): string {
+  if (h160.length !== H160_LEN) {
+    throw new Error(`toEip55 expects 20 bytes, got ${h160.length}`);
+  }
+  const lowerHex = bytesToHex(h160);
+  const hashBytes = keccak_256(new TextEncoder().encode(lowerHex));
+  let out = "0x";
+  for (let i = 0; i < lowerHex.length; i++) {
+    const c = lowerHex[i]!;
+    const nibble = i % 2 === 0 ? hashBytes[i >> 1]! >> 4 : hashBytes[i >> 1]! & 0x0f;
+    out += nibble >= 8 ? c.toUpperCase() : c;
+  }
+  return out;
+}
+
+export function isH160Hex(input: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(input);
+}
+
+export function h160FromHex(input: string): Uint8Array {
+  if (!isH160Hex(input)) {
+    throw new Error(`Not a valid 0x-prefixed 20-byte hex string: ${input}`);
+  }
+  return hexToBytes(input.slice(2));
+}


### PR DESCRIPTION
## Summary

- `dot account inspect <ref>` (including `dot account alice` and friends) now shows the pallet-revive 20-byte H160 alongside the existing SS58 / Public Key fields. EIP-55 checksummed, prefix-independent, also surfaced as `h160` in `--output json`.
- `dot account inspect 0x<40-hex>` is accepted as a new input form and resolves to the deterministic fallback AccountId32 (`H160 || 0xEE * 12`), reporting `Kind: revive H160 fallback`.
- Pure conversion module `src/core/h160.ts` (`accountIdToH160`, `h160ToFallbackAccountId`, EIP-55 `toEip55`, helpers) with 12 unit-test vectors including Alice and the canonical EIP-55 spec cases.

## Mapping rule (current `polkadot-sdk` master)

- **AccountId32 → H160:** if `accountId[20..] == 0xEE * 12`, the H160 is `accountId[..20]` (eth-derived account); otherwise `keccak256(accountId)[12..]` (the "keccak fallback" path).
- **H160 → AccountId32 (offline):** `H160 || 0xEE * 12`. The full mapping after a successful `pallet_revive.map_account` extrinsic lives in on-chain `AddressSuffix` storage — out of scope here, would need an RPC lookup.

Older `stable2412` runtimes used plain `accountId[..20]` truncation; a `--revive-truncate` flag for those is **out of scope** for this PR.

## Examples

```
$ dot account alice
Account Info

  Name:        Alice
  Kind:        dev
  Public Key:  0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
  SS58:        5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
  H160:        0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
  Prefix:      42

$ dot account inspect 0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
Account Info

  Kind:        revive H160 fallback
  Public Key:  0x9621dde636de098b43efb0fa9b61facfe328f99deeeeeeeeeeeeeeeeeeeeeeee
  SS58:        5FTZ6n1wY3GBqEZ2DWEdspbTarvRnp8DM8x2YXbWubu7JN98
  H160:        0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
  Prefix:      42

$ dot account inspect alice --json | jq -r .h160
0x9621DDe636dE098B43Efb0fA9b61fAcFE328F99D
```

## Docs

- `README.md` — new section under "Inspect an account" covering H160 display + reverse lookup.
- `docs/content/_index.md` — same in the Hugo docs.
- `dot-cli/SKILL.md` — new "Inspecting accounts (and the pallet-revive H160)" subsection.
- `.changeset/feature-h160.md` — minor bump.

## Test plan

- [x] `bun test src/core/h160.test.ts` — 12 vectors: Alice keccak path, eth-derived suffix round-trip, canonical EIP-55 cases from the spec, validators on input length.
- [x] `bun test src/commands/account.test.ts` — extended `inspect alice` and `--output json` snapshots; two new tests for H160-as-input (human + JSON).
- [x] Full `bun test` — 1557 pass / 0 fail (pre-commit hook ran it).
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean.
- [x] Coverage on `src/core/h160.ts`: 100% functions, 97.87% lines.
- [x] Manual smoke: `dot account alice`, `dot account inspect <h160>`, `dot account inspect bob --prefix 0` (H160 unchanged across prefixes), `dot account alice --output json | jq .h160`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)