### PR TITLE
fix(tx): fire stale-metadata hint on BadProof / AncientBirthBlock

### DIFF
--- a/.changeset/bug-badproof.md
+++ b/.changeset/bug-badproof.md
@@ -1,0 +1,28 @@
+---
+"polkadot-cli": patch
+---
+
+fix(tx): show stale-metadata hint on `BadProof` / `AncientBirthBlock`
+
+`withStalenessSuggestion` already wraps every `signSubmitAndWatch` call
+and, on error, compares cached `(specVersion, transactionVersion,
+codeHash)` against the live runtime — if they diverge it appends the
+`⚠ Local metadata for "<chain>" is out of date … Run: dot chain update
+<chain>` hint. But the gating regex only matched wasm-trap / codec /
+decode symptoms, not `Invalid::BadProof` or `Invalid::AncientBirthBlock`.
+
+After a chain runtime upgrade the signer used the cached spec/tx
+version, the runtime reconstructed a different payload, the signature
+didn't verify and the tx was rejected with a bare `BadProof` — leaving
+the user guessing. The fingerprint mismatch was right there but the
+regex skipped over it.
+
+`CheckSpecVersion` / `CheckTxVersion` / `CheckGenesis` /
+`CheckMortality` are all in the signed payload, so `BadProof` and
+`AncientBirthBlock` are exactly the variants that smell like stale
+metadata. Adding them to the pattern list lets the existing fingerprint
+gate run; if cached matches live (genuine bad key / wrong chain) the
+raw error still passes through unchanged.
+
+Nonce-mismatch variants (`Future`, `Stale`) are deliberately excluded —
+those are account-state issues, not metadata.

--- a/src/core/staleness.test.ts
+++ b/src/core/staleness.test.ts
@@ -227,6 +227,111 @@ describe("withStalenessSuggestion", () => {
     }
   });
 
+  test("wraps a BadProof error with the staleness hint when spec diverged", async () => {
+    // Reproduces the original bug: nextv2-ah moved spec 2000011 → 2000014,
+    // signer used the cached spec, runtime rejected with Invalid::BadProof.
+    // The post-error path should detect the fingerprint mismatch and append
+    // the "Run: dot chain update <chain>" hint instead of leaving the user
+    // staring at a bare BadProof.
+    const home = makeFreshHome();
+    const cached = {
+      specName: "polkadot",
+      specVersion: 2000011,
+      transactionVersion: 16,
+      implName: "parity-polkadot",
+      implVersion: 0,
+      authoringVersion: 0,
+      codeHash: "0xaaaa",
+      fetchedAt: "2026-04-27T12:00:00Z",
+    };
+    const client = makeMockClient((method) => {
+      if (method === "state_getRuntimeVersion") {
+        return {
+          specName: "polkadot",
+          specVersion: 2000014,
+          transactionVersion: 16,
+          implName: "parity-polkadot",
+          implVersion: 0,
+          authoringVersion: 0,
+        };
+      }
+      if (method === "state_getStorageHash") return "0xbbbb";
+      throw new Error(`unexpected method: ${method}`);
+    });
+    // The actual papi InvalidTxError carries a JSON-stringified payload.
+    const BAD_PROOF = new Error(
+      '{\n  "type": "Invalid",\n  "value": {\n    "type": "BadProof"\n  }\n}',
+    );
+    try {
+      await withDotHome(home, async () => {
+        withFingerprint(home, cached);
+        let captured: Error | undefined;
+        try {
+          await withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+            throw BAD_PROOF;
+          });
+        } catch (err) {
+          captured = err as Error;
+        }
+        expect(captured).toBeDefined();
+        expect(captured!.message).toContain('Local metadata for "polkadot" is out of date');
+        expect(captured!.message).toContain("spec 2000011 → 2000014");
+        expect(captured!.message).toContain("dot chain update polkadot");
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates BadProof unchanged when fingerprint matches (likely bad key)", async () => {
+    // If the signer's key really is wrong and metadata is current, we must
+    // NOT mislead the user into running `dot chain update`. The fingerprint
+    // gate is the safety net.
+    const home = makeFreshHome();
+    const fp = {
+      specName: "polkadot",
+      specVersion: 2000014,
+      transactionVersion: 16,
+      implName: "parity-polkadot",
+      implVersion: 0,
+      authoringVersion: 0,
+      codeHash: "0xfeed",
+      fetchedAt: "2026-04-27T12:00:00Z",
+    };
+    const client = makeMockClient((method) => {
+      if (method === "state_getRuntimeVersion") {
+        return {
+          specName: fp.specName,
+          specVersion: fp.specVersion,
+          transactionVersion: fp.transactionVersion,
+          implName: fp.implName,
+          implVersion: fp.implVersion,
+          authoringVersion: fp.authoringVersion,
+        };
+      }
+      if (method === "state_getStorageHash") return "0xfeed";
+      throw new Error(`unexpected method: ${method}`);
+    });
+    try {
+      await withDotHome(home, async () => {
+        withFingerprint(home, fp);
+        let captured: Error | undefined;
+        try {
+          await withStalenessSuggestion("polkadot", client as unknown as ClientHandle, async () => {
+            throw new Error("Invalid Transaction: BadProof");
+          });
+        } catch (err) {
+          captured = err as Error;
+        }
+        expect(captured).toBeDefined();
+        expect(captured!.message).toContain("BadProof");
+        expect(captured!.message).not.toContain("dot chain update");
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   test("wraps with code-hash note when only codeHash differs (same spec)", async () => {
     const home = makeFreshHome();
     const cached = {

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -92,6 +92,33 @@ describe("isLikelyStaleMetadataError", () => {
     expect(isLikelyStaleMetadataError(new Error("metadata mismatch detected"))).toBe(true);
   });
 
+  test("matches BadProof from papi InvalidTxError (JSON-stringified payload)", () => {
+    // What polkadot-api throws when validate_transaction returns Invalid::BadProof:
+    // the message is JSON.stringify of the TransactionValidityError enum.
+    const papiMsg = '{\n  "type": "Invalid",\n  "value": {\n    "type": "BadProof"\n  }\n}';
+    expect(isLikelyStaleMetadataError(new Error(papiMsg))).toBe(true);
+  });
+
+  test("matches BadProof from a substrate JSON-RPC text error", () => {
+    expect(isLikelyStaleMetadataError(new Error("Invalid Transaction: BadProof"))).toBe(true);
+  });
+
+  test("matches AncientBirthBlock (signed-payload era hash diverged)", () => {
+    const papiMsg =
+      '{\n  "type": "Invalid",\n  "value": {\n    "type": "AncientBirthBlock"\n  }\n}';
+    expect(isLikelyStaleMetadataError(new Error(papiMsg))).toBe(true);
+    expect(isLikelyStaleMetadataError(new Error("Invalid Transaction: AncientBirthBlock"))).toBe(
+      true,
+    );
+  });
+
+  test("does NOT match nonce-mismatch variants (Future / Stale)", () => {
+    // These are account-nonce errors, not stale-metadata symptoms. Asking the
+    // user to refresh metadata here would be misleading.
+    expect(isLikelyStaleMetadataError(new Error("Invalid Transaction: Future"))).toBe(false);
+    expect(isLikelyStaleMetadataError(new Error("Invalid Transaction: Stale"))).toBe(false);
+  });
+
   test("does NOT match user-typo errors", () => {
     expect(isLikelyStaleMetadataError(new Error("pallet 'Foo' not found"))).toBe(false);
     expect(isLikelyStaleMetadataError(new Error("call 'bar' not found in pallet System"))).toBe(

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -34,9 +34,17 @@ export function isPapiCleanupError(err: unknown): boolean {
 }
 
 // Errors that smell like the runtime saw a SCALE-encoded extrinsic / storage
-// key produced from out-of-date type tables. These are the symptoms of stale
-// local metadata. User-typo errors ("pallet not found", "call not found") are
-// deliberately NOT in this set — they propagate immediately.
+// key produced from out-of-date type tables, or signed-extension fields that
+// disagree with the live runtime. These are the symptoms of stale local
+// metadata. User-typo errors ("pallet not found", "call not found") are
+// deliberately NOT in this set — they propagate immediately. BadProof /
+// AncientBirthBlock come from TransactionValidityError after a runtime
+// upgrade: CheckSpecVersion / CheckTxVersion / CheckGenesis / CheckMortality
+// fields are part of the signed payload, so a signer using stale values
+// produces a payload the runtime won't reconstruct identically. The
+// withStalenessSuggestion fingerprint check is the safety net for the
+// false-positive cases (wrong key, wrong chain) — if cached fingerprint
+// matches live, the raw error passes through unchanged.
 const STALE_METADATA_PATTERNS: RegExp[] = [
   /wasm trap/i,
   /wasm `?unreachable`? instruction/i,
@@ -45,6 +53,8 @@ const STALE_METADATA_PATTERNS: RegExp[] = [
   /decod(e|ing)/i,
   /Lookup failed/i,
   /metadata.*mismatch/i,
+  /BadProof/,
+  /AncientBirthBlock/,
 ];
 
 export function isLikelyStaleMetadataError(err: unknown): boolean {


### PR DESCRIPTION
## Summary

- `withStalenessSuggestion` already wraps every `signSubmitAndWatch` call and emits a `⚠ Local metadata for "<chain>" is out of date … Run: dot chain update <chain>` hint when the cached `(specVersion, transactionVersion, codeHash)` diverges from live — but the gating regex skipped `Invalid::BadProof` / `Invalid::AncientBirthBlock`, so a stale signer after a chain runtime upgrade got a bare `BadProof` and the user had to guess.
- `CheckSpecVersion` / `CheckTxVersion` / `CheckGenesis` / `CheckMortality` are part of the signed payload, so these are exactly the `TransactionValidityError` variants that smell like stale metadata. The existing fingerprint check is the safety net for false positives (real bad key, wrong chain) — if cached matches live, the raw error still passes through unchanged.
- Nonce variants (`Future`, `Stale`) are deliberately excluded — those are account-state issues, not metadata.

> Rebased onto latest `main` (post polkadot-api 2.1.4 upgrade and verifiable-primitives merge) — clean rebase, no conflicts.

## Test plan

- [x] `bun test src/utils/errors.test.ts src/core/staleness.test.ts` — new positive cases for BadProof / AncientBirthBlock (both papi `InvalidTxError` JSON form and substrate JSON-RPC text form), negative cases for `Future` / `Stale`, plus an end-to-end staleness test that reproduces the original bug (spec 2000011 → 2000014) and a safety-net test that confirms a real bad key (fingerprint matches live) does **not** suggest `dot chain update`.
- [x] Full suite after rebase: 1655 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
