### PR TITLE
chore(deps): upgrade verifiablejs to 1.3.0

### DIFF
--- a/.changeset/upgrade-verifiablejs-1-3-0.md
+++ b/.changeset/upgrade-verifiablejs-1-3-0.md
@@ -1,0 +1,13 @@
+---
+"polkadot-cli": patch
+---
+
+chore(deps): upgrade `verifiablejs` to `1.3.0`
+
+Bumps `verifiablejs` from `1.3.0-beta.2` to the stable `1.3.0` release. The JS
+API consumed by the CLI (`member_from_entropy`) is unchanged, but the release
+bumps the underlying `verifiable` crate to v0.5.0 (ThinVRF, new ring proofs),
+so derived Bandersnatch member keys are **wire-incompatible** with `beta.2` —
+this is the intended alignment with the `verifiable` crate used on-chain by
+`individuality`. Updated the documented example keys (README, docs) and added a
+regression test pinning alice's derived member keys to the 1.3.0 wire format.

--- a/README.md
+++ b/README.md
@@ -1871,7 +1871,7 @@ dot verifiable alice
 # Bandersnatch Member Key
 #
 #   Account:    alice
-#   Member Key: 0x66813b70ba616b374c90ac92edff6e3be95e12adbc93ea7a6c37cbf334ab87e2
+#   Member Key: 0xbb6ee099b568f1844d62fc00e6305c2e83aa8da30ce59e664ef39e089204d43c
 
 # Derive keyed member key (full person — "candidate" context)
 dot verifiable alice --context candidate
@@ -1880,7 +1880,7 @@ dot verifiable alice --context candidate
 #
 #   Account:    alice
 #   Context:    candidate
-#   Member Key: 0x2fd5b74033d904cf5575b932507939c5d43811e488223229eaf5596565f15ae6
+#   Member Key: 0x5f915576987547d3e55bb4129ac8cae1d338f8933073dc74272b4c825f738592
 
 # Arbitrary context string
 dot verifiable alice --context pps

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@scure/sr25519": "^1.0.0",
         "cac": "^6.7.14",
         "polkadot-api": "^2.1.4",
-        "verifiablejs": "1.3.0-beta.2",
+        "verifiablejs": "1.3.0",
         "yaml": "^2.8.3",
       },
       "devDependencies": {
@@ -550,7 +550,7 @@
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
-    "verifiablejs": ["verifiablejs@1.3.0-beta.2", "", {}, "sha512-asQR9sueO6LtUjrErSla3kt0ft2t/8kGrK6Q5HKkACAgLVKqdJ0Uk3QVmFQQx8FjkqxN9biKgL+J1fQowtm+Lw=="],
+    "verifiablejs": ["verifiablejs@1.3.0", "", {}, "sha512-krSKBgngqU4pHYsxnpNLvLAseI7Yn8ONw1ONp/i/CRZbRAAHw/0PIET7VAcGpgrMK/1hXmtPR4Zg1tjn/Mq7aA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -2497,7 +2497,7 @@ Bandersnatch Member Key
 
   Account:    alice
   Context:    candidate
-  Member Key: 0x2fd5b74033d904cf5575b932507939c5d43811e488223229eaf5596565f15ae6
+  Member Key: 0x5f915576987547d3e55bb4129ac8cae1d338f8933073dc74272b4c825f738592
 ```
 
 When `--context` is omitted, the "Context:" line is not shown.
@@ -2511,7 +2511,7 @@ dot verifiable alice --context candidate --json
 ```json
 {
   "account": "alice",
-  "memberKey": "0x2fd5b74033d904cf5575b932507939c5d43811e488223229eaf5596565f15ae6",
+  "memberKey": "0x5f915576987547d3e55bb4129ac8cae1d338f8933073dc74272b4c825f738592",
   "context": "candidate"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@scure/sr25519": "^1.0.0",
     "cac": "^6.7.14",
     "polkadot-api": "^2.1.4",
-    "verifiablejs": "1.3.0-beta.2",
+    "verifiablejs": "1.3.0",
     "yaml": "^2.8.3"
   },
   "devDependencies": {

--- a/src/commands/verifiable.test.ts
+++ b/src/commands/verifiable.test.ts
@@ -186,6 +186,28 @@ describe("dot verifiable", { timeout: 15_000 }, () => {
     expect(JSON.parse(candidate.stdout).memberKey).not.toBe(JSON.parse(pps.stdout).memberKey);
   });
 
+  // Pins the exact member keys produced by the underlying verifiablejs WASM
+  // (verifiable crate v0.5.0). These bytes must match what the on-chain
+  // `verifiable` pallet expects, so a silent crypto/serialization change in the
+  // library — like the wire-incompatible bump from beta.2 — fails this test.
+  test("alice derives known member keys (verifiablejs wire format)", async () => {
+    const unkeyed = await runCli(["verifiable", "alice", "--output", "json"]);
+    const candidate = await runCli([
+      "verifiable",
+      "alice",
+      "--context",
+      "candidate",
+      "--output",
+      "json",
+    ]);
+    expect(JSON.parse(unkeyed.stdout).memberKey).toBe(
+      "0xbb6ee099b568f1844d62fc00e6305c2e83aa8da30ce59e664ef39e089204d43c",
+    );
+    expect(JSON.parse(candidate.stdout).memberKey).toBe(
+      "0x5f915576987547d3e55bb4129ac8cae1d338f8933073dc74272b4c825f738592",
+    );
+  });
+
   test("saves bandersnatch key for stored accounts", async () => {
     // First derive
     const derive = await runCli(["verifiable", "my-account", "--context", "candidate"], {


### PR DESCRIPTION
## Summary

Upgrades `verifiablejs` from `1.3.0-beta.2` to the stable **`1.3.0`** release.

The JS API consumed by the CLI (`member_from_entropy`, used in `src/core/bandersnatch.ts`) is **unchanged** in signature, so no code changes were needed. However, `1.3.0` bumps the underlying `verifiable` Rust crate to **v0.5.0** (ThinVRF signatures, new ring proofs), which makes derived Bandersnatch member keys **wire-incompatible** with `beta.2`. Per the upstream [v1.3.0 changelog](https://github.com/paritytech/verifiablejs/releases/tag/v1.3.0), this is the intended alignment with the `verifiable` crate rev used on-chain by `individuality`.

Concretely, `dot verifiable alice` now derives:

| | beta.2 | 1.3.0 |
|---|---|---|
| unkeyed | `0x66813b70…87e2` | `0xbb6ee099…d43c` |
| `--context candidate` | `0x2fd5b740…5ae6` | `0x5f915576…8592` |

## Changes

- `package.json` / `bun.lock`: `verifiablejs` `1.3.0-beta.2` → `1.3.0`
- `README.md` & `docs/content/_index.md`: update the documented example member keys to the new 1.3.0 wire format
- `src/commands/verifiable.test.ts`: add a regression test pinning alice's derived member keys, so a future silent crypto/serialization change in the library is caught
- Add changeset (patch)

## Verification

- `bun run typecheck` ✅
- `bun run lint` (biome) ✅
- `bun run build` ✅
- `bun test` ✅ (full suite passes; the pre-existing `buildCustomSignedExtensions` failure on `main`'s working tree is from an unrelated locally-modified `polkadot-metadata.bin` fixture and is not touched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)