### PR TITLE
fix(test): stop cross-file mock.module clobbering between client and load-meta tests

### DIFF
--- a/.changeset/test-mock-isolation.md
+++ b/.changeset/test-mock-isolation.md
@@ -1,0 +1,13 @@
+---
+"polkadot-cli": patch
+---
+
+fix(test): make polkadot-api module mocks ordering-safe across test files
+
+No runtime behavior change — this fixes the flaky CI failures where
+`createChainClient` tests failed depending on test-file scheduling order.
+bun's `mock.module()` is global to the test process and not restored between
+files, so `client.test.ts` and `load-meta.test.ts` clobbered each other's
+mocks. Both now share a fixture that spreads the real module exports into
+the mocks and captures the real `createChainClient` before any file can stub
+the `client.ts` module.

--- a/src/commands/load-meta.test.ts
+++ b/src/commands/load-meta.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+// Installs spread-based polkadot-api mocks and captures the real
+// createChainClient BEFORE this file stubs the whole client.ts module —
+// client.test.ts depends on that capture regardless of file order.
+import "../core/__fixtures__/papi-mocks.ts";
 
 // ---------------------------------------------------------------------------
 // Load fixture metadata and actual metadata functions before mocking.

--- a/src/core/__fixtures__/papi-mocks.ts
+++ b/src/core/__fixtures__/papi-mocks.ts
@@ -1,0 +1,24 @@
+import { mock } from "bun:test";
+
+// bun's mock.module() is global to the test process and is NOT restored
+// between files, so any test file that mocks "polkadot-api" must keep every
+// real export intact — other in-process tests import Binary etc. from it.
+// Real modules are captured before mock.module so the spreads below do that.
+const actualPapi = await import("polkadot-api");
+const actualWs = await import("polkadot-api/ws");
+
+export const mockGetWsProvider = mock((_endpoints: any, _config?: any) => (() => {}) as any);
+export const mockCreateClient = mock(
+  () =>
+    ({
+      destroy: () => {},
+    }) as any,
+);
+
+mock.module("polkadot-api", () => ({ ...actualPapi, createClient: mockCreateClient }));
+mock.module("polkadot-api/ws", () => ({ ...actualWs, getWsProvider: mockGetWsProvider }));
+
+// Capture the real createChainClient before any test file stubs the whole
+// client.ts module (load-meta.test.ts does) — file evaluation order depends
+// on test scheduling, so client.test.ts cannot rely on importing it itself.
+export const { createChainClient } = await import("../client.ts");

--- a/src/core/client.test.ts
+++ b/src/core/client.test.ts
@@ -1,25 +1,13 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { ChainConfig } from "../config/types.ts";
 import { ConnectionError } from "../utils/errors.ts";
-
-// Capture calls to getWsProvider so we can inspect the config it receives
-const mockGetWsProvider = mock((_endpoints: any, _config?: any) => (() => {}) as any);
-const mockCreateClient = mock(
-  () =>
-    ({
-      destroy: () => {},
-    }) as any,
-);
-
-mock.module("polkadot-api/ws", () => ({
-  getWsProvider: mockGetWsProvider,
-}));
-mock.module("polkadot-api", () => ({
-  createClient: mockCreateClient,
-}));
-
-// Import after mocking so the mocks take effect
-const { createChainClient } = await import("./client.ts");
+// The shared fixture installs the polkadot-api mocks and captures the real
+// createChainClient before load-meta.test.ts can stub the client.ts module.
+import {
+  createChainClient,
+  mockCreateClient,
+  mockGetWsProvider,
+} from "./__fixtures__/papi-mocks.ts";
 
 describe("createChainClient", () => {
   test("passes timeout config to getWsProvider", async () => {


### PR DESCRIPTION
## Problem

CI fails intermittently with 9 `createChainClient` test failures (`getWsProvider` called 0 times, promises resolving instead of rejecting) — most recently on main's own run [27340127974](https://github.com/peetzweg/polkadot-cli/actions/runs/27340127974). The same suite passes on a local Mac. Not flaky tests in the usual sense: it's deterministic given a file evaluation order, and the order differs between machines.

## Root cause

bun's `mock.module()` swaps a module in the **process-global** module registry and is never restored between test files. Two files mock overlapping modules with incompatible expectations:

- `client.test.ts` replaced the entire `polkadot-api` module with just `{ createClient }`. If it evaluates first, `load-meta.test.ts`'s real `metadata.ts` import crashes with `Export named 'Binary' not found`.
- `load-meta.test.ts` stubbed the entire `../core/client.ts` module. If it evaluates first, `client.test.ts`'s `await import("./client.ts")` silently receives the stub instead of the real implementation, and all 9 assertions against the papi spies fail — exactly the CI signature.

Which direction you get depends purely on scheduling. Reproducible on any machine, even sequentially:

```
bun test src/commands/load-meta.test.ts src/core/client.test.ts
```

## Fix

A shared fixture, `src/core/__fixtures__/papi-mocks.ts`, that both files import first:

1. **Complete mocks** — it mocks `polkadot-api` and `polkadot-api/ws` by spreading the real module exports and overriding only `createClient` / `getWsProvider`. Every other export (`Binary`, …) stays intact for any in-process test that imports them.
2. **Early capture** — it imports the real `client.ts` and re-exports `createChainClient` *at fixture evaluation time*, before any test file can stub the module. `client.test.ts` tests that captured reference, so `load-meta.test.ts`'s stub can no longer reach it regardless of which file loads first.
3. **No shared assertion state** — `load-meta.test.ts` keeps its own local spies and (via its `client.ts` stub) never touches the papi spies that `client.test.ts` clears and counts, so concurrent execution can't cross-talk.

Verified: the two-file repro passes in both file orders on bun 1.3.12 and 1.3.14; full suite 1621 pass / 0 fail.

## Is this future-proof?

For the *existing* collision: yes, deterministically — the capture happens at first-evaluation time, which is always before any file body runs `mock.module`.

For the *class* of bug: partially. Nothing in bun enforces this; a future test file that calls `mock.module()` with an incomplete module shape, or stubs a module another in-process test imports for real, can reintroduce the same failure mode. Mitigations, in increasing order of weight:

- **Convention (this PR):** any `mock.module()` of a shared module goes through (or copies the pattern of) `papi-mocks.ts` — spread the real exports, override only what you must. The fixture's comments document why.
- **Dependency injection:** make `createChainClient`/`loadMeta` accept their collaborators as (defaulted) parameters and drop `mock.module` entirely. Strongest fix, touches runtime signatures — worth doing if a third mocking test file ever appears.
- **Process isolation:** bun currently has no per-file process isolation for tests; if it ships one, adopting it removes the whole bug class.

## Note

This fix was originally bundled into #231 (whose CI it unblocked) and is split out here for independent review. **Merge this one first** — #231 and any other PR will keep hitting the flake on CI until this lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)