### PR TITLE
feat: global DOT_DRY_RUN flag to force dry-run on all extrinsics

### DIFF
--- a/.changeset/global-dry-run.md
+++ b/.changeset/global-dry-run.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Add a global `DOT_DRY_RUN` environment variable. When set to a truthy value (`1`, `true`, `yes`, or `on`), every extrinsic-submitting command behaves as if `--dry-run` had been passed — the transaction is simulated and never broadcast. A one-line hint is printed to stderr (keeping `--json`/piped stdout clean). An explicit `--dry-run` / `--no-dry-run` flag always wins, and decode-only paths (`--encode`, `--to-yaml`, `--to-json`) are unaffected.

--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,13 @@ dot polkadot.tx.Balances.transfer_keep_alive bob 1000000000000 --from alice --dr
 # Submit (omit --dry-run)
 dot polkadot.tx.System.remark 0xdeadbeef --from alice
 
+# Force every tx to dry-run via the global DOT_DRY_RUN env var — a safety net
+# for scripts and demos. A hint is printed to stderr; the command behaves
+# exactly as if --dry-run had been passed.
+DOT_DRY_RUN=1 dot polkadot.tx.System.remark 0xdeadbeef --from alice
+# stderr: ⚠ DOT_DRY_RUN is set — extrinsics will be simulated, not submitted.
+# stdout: (the dry-run output above — no broadcast)
+
 # Submit a raw SCALE-encoded call (e.g. from a multisig proposal or another tool)
 dot polkadot.tx 0x000010deadbeef --from alice --dry-run
 
@@ -2191,6 +2198,24 @@ cd - && rm -rf "$tmp"        # nothing ever touched ~/.polkadot
 ```
 
 For secrets that should never hit disk at all, combine workspaces with `--env` secret sources (see [Manage accounts](#manage-accounts)).
+
+### `DOT_DRY_RUN` — force every extrinsic to dry-run
+
+Set `DOT_DRY_RUN` to a truthy value (`1`, `true`, `yes`, or `on`, case-insensitive) to make **every** extrinsic-submitting command behave as if `--dry-run` had been passed: the transaction is simulated (call decoded, fees estimated) and **never broadcast**. This is a global safety net for scripts, demos, and CI dry-runs where you want to be sure nothing lands on-chain.
+
+When active, the CLI prints a one-line hint to **stderr** (so it never corrupts `--json` or piped stdout):
+
+```bash
+DOT_DRY_RUN=1 dot polkadot.tx.Balances.transfer_keep_alive bob 1000000000000 --from alice
+# stderr: ⚠ DOT_DRY_RUN is set — extrinsics will be simulated, not submitted.
+# stdout: the usual dry-run report (Chain / From / Call / Decode / Estimated fees)
+
+# Set it for a whole shell session as a safety net:
+export DOT_DRY_RUN=1
+dot polkadot.tx.System.remark 0xdeadbeef --from alice   # simulated, not submitted
+```
+
+**Precedence:** an explicit per-command flag always wins. `--dry-run` forces a dry-run; `--no-dry-run` forces a real submission even when `DOT_DRY_RUN` is set. The env var only supplies the default when no flag is given. Decode-only paths (`--encode`, `--to-yaml`, `--to-json`) never submit anything, so `DOT_DRY_RUN` leaves them untouched.
 
 ### `DOT_TRUST_CACHED_METADATA` — skip the staleness check
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1534,6 +1534,13 @@ dot polkadot.tx.Balances.transfer_keep_alive bob 1000000000 --from alice --dry-r
 
 # Submit (omit --dry-run)
 dot polkadot.tx.System.remark 0xdeadbeef --from alice
+
+# Force every tx to dry-run via the global DOT_DRY_RUN env var — a safety net
+# for scripts and demos. A hint is printed to stderr; the command behaves
+# exactly as if --dry-run had been passed.
+DOT_DRY_RUN=1 dot polkadot.tx.System.remark 0xdeadbeef --from alice
+# stderr: ⚠ DOT_DRY_RUN is set — extrinsics will be simulated, not submitted.
+# stdout: (the dry-run output above — no broadcast)
 ```
 
 The `--chain` flag is equivalent:
@@ -2804,6 +2811,24 @@ cd - && rm -rf "$tmp"        # nothing ever touched ~/.polkadot
 ```
 
 For secrets that should never hit disk at all, combine workspaces with `--env` secret sources.
+
+### `DOT_DRY_RUN` — force every extrinsic to dry-run
+
+Set `DOT_DRY_RUN` to a truthy value (`1`, `true`, `yes`, or `on`, case-insensitive) to make **every** extrinsic-submitting command behave as if `--dry-run` had been passed: the transaction is simulated (call decoded, fees estimated) and **never broadcast**. This is a global safety net for scripts, demos, and CI dry-runs where you want to be sure nothing lands on-chain.
+
+When active, the CLI prints a one-line hint to **stderr** (so it never corrupts `--json` or piped stdout):
+
+```bash
+DOT_DRY_RUN=1 dot polkadot.tx.Balances.transfer_keep_alive bob 1000000000000 --from alice
+# stderr: ⚠ DOT_DRY_RUN is set — extrinsics will be simulated, not submitted.
+# stdout: the usual dry-run report (Chain / From / Call / Decode / Estimated fees)
+
+# Set it for a whole shell session as a safety net:
+export DOT_DRY_RUN=1
+dot polkadot.tx.System.remark 0xdeadbeef --from alice   # simulated, not submitted
+```
+
+**Precedence:** an explicit per-command flag always wins. `--dry-run` forces a dry-run; `--no-dry-run` forces a real submission even when `DOT_DRY_RUN` is set. The env var only supplies the default when no flag is given. Decode-only paths (`--encode`, `--to-yaml`, `--to-json`) never submit anything, so `DOT_DRY_RUN` leaves them untouched.
 
 ### `DOT_TRUST_CACHED_METADATA` — skip the staleness check
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -24,7 +24,7 @@ Categories: `query`, `tx`, `apis`, `const`, `events`, `errors`, `extensions`, `r
 
 Top-level commands: `dot inspect`, `dot metadata`, `dot chain`, `dot account`, `dot sign`, `dot hash`, `dot verifiable`, `dot init`, `dot which`.
 
-State (accounts, custom chains, metadata cache) lives in a config root resolved per run: `DOT_HOME` env var → a local `.polkadot/` workspace discovered from cwd → global `~/.polkadot`. Run `dot which` to see which one is active, and see [Local Workspaces](#local-workspaces) for isolated per-directory setups.
+State (accounts, custom chains, metadata cache) lives in a config root resolved per run: `DOT_HOME` env var → a local `.polkadot/` workspace discovered from cwd → global `~/.polkadot`. Run `dot which` to see which one is active, and see [Local Workspaces](#local-workspaces) for isolated per-directory setups. Set `DOT_DRY_RUN=1` to force every extrinsic to dry-run instead of submitting (see [Submitting Transactions](#submitting-transactions)).
 
 Omit deeper levels to discover what's available. Always include the chain prefix:
 
@@ -190,6 +190,16 @@ dot polkadot.tx.Balances.transfer_keep_alive 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZ
 # Submit (omit --dry-run). Method names are snake_case as defined in the runtime.
 dot polkadot.tx.Balances.transfer_keep_alive bob 1000000000 --from alice
 ```
+
+**Global dry-run safety net.** Set the `DOT_DRY_RUN` env var (truthy: `1`/`true`/`yes`/`on`) to force EVERY tx to dry-run instead of submitting — handy when scripting or demoing so nothing accidentally lands on-chain. A hint is printed to stderr (stdout stays clean for `--json`):
+
+```bash
+DOT_DRY_RUN=1 dot polkadot.tx.System.remark 0xdeadbeef --from alice
+# stderr: ⚠ DOT_DRY_RUN is set — extrinsics will be simulated, not submitted.
+# stdout: the dry-run report (no broadcast)
+```
+
+Precedence: an explicit flag wins — `--dry-run` forces dry-run, `--no-dry-run` forces a real submission even with `DOT_DRY_RUN=1`. Decode-only paths (`--encode`, `--to-yaml`, `--to-json`) are unaffected.
 
 ### Encoding Calls (for Sudo, XCM, Batch)
 
@@ -675,7 +685,7 @@ dot verifiable verify --proof 0x<proof> --context dotns \
 | `--json` | all | JSON output (but `undefined` and errors may not be JSON) |
 | `--from <name>` | tx | Account to sign with |
 | `--encode` | tx | Encode to hex, don't sign or submit |
-| `--dry-run` | tx | Estimate fees without submitting |
+| `--dry-run` / `--no-dry-run` | tx | Force / forbid dry-run (overrides `DOT_DRY_RUN`) |
 | `--dump` | query | Dump all entries of a storage map |
 | `--ext <json>` | tx | Custom signed extension values |
 | `--at <block>` | tx, query, apis | Block hash, `"best"`, or `"finalized"` to read/validate against. Defaults to finalized. Tx submission rejects `"best"`. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { registerSignCommand } from "./commands/sign.ts";
 import { handleTx } from "./commands/tx.ts";
 import { registerWorkspaceCommands } from "./commands/workspace.ts";
 import { loadConfig } from "./config/store.ts";
+import { isGlobalDryRun, printGlobalDryRunHint, resolveDryRun } from "./core/dry-run.ts";
 import { isFilePath, loadCommandFile, parseVarFlags } from "./core/file-loader.ts";
 import {
   getUpdateNotification,
@@ -150,12 +151,17 @@ if (process.argv[2] === "__complete") {
           const target = `${cmd.pallet}.${cmd.item}`;
 
           switch (cmd.category) {
-            case "tx":
+            case "tx": {
+              const fileDecodeOnly = Boolean(opts.encode || opts.toYaml || opts.toJson);
+              const fileDryRun = resolveDryRun(opts.dryRun, fileDecodeOnly);
+              if (fileDryRun && isGlobalDryRun() && opts.dryRun === undefined) {
+                printGlobalDryRunHint();
+              }
               await handleTx(target, args, {
                 ...handlerOpts,
                 from: opts.from,
                 unsigned: opts.unsigned ?? cmd.unsigned,
-                dryRun: opts.dryRun,
+                dryRun: fileDryRun,
                 encode: opts.encode,
                 toYaml: opts.toYaml,
                 toJson: opts.toJson,
@@ -169,6 +175,7 @@ if (process.argv[2] === "__complete") {
                 parsedArgs: cmd.args,
               });
               break;
+            }
             case "query":
               await handleQuery(target, args, {
                 ...handlerOpts,
@@ -249,12 +256,17 @@ if (process.argv[2] === "__complete") {
             await handleQuery(target, args, { ...handlerOpts, dump: opts.dump, at: atRaw });
             break;
           case "tx": {
+            const decodeOnly = Boolean(opts.encode || opts.toYaml || opts.toJson);
+            const dryRun = resolveDryRun(opts.dryRun, decodeOnly);
+            if (dryRun && isGlobalDryRun() && opts.dryRun === undefined) {
+              printGlobalDryRunHint();
+            }
             // Handle raw hex: if pallet starts with 0x, it's a raw call hex
             const txOpts = {
               ...handlerOpts,
               from: opts.from,
               unsigned: opts.unsigned,
-              dryRun: opts.dryRun,
+              dryRun,
               encode: opts.encode,
               toYaml: opts.toYaml,
               toJson: opts.toJson,

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -2441,3 +2441,65 @@ describe("--unsigned with file-based input", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// DOT_DRY_RUN global flag (issue #234)
+// ---------------------------------------------------------------------------
+
+// @ts-expect-error Bun supports describe(label, options, fn) at runtime
+describe("DOT_DRY_RUN global flag", { timeout: 15_000 }, () => {
+  test("DOT_DRY_RUN=1 dry-runs an otherwise-submitting tx and prints the hint", async () => {
+    // An unsigned tx without --dry-run would attempt to broadcast (and, offline,
+    // fail to connect). With DOT_DRY_RUN set it must dry-run instead: print the
+    // unsigned dry-run output to stdout and never connect.
+    const { stdout, stderr, exitCode } = await runCli(
+      ["tx.System.remark", "0xdeadbeef", "--unsigned"],
+      { env: { DOT_DRY_RUN: "1" } },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("unsigned (bare)");
+    expect(stdout).toContain("N/A (unsigned transaction)");
+    // Hint goes to stderr so it never corrupts stdout.
+    expect(stderr).toContain("DOT_DRY_RUN is set");
+  });
+
+  test("hint is written to stderr, never stdout (clean --json)", async () => {
+    const { stdout, stderr, exitCode } = await runCli(
+      ["tx.System.remark", "0xdeadbeef", "--unsigned", "--json"],
+      { env: { DOT_DRY_RUN: "1" } },
+    );
+    expect(exitCode).toBe(0);
+    // stdout must be valid JSON with no banner text mixed in.
+    expect(stdout).not.toContain("DOT_DRY_RUN");
+    const parsed = JSON.parse(stdout);
+    expect(parsed.unsigned).toBe(true);
+    expect(parsed.estimatedFees).toBeNull();
+    expect(stderr).toContain("DOT_DRY_RUN is set");
+  });
+
+  test("explicit --no-dry-run overrides DOT_DRY_RUN (hint suppressed)", async () => {
+    // With an explicit flag the env-driven hint must be suppressed. We use
+    // --encode (a non-connecting path) so the assertion stays offline-safe;
+    // the dry-run override semantics themselves are unit-tested in
+    // src/core/dry-run.test.ts.
+    const { stderr } = await runCli(
+      ["tx.System.remark", "0xdeadbeef", "--encode", "--no-dry-run"],
+      { env: { DOT_DRY_RUN: "1" } },
+    );
+    expect(stderr).not.toContain("DOT_DRY_RUN is set");
+  });
+
+  test("DOT_DRY_RUN does not break decode-only --encode", async () => {
+    const { stdout, stderr, exitCode } = await runCli(
+      ["tx.System.remark", "0xdeadbeef", "--encode"],
+      { env: { DOT_DRY_RUN: "1" } },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/^0x[0-9a-f]+$/);
+    // Decode-only paths never submit, so the env var must not force dry-run
+    // (which would trip the "--encode and --dry-run are mutually exclusive" guard)
+    // and the hint is not shown.
+    expect(stderr).not.toContain("mutually exclusive");
+    expect(stderr).not.toContain("DOT_DRY_RUN is set");
+  });
+});

--- a/src/core/dry-run.test.ts
+++ b/src/core/dry-run.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { isGlobalDryRun, resolveDryRun } from "./dry-run.ts";
+import {
+  __resetDryRunHintForTests,
+  isGlobalDryRun,
+  printGlobalDryRunHint,
+  resolveDryRun,
+} from "./dry-run.ts";
 
 describe("isGlobalDryRun", () => {
   const original = process.env.DOT_DRY_RUN;
@@ -69,5 +74,38 @@ describe("resolveDryRun", () => {
   test("decode-only still honors an explicit flag", () => {
     process.env.DOT_DRY_RUN = "1";
     expect(resolveDryRun(true, true)).toBe(true);
+  });
+});
+
+describe("printGlobalDryRunHint", () => {
+  let captured: string;
+  let originalWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    __resetDryRunHintForTests();
+    captured = "";
+    originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string) => {
+      captured += chunk;
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+    __resetDryRunHintForTests();
+  });
+
+  test("writes the hint to stderr", () => {
+    printGlobalDryRunHint();
+    expect(captured).toContain("DOT_DRY_RUN is set");
+    expect(captured).toContain("simulated, not submitted");
+  });
+
+  test("is idempotent within a process (prints at most once)", () => {
+    printGlobalDryRunHint();
+    printGlobalDryRunHint();
+    const occurrences = captured.split("DOT_DRY_RUN is set").length - 1;
+    expect(occurrences).toBe(1);
   });
 });

--- a/src/core/dry-run.test.ts
+++ b/src/core/dry-run.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { isGlobalDryRun, resolveDryRun } from "./dry-run.ts";
+
+describe("isGlobalDryRun", () => {
+  const original = process.env.DOT_DRY_RUN;
+  afterEach(() => {
+    if (original === undefined) delete process.env.DOT_DRY_RUN;
+    else process.env.DOT_DRY_RUN = original;
+  });
+
+  test("unset is false", () => {
+    delete process.env.DOT_DRY_RUN;
+    expect(isGlobalDryRun()).toBe(false);
+  });
+
+  test("empty string is false", () => {
+    process.env.DOT_DRY_RUN = "";
+    expect(isGlobalDryRun()).toBe(false);
+  });
+
+  test("truthy values are true", () => {
+    for (const v of ["1", "true", "TRUE", "yes", "On", " 1 "]) {
+      process.env.DOT_DRY_RUN = v;
+      expect(isGlobalDryRun()).toBe(true);
+    }
+  });
+
+  test("falsey values are false", () => {
+    for (const v of ["0", "false", "no", "off"]) {
+      process.env.DOT_DRY_RUN = v;
+      expect(isGlobalDryRun()).toBe(false);
+    }
+  });
+});
+
+describe("resolveDryRun", () => {
+  const original = process.env.DOT_DRY_RUN;
+  beforeEach(() => {
+    delete process.env.DOT_DRY_RUN;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.DOT_DRY_RUN;
+    else process.env.DOT_DRY_RUN = original;
+  });
+
+  test("explicit --dry-run wins over env off", () => {
+    expect(resolveDryRun(true)).toBe(true);
+  });
+
+  test("explicit --no-dry-run wins over env on", () => {
+    process.env.DOT_DRY_RUN = "1";
+    expect(resolveDryRun(false)).toBe(false);
+  });
+
+  test("env on with no flag forces dry-run", () => {
+    process.env.DOT_DRY_RUN = "1";
+    expect(resolveDryRun(undefined)).toBe(true);
+  });
+
+  test("env off with no flag is off", () => {
+    expect(resolveDryRun(undefined)).toBe(false);
+  });
+
+  test("decode-only path is never forced by env", () => {
+    process.env.DOT_DRY_RUN = "1";
+    expect(resolveDryRun(undefined, true)).toBe(false);
+  });
+
+  test("decode-only still honors an explicit flag", () => {
+    process.env.DOT_DRY_RUN = "1";
+    expect(resolveDryRun(true, true)).toBe(true);
+  });
+});

--- a/src/core/dry-run.ts
+++ b/src/core/dry-run.ts
@@ -1,0 +1,57 @@
+import { BOLD, RESET, YELLOW } from "./output.ts";
+
+/**
+ * Whether the global `DOT_DRY_RUN` environment variable is set to a truthy value.
+ *
+ * Truthy values (case-insensitive): "1", "true", "yes", "on".
+ * Anything else (including unset, "0", "false") is treated as off.
+ *
+ * When active, every extrinsic-submitting command behaves as if `--dry-run`
+ * was passed: it simulates the transaction and never submits it.
+ */
+export function isGlobalDryRun(): boolean {
+  const raw = process.env.DOT_DRY_RUN?.trim().toLowerCase();
+  if (raw === undefined || raw === "") return false;
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+/**
+ * Resolve the effective dry-run setting for a tx command.
+ *
+ * Precedence (highest first):
+ *   1. An explicit `--dry-run` / `--no-dry-run` flag (explicitFlag is a boolean).
+ *   2. The `DOT_DRY_RUN` environment variable (when set to a truthy value).
+ *   3. Off.
+ *
+ * `explicitFlag` is `undefined` when no flag was passed on the command line.
+ *
+ * `decodeOnly` indicates a non-submitting path (`--encode`/`--to-yaml`/`--to-json`).
+ * Those never broadcast an extrinsic, so the env var must NOT force dry-run on
+ * them (it would otherwise trip the mutual-exclusivity guards). An explicit
+ * `--dry-run` flag still wins and surfaces the existing conflict error.
+ */
+export function resolveDryRun(explicitFlag: boolean | undefined, decodeOnly = false): boolean {
+  if (explicitFlag !== undefined) return explicitFlag;
+  if (decodeOnly) return false;
+  return isGlobalDryRun();
+}
+
+/**
+ * Print a prominent hint that DOT_DRY_RUN is active. Written to stderr so it
+ * never corrupts `--json` (or any other) output on stdout.
+ *
+ * Idempotent within a process: the banner is printed at most once.
+ */
+let hintPrinted = false;
+export function printGlobalDryRunHint(): void {
+  if (hintPrinted) return;
+  hintPrinted = true;
+  process.stderr.write(
+    `${YELLOW}${BOLD}⚠ DOT_DRY_RUN is set${RESET}${YELLOW} — extrinsics will be simulated, not submitted.${RESET}\n`,
+  );
+}
+
+/** Test-only: reset the once-per-process latch for the hint banner. */
+export function __resetDryRunHintForTests(): void {
+  hintPrinted = false;
+}


### PR DESCRIPTION
## Summary

Adds a global **`DOT_DRY_RUN`** environment variable. When set to a truthy value (`1`, `true`, `yes`, or `on`, case-insensitive), **every** extrinsic-submitting command behaves as if `--dry-run` had been passed: the transaction is decoded, fees are estimated, and **nothing is broadcast**. This is a global safety net for scripts, demos, and CI where you want to be certain nothing lands on-chain.

A prominent one-line hint is printed to **stderr** (so `--json` and piped stdout stay clean).

### Precedence
1. An explicit `--dry-run` / `--no-dry-run` flag always wins (`--no-dry-run` forces a real submission even with `DOT_DRY_RUN=1`).
2. Otherwise `DOT_DRY_RUN` supplies the default.
3. Decode-only paths (`--encode`, `--to-yaml`, `--to-json`) never submit anything, so the env var leaves them untouched (no spurious "mutually exclusive" errors).

## Example: before vs. after

Without the flag, an unsigned remark proceeds to broadcast:

```console
$ dot polkadot.tx.System.remark 0xdeadbeef --unsigned
… (connects and broadcasts) …
```

With `DOT_DRY_RUN=1`, the same command is simulated instead, and a hint is printed to stderr:

```console
$ DOT_DRY_RUN=1 dot polkadot.tx.System.remark 0xdeadbeef --unsigned
⚠ DOT_DRY_RUN is set — extrinsics will be simulated, not submitted.   ← stderr
  Chain:  polkadot                                                     ← stdout
  Type:   unsigned (bare)
  Call:   0x000010deadbeef
  Decode: System.remark
    {
      "remark": "0xdeadbeef"
    }
  Fees:   N/A (unsigned transaction)
```

`--json` stdout stays clean (hint only on stderr):

```console
$ DOT_DRY_RUN=1 dot polkadot.tx.System.remark 0xdeadbeef --unsigned --json 2>/dev/null
{
  "chain": "polkadot",
  "unsigned": true,
  "callHex": "0x000010deadbeef",
  "decoded": "System.remark { remark: 0xdeadbeef }",
  "estimatedFees": null
}
```

Explicit `--no-dry-run` overrides the env var (real submission), and `--encode` is unaffected:

```console
$ DOT_DRY_RUN=1 dot polkadot.tx.System.remark 0xdeadbeef --encode 2>/dev/null
0x000010deadbeef
```

## Changes
- **`src/core/dry-run.ts`** (new): `isGlobalDryRun()`, `resolveDryRun(explicitFlag, decodeOnly)`, and `printGlobalDryRunHint()` (stderr, once per process).
- **`src/cli.ts`**: both tx dispatch paths (inline dot-path + file-based) now resolve the effective dry-run via `resolveDryRun(opts.dryRun, decodeOnly)` and print the hint when the env var is the source.
- Tests: 12 unit tests (`src/core/dry-run.test.ts`) + 4 integration tests via `runCli` (`src/commands/tx.test.ts`).
- Docs: `README.md`, `docs/content/_index.md`, and the `dot-cli` skill (`dot-cli/SKILL.md`) all document the env var, its truthy values, precedence, and the stderr hint.
- Changeset: `minor`.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
