### PR TITLE
fix(cli): stop dropping --help for nested subcommands (#238)

### DIFF
--- a/.changeset/nested-help.md
+++ b/.changeset/nested-help.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": patch
+---
+
+Fix `--help` being dropped for nested subcommands. Previously `dot account add --help` (and other nested commands like `dot chain add --help`, `dot account inspect --help`, `dot hash <algo> --help`, `dot verifiable <action> --help`) ran the command's action and exited with an error about the missing positional argument instead of printing usage. Now `--help` reliably prints the command's usage block and exits 0 at every nested command level. Commands with a required positional (`dot metadata --help`, `dot completions --help`) also print help instead of erroring.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,11 @@ import {
   waitForPendingCheck,
 } from "./core/update-notifier.ts";
 import { registerVerifiableCommands } from "./features/verifiable/register.ts";
-import { readRawOptionValue, registerGlobalOptions } from "./platform/cli.ts";
+import {
+  printMatchedCommandHelp,
+  readRawOptionValue,
+  registerGlobalOptions,
+} from "./platform/cli.ts";
 import { CliError, formatRuntimeError, isPapiCleanupError } from "./utils/errors.ts";
 import { parseDotPath } from "./utils/parse-dot-path.ts";
 
@@ -444,8 +448,15 @@ if (process.argv[2] === "__complete") {
       if (cli.options.version) {
         await showUpdateAndExit(0);
       } else if (cli.options.help) {
-        if ((cli as any).matchedCommand) {
-          // A named command matched — let it show its own help
+        // A named command with registered help (account, chain, sign, …) prints
+        // its own usage block — even when an action positional is present, e.g.
+        // `dot account add --help`. Without this, the action would run and fail
+        // on the missing argument instead of showing help (issue #238).
+        if (printMatchedCommandHelp(cli)) {
+          await showUpdateAndExit(0);
+        } else if ((cli as any).matchedCommand) {
+          // The default dot-path command handles item-level help inside its
+          // action (e.g. `dot polkadot.query.System.Account --help`).
           const result = (cli as any).runMatchedCommand();
           if (result && typeof result.then === "function") {
             await result.then(() => showUpdateAndExit(0), handleError);

--- a/src/commands/account.test.ts
+++ b/src/commands/account.test.ts
@@ -40,6 +40,32 @@ describe("dot account", { timeout: 15_000 }, () => {
     expect(help.stdout).toBe(bare.stdout);
   });
 
+  // Regression for #238: `--help` must not be dropped for nested subcommands.
+  // Previously `dot account add --help` ran the action and exited 1 with
+  // "Account name is required" instead of printing usage.
+  for (const sub of ["add", "inspect", "create", "import", "export", "derive", "remove", "list"]) {
+    test(`account ${sub} --help prints usage and exits 0`, async () => {
+      const { stdout, exitCode } = await runCli(["account", sub, "--help"]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("dot account add");
+      expect(stdout).toContain("dot account list");
+    });
+  }
+
+  test("account add --help is identical to bare account help", async () => {
+    const bare = await runCli(["account"]);
+    const sub = await runCli(["account", "add", "--help"]);
+    expect(sub.exitCode).toBe(0);
+    expect(sub.stdout).toBe(bare.stdout);
+  });
+
+  test("account add still adds a watch-only account (help not triggered without flag)", async () => {
+    const { stdout, exitCode } = await runCli(["account", "add", "treasury", ALICE_SS58]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("watch-only");
+    expect(stdout).toContain("treasury");
+  });
+
   test("accounts shorthand lists accounts", async () => {
     const { stdout, exitCode } = await runCli(["accounts"]);
     expect(exitCode).toBe(0);

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -49,6 +49,7 @@ import {
   isValidParaId,
   type SovereignAccountType,
 } from "../core/parachain.ts";
+import { withHelp } from "../platform/cli.ts";
 
 const ACCOUNT_HELP = `
 ${BOLD}Usage:${RESET}
@@ -105,7 +106,7 @@ ${YELLOW}Note: Secrets are stored unencrypted in ~/.polkadot/accounts.json.
 `.trimStart();
 
 export function registerAccountCommands(cli: CAC) {
-  cli
+  const command = cli
     .command(
       "account [action] [...names]",
       "Manage local accounts (create, import, list, remove, export)",
@@ -199,6 +200,7 @@ export function registerAccountCommands(cli: CAC) {
         }
       },
     );
+  withHelp(command, () => console.log(ACCOUNT_HELP));
 }
 
 async function accountCreate(

--- a/src/commands/chain.ts
+++ b/src/commands/chain.ts
@@ -34,6 +34,7 @@ import {
 } from "../core/output.ts";
 import { fetchRpcMethods } from "../core/rpc.ts";
 import { inferFamily, RPC_REGISTRY } from "../data/rpc-registry.ts";
+import { withHelp } from "../platform/cli.ts";
 
 const CHAIN_HELP = `
 ${BOLD}Usage:${RESET}
@@ -69,7 +70,7 @@ ${BOLD}Examples:${RESET}
 `.trimStart();
 
 export function registerChainCommands(cli: CAC) {
-  cli
+  const command = cli
     .command(
       "chain [action] [...names]",
       "Manage chains (add, remove, update, list, export, import)",
@@ -133,6 +134,7 @@ export function registerChainCommands(cli: CAC) {
         }
       },
     );
+  withHelp(command, () => console.log(CHAIN_HELP));
 }
 
 /**

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,4 +1,5 @@
 import type { CAC } from "cac";
+import { withHelp } from "../platform/cli.ts";
 
 const ZSH_SCRIPT = `\
 _dot_completions() {
@@ -76,7 +77,7 @@ const SCRIPTS: Record<string, string> = {
 };
 
 export function registerCompletionsCommand(cli: CAC) {
-  cli
+  const command = cli
     .command("completions <shell>", "Generate shell completion script (zsh, bash, fish)")
     .action((shell: string) => {
       const script = SCRIPTS[shell];
@@ -99,4 +100,5 @@ export function registerCompletionsCommand(cli: CAC) {
       // Print the script to stdout
       console.log(script);
     });
+  withHelp(command);
 }

--- a/src/commands/global.test.ts
+++ b/src/commands/global.test.ts
@@ -113,4 +113,37 @@ describe("global CLI", () => {
     const { stdout } = await runCli(["--help"]);
     expect(stdout).toContain("--json");
   });
+
+  // Regression for #238: `--help` must reach the matched command for ALL nested
+  // command levels, printing usage and exiting 0 — never running the action and
+  // failing on a missing positional argument.
+  describe("nested command --help (issue #238)", () => {
+    const cases: { args: string[]; expect: string }[] = [
+      { args: ["account", "add", "--help"], expect: "dot account add" },
+      { args: ["account", "inspect", "--help"], expect: "dot account inspect" },
+      { args: ["chain", "add", "--help"], expect: "dot chain add" },
+      { args: ["chain", "remove", "--help"], expect: "dot chain remove" },
+      { args: ["hash", "blake2b256", "--help"], expect: "dot hash" },
+      { args: ["sign", "hello", "--help"], expect: "dot sign" },
+      { args: ["verifiable", "prove", "--help"], expect: "dot verifiable" },
+      { args: ["parachain", "1000", "--help"], expect: "dot parachain" },
+    ];
+    for (const { args, expect: needle } of cases) {
+      test(`${args.join(" ")} prints usage and exits 0`, async () => {
+        const { stdout, stderr, exitCode } = await runCli(args, { noDefaultChain: true });
+        expect(exitCode).toBe(0);
+        expect(stdout + stderr).toContain(needle);
+      });
+    }
+
+    test("metadata --help exits 0 despite required <chain> arg", async () => {
+      const { exitCode } = await runCli(["metadata", "--help"], { noDefaultChain: true });
+      expect(exitCode).toBe(0);
+    });
+
+    test("completions --help exits 0 despite required <shell> arg", async () => {
+      const { exitCode } = await runCli(["completions", "--help"], { noDefaultChain: true });
+      expect(exitCode).toBe(0);
+    });
+  });
 });

--- a/src/commands/hash.ts
+++ b/src/commands/hash.ts
@@ -8,6 +8,7 @@ import {
 } from "../core/hash.ts";
 import { resolveDataInput } from "../core/input.ts";
 import { BOLD, CYAN, DIM, isJsonOutput, printResult, RESET } from "../core/output.ts";
+import { withHelp } from "../platform/cli.ts";
 import { CliError } from "../utils/errors.ts";
 import { suggestMessage } from "../utils/fuzzy-match.ts";
 
@@ -31,7 +32,7 @@ function printAlgorithmHelp(): void {
 }
 
 export function registerHashCommand(cli: CAC) {
-  cli
+  const command = cli
     .command("hash [algorithm] [data]", "Compute cryptographic hashes")
     .option("--file <path>", "Hash file contents (raw bytes)")
     .option("--stdin", "Read data from stdin")
@@ -68,4 +69,5 @@ export function registerHashCommand(cli: CAC) {
         }
       },
     );
+  withHelp(command, printAlgorithmHelp);
 }

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -26,11 +26,12 @@ import {
   RESET,
 } from "../core/output.ts";
 import { prettyCallArgs, prettyEventFields, prettyTypeById } from "../core/pretty-type.ts";
+import { withHelp } from "../platform/cli.ts";
 import { suggestMessage } from "../utils/fuzzy-match.ts";
 import { parseTarget, resolveTargetChain } from "../utils/parse-target.ts";
 
 export function registerInspectCommand(cli: CAC) {
-  cli
+  const command = cli
     .command(
       "inspect [target]",
       "Inspect chain metadata (pallets, storage, constants, calls, events, errors)",
@@ -464,4 +465,5 @@ export function registerInspectCommand(cli: CAC) {
         throw new Error(suggestMessage(`item in ${pallet.name}`, itemName, allItems));
       },
     );
+  withHelp(command);
 }

--- a/src/commands/metadata.ts
+++ b/src/commands/metadata.ts
@@ -15,6 +15,7 @@ import {
   parseMetadata,
 } from "../core/metadata.ts";
 import { formatJson, writeStdout } from "../core/output.ts";
+import { withHelp } from "../platform/cli.ts";
 import { CliError } from "../utils/errors.ts";
 import type { RuntimeFingerprint } from "../utils/runtime-fingerprint.ts";
 
@@ -84,10 +85,11 @@ export async function handleMetadata(chain: string, opts: MetadataCommandOpts): 
 }
 
 export function registerMetadataCommand(cli: CAC) {
-  cli
+  const command = cli
     .command("metadata <chain>", "Fetch chain metadata (decoded JSON; --raw for SCALE hex)")
     .option("--raw", "Print SCALE-encoded metadata bytes as hex instead of decoded JSON")
     .option("--cached", "Use cached metadata instead of fetching fresh from the chain")
     .option("--rpc <url>", "Override RPC endpoint(s)")
     .action((chain: string, opts: MetadataCommandOpts) => handleMetadata(chain, opts));
+  withHelp(command);
 }

--- a/src/commands/parachain.ts
+++ b/src/commands/parachain.ts
@@ -11,6 +11,7 @@ import {
   SOVEREIGN_ACCOUNT_TYPES,
   type SovereignAccountType,
 } from "../core/parachain.ts";
+import { withHelp } from "../platform/cli.ts";
 import { CliError } from "../utils/errors.ts";
 
 function printParachainHelp(): void {
@@ -39,7 +40,7 @@ function validateType(type: string): SovereignAccountType {
 }
 
 export function registerParachainCommand(cli: CAC) {
-  cli
+  const command = cli
     .command("parachain [paraId]", "Derive parachain sovereign accounts")
     .option("--type <type>", "Account type: child, sibling (default: both)")
     .option("--prefix <number>", "SS58 prefix for address encoding (default: 42)")
@@ -100,4 +101,5 @@ export function registerParachainCommand(cli: CAC) {
         }
       },
     );
+  withHelp(command, printParachainHelp);
 }

--- a/src/commands/sign.ts
+++ b/src/commands/sign.ts
@@ -3,6 +3,7 @@ import { resolveAccountKeypair } from "../core/accounts.ts";
 import { toHex } from "../core/hash.ts";
 import { resolveDataInput } from "../core/input.ts";
 import { BOLD, CYAN, DIM, isJsonOutput, printResult, RESET } from "../core/output.ts";
+import { withHelp } from "../platform/cli.ts";
 import { CliError } from "../utils/errors.ts";
 
 const SUPPORTED_TYPES = ["sr25519"] as const;
@@ -40,7 +41,7 @@ function printSignHelp(): void {
 }
 
 export function registerSignCommand(cli: CAC) {
-  cli
+  const command = cli
     .command("sign [message]", "Sign a message with an account keypair")
     .option("--from <name>", "Account to sign with")
     .option("--type <algo>", "Signature type (default: sr25519)")
@@ -99,4 +100,5 @@ export function registerSignCommand(cli: CAC) {
         }
       },
     );
+  withHelp(command, printSignHelp);
 }

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -5,6 +5,7 @@ import type { CAC } from "cac";
 import { type ResolvedConfigDir, resolveConfigDir } from "../config/store.ts";
 import { canonicalPath, findWorkspace, WORKSPACE_DIR_NAME } from "../config/workspace.ts";
 import { isJsonOutput, writeStdout } from "../core/output.ts";
+import { withHelp } from "../platform/cli.ts";
 import { CliError } from "../utils/errors.ts";
 
 export interface InitResult {
@@ -85,11 +86,13 @@ export async function handleWhich(
 }
 
 export function registerWorkspaceCommands(cli: CAC) {
-  cli
+  const initCommand = cli
     .command("init", "Initialize a local .polkadot workspace in the current directory")
     .action(() => handleInit());
+  withHelp(initCommand);
 
-  cli
+  const whichCommand = cli
     .command("which", "Show the active config root (workspace, DOT_HOME, or global)")
     .action((opts: { json?: boolean; output?: string }) => handleWhich(opts));
+  withHelp(whichCommand);
 }

--- a/src/features/verifiable/register.ts
+++ b/src/features/verifiable/register.ts
@@ -1,5 +1,5 @@
 import type { CAC } from "cac";
-import { BOLD, RESET, readRawOptionValue } from "../../platform/index.ts";
+import { BOLD, RESET, readRawOptionValue, withHelp } from "../../platform/index.ts";
 
 /**
  * Command registration for `dot verifiable`, kept free of heavy imports: the
@@ -96,7 +96,7 @@ const RAW_STRING_FLAGS: Array<[string, keyof VerifiableOpts]> = [
 ];
 
 export function registerVerifiableCommands(cli: CAC) {
-  cli
+  const command = cli
     .command(
       "verifiable [action] [...rest]",
       "Bandersnatch member keys, ring-VRF proofs, signing and verification",
@@ -129,4 +129,5 @@ export function registerVerifiableCommands(cli: CAC) {
       const { runVerifiable } = await import("./commands.ts");
       return runVerifiable(action, rest, opts);
     });
+  withHelp(command, () => console.log(VERIFIABLE_HELP));
 }

--- a/src/platform/cli.test.ts
+++ b/src/platform/cli.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import cac from "cac";
+import {
+  printMatchedCommandHelp,
+  readRawOptionValue,
+  registerGlobalOptions,
+  withHelp,
+} from "./cli.ts";
+
+// In-process unit tests for the per-command help registry (issue #238). The
+// end-to-end behaviour is covered by spawned-CLI tests in commands/*.test.ts,
+// but those run in subprocesses and don't contribute to in-process coverage —
+// so we exercise the registry functions directly here.
+
+function buildCli() {
+  const cli = cac("dot");
+  registerGlobalOptions(cli);
+  return cli;
+}
+
+describe("platform/cli help registry", () => {
+  test("withHelp returns the command for chaining", () => {
+    const cli = buildCli();
+    const command = cli.command("demo [action]", "demo");
+    expect(withHelp(command, () => {})).toBe(command);
+  });
+
+  test("printMatchedCommandHelp runs the registered printer for the matched command", () => {
+    const cli = buildCli();
+    let printed = 0;
+    withHelp(
+      cli.command("widget [action] [...rest]", "widget").action(() => {}),
+      () => {
+        printed++;
+      },
+    );
+    cli.command("[dotpath] [...args]", "default").action(() => {});
+    cli.option("--help, -h", "help");
+
+    // `dot widget add --help` — an action positional plus --help must still
+    // resolve to the registered printer rather than running the action.
+    cli.parse(["bun", "dot", "widget", "add", "--help"], { run: false });
+    expect(printMatchedCommandHelp(cli)).toBe(true);
+    expect(printed).toBe(1);
+  });
+
+  test("printMatchedCommandHelp falls back to cac outputHelp when no custom printer", () => {
+    const cli = buildCli();
+    const command = cli.command("gadget <name>", "gadget").action(() => {});
+    withHelp(command); // no custom printer → cac auto-help
+    cli.option("--help, -h", "help");
+
+    const original = console.log;
+    const lines: string[] = [];
+    console.log = (...args: unknown[]) => {
+      lines.push(args.join(" "));
+    };
+    try {
+      cli.parse(["bun", "dot", "gadget", "--help"], { run: false });
+      expect(printMatchedCommandHelp(cli)).toBe(true);
+    } finally {
+      console.log = original;
+    }
+    expect(lines.join("\n")).toContain("gadget");
+  });
+
+  test("printMatchedCommandHelp returns false for an unregistered matched command", () => {
+    const cli = buildCli();
+    cli.command("[dotpath] [...args]", "default").action(() => {});
+    cli.option("--help, -h", "help");
+    cli.parse(["bun", "dot", "polkadot.query.System.Account"], { run: false });
+    // The default dot-path command is intentionally not registered, so the
+    // caller falls through to running it (preserving item-level help).
+    expect(printMatchedCommandHelp(cli)).toBe(false);
+  });
+
+  test("printMatchedCommandHelp returns false when no command matched", () => {
+    const cli = buildCli();
+    cli.command("solo", "solo").action(() => {});
+    cli.option("--help, -h", "help");
+    cli.parse(["bun", "dot"], { run: false });
+    expect(printMatchedCommandHelp(cli)).toBe(false);
+  });
+});
+
+describe("platform/cli global options + raw option reader", () => {
+  test("registerGlobalOptions exposes the shared flags", () => {
+    const cli = buildCli();
+    const names = cli.globalCommand.options.map((o) => o.name);
+    expect(names).toContain("chain");
+    expect(names).toContain("rpc");
+    expect(names).toContain("output");
+    expect(names).toContain("json");
+  });
+
+  test("readRawOptionValue reads --name value and --name=value, last wins", () => {
+    expect(readRawOptionValue("chain", ["--chain", "polkadot"])).toBe("polkadot");
+    expect(readRawOptionValue("chain", ["--chain=paseo"])).toBe("paseo");
+    expect(readRawOptionValue("chain", ["--chain", "a", "--chain", "b"])).toBe("b");
+  });
+
+  test("readRawOptionValue stops at the -- terminator and ignores prefix siblings", () => {
+    expect(readRawOptionValue("member", ["--members", "0xdead", "--member", "0xbeef"])).toBe(
+      "0xbeef",
+    );
+    expect(readRawOptionValue("chain", ["--", "--chain", "polkadot"])).toBeUndefined();
+    expect(readRawOptionValue("chain", ["query.System"])).toBeUndefined();
+  });
+});

--- a/src/platform/cli.ts
+++ b/src/platform/cli.ts
@@ -1,4 +1,45 @@
-import type { CAC } from "cac";
+import type { CAC, Command } from "cac";
+
+/**
+ * Per-command `--help` text printers, keyed by the command's first name token
+ * (e.g. `account`, `chain`, `sign`). Commands register their rich usage block
+ * here so `--help` prints proper usage for nested subcommands
+ * (`dot account add --help`, `dot chain add --help`, …) instead of running the
+ * action and failing on the missing positional argument.
+ */
+const commandHelpPrinters = new Map<string, () => void>();
+
+/** Extract the leading command-name token (e.g. `account` from `account [action] [...names]`). */
+function commandKey(command: Command): string {
+  return command.name.split(/\s+/)[0] ?? command.name;
+}
+
+/**
+ * Associate a help printer with a `cac` command so `--help` prints proper usage
+ * even when an action positional is present (the bug behind #238). Pass a custom
+ * printer for commands with a rich usage block; omit it to fall back to `cac`'s
+ * auto-generated per-command help. Returns the command for chaining.
+ */
+export function withHelp(command: Command, printHelp?: () => void): Command {
+  commandHelpPrinters.set(commandKey(command), printHelp ?? (() => command.outputHelp()));
+  return command;
+}
+
+/**
+ * Print the registered help for the matched command. Returns true if the
+ * matched command had a registered help printer (and it was printed). Commands
+ * without a registered printer — notably the default dot-path command, which
+ * handles item-level help inside its own action — return false so the caller
+ * can fall through to running them.
+ */
+export function printMatchedCommandHelp(cli: CAC): boolean {
+  const matched = (cli as unknown as { matchedCommand?: Command }).matchedCommand;
+  if (!matched) return false;
+  const printer = commandHelpPrinters.get(commandKey(matched));
+  if (!printer) return false;
+  printer();
+  return true;
+}
 
 /**
  * Register the shared global options on a `cac` instance. Kept in one place so

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -24,7 +24,7 @@ export { resolveDataInput } from "../core/input.ts";
 export { BOLD, formatJson, isJsonOutput, printHeading, RESET } from "../core/output.ts";
 export { CliError } from "../utils/errors.ts";
 export { findClosest } from "../utils/fuzzy-match.ts";
-export { readRawOptionValue } from "./cli.ts";
+export { readRawOptionValue, withHelp } from "./cli.ts";
 
 // Entry-point bootstrap (registerGlobalOptions) lives in ./cli.ts and is
 // imported directly by entry points (src/cli.ts) — not re-exported here, since


### PR DESCRIPTION
Closes #238

## The bug

`dot account add --help` (and other nested subcommands) **dropped the `--help` flag**: instead of printing usage, the command ran its action, hit the missing positional argument, and exited `1` with an error.

`cac` matches the *parent* command (`account`, `chain`, …) and the bespoke action handlers only printed help when the primary positional was absent. So an action positional like `add` together with `--help` fell straight through to the business logic.

## Before vs after

**BEFORE** — `dot account add --help` errored instead of helping:

```console
$ dot account add --help
Account name is required.

Usage: dot account add <name> <ss58-address|0x-public-key>
$ echo $?
1
```

**AFTER** — `dot account add --help` prints full usage and exits `0`:

```console
$ dot account add --help
Usage:
  $ dot account add <name> <ss58|hex>                                Add a watch-only address (no secret)
  $ dot account add <name> --secret <s> [--path <derivation>]        Import from BIP39 mnemonic or 32-byte hex seed
  $ dot account add <name> --env <VAR> [--path <derivation>]         Import account backed by env variable
  $ dot account add <name> --parachain <id> --parachain-type <t>     Derive a parachain sovereign (t = child|sibling)
  $ dot account add <name> --pallet-id <8 chars or 0x hex>           Derive a pallet sovereign (e.g. py/trsry)
  ... (full account usage block) ...

Examples:
  $ dot account add treasury 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
  ...
$ echo $?
0
```

This was not limited to `account add`. The same drop affected every nested level, e.g.:

| Command | Before | After |
| --- | --- | --- |
| `dot account add --help` | `1` — "Account name is required." | `0` — usage |
| `dot account inspect --help` | `1` — "Input is required." | `0` — usage |
| `dot chain add --help` | `1` — "Chain name is required." | `0` — usage |
| `dot hash blake2b256 --help` | would hash instead | `0` — usage |
| `dot sign hello --help` | would try to sign, fail on `--from` | `0` — usage |
| `dot verifiable prove --help` | ran the action | `0` — usage |
| `dot metadata --help` | `1` — "missing required args" | `0` — usage |
| `dot completions --help` | `1` — "missing required args" | `0` — usage |

## The fix

A small per-command help registry in `src/platform/cli.ts`:

- `withHelp(command, printer?)` registers a help printer for a command — its rich usage block, or `cac`'s auto-generated per-command help as a fallback.
- `printMatchedCommandHelp(cli)` is consulted in `main()` when `--help` is set and a named command matched: it prints usage and exits `0` **without** running the action.

Every named command (`account`, `chain`, `sign`, `hash`, `parachain`, `verifiable`, `metadata`, `completions`, `inspect`, `init`, `which`) registers via `withHelp`. The default dot-path command is intentionally **not** registered, so item-level help such as `dot polkadot.query.System.Account --help` keeps working through its own action (regression-tested).

## Tests

Added regression coverage:

- `src/commands/global.test.ts` — a `nested command --help (issue #238)` block asserting exit `0` + usage for `account add`, `account inspect`, `chain add`, `chain remove`, `hash <algo>`, `sign <msg>`, `verifiable prove`, `parachain <id>`, plus the required-arg commands `metadata` and `completions`.
- `src/commands/account.test.ts` — `account <sub> --help` for every subcommand prints usage and exits `0`; `account add --help` output is byte-identical to bare `account` help; and `account add <name> <addr>` still adds a watch-only account (help is not triggered without the flag).

Full suite: **1706 pass / 0 fail**. `bun run lint` and `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
