### PR TITLE
fix(cli): make nested --help survive the production bundle (#238)

### DIFF
--- a/.changeset/help-registry-bundling.md
+++ b/.changeset/help-registry-bundling.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": patch
+---
+
+Fix nested `--help` being dropped in the published bundle. The per-command help registry from the previous fix relied on a module-level `Map`, which `bun build` duplicated (the module is imported both directly and via the `platform/index.ts` barrel) — `withHelp` populated one copy while `printMatchedCommandHelp` read an empty other copy, so `dot account add --help` still ran the action and errored in `dist/cli.mjs` even though the source and tests were green. The help printer is now stored on the `cac` command instance under a `Symbol.for` key, which is immune to module duplication. A post-build smoke test (`src/cli.smoke.test.ts`) now exercises the built bundle under `node` so this class of bundler-only regression is caught.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 out
 dist
 *.tgz
+.smoke-cli.*.mjs
 
 # code coverage
 coverage

--- a/src/cli.smoke.test.ts
+++ b/src/cli.smoke.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "./config/types.ts";
+
+// Post-build smoke test (issue #238 follow-up). The `runCli` fixture spawns the
+// unbundled TypeScript source via `bun`, so it cannot catch bugs introduced by
+// `bun build` — most notably module duplication, which split the per-command
+// `--help` registry across two copies and silently dropped help in the shipped
+// `dist/cli.mjs` while every source-level test stayed green. These tests build
+// the bundle the same way `bun run build` does and execute it with `node`, the
+// way the published binary actually runs.
+
+const REPO_ROOT = join(import.meta.dir, "..");
+// Built into the repo tree so `--packages external` deps resolve against the
+// repo's node_modules; a unique name avoids collisions if test files run in
+// parallel.
+const BUNDLE = join(REPO_ROOT, `.smoke-cli.${process.pid}.mjs`);
+
+async function build(): Promise<void> {
+  const proc = Bun.spawn(
+    [
+      "bun",
+      "build",
+      join(import.meta.dir, "cli.ts"),
+      "--outfile",
+      BUNDLE,
+      "--target",
+      "node",
+      "--packages",
+      "external",
+    ],
+    { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" },
+  );
+  const stderr = await new Response(proc.stderr as ReadableStream).text();
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) throw new Error(`build failed:\n${stderr}`);
+}
+
+async function runBuilt(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const tmpHome = mkdtempSync(join(tmpdir(), "dot-smoke-"));
+  const dotDir = join(tmpHome, ".polkadot");
+  mkdirSync(dotDir, { recursive: true });
+  writeFileSync(join(dotDir, "config.json"), JSON.stringify(DEFAULT_CONFIG));
+  try {
+    const proc = Bun.spawn(["node", BUNDLE, ...args], {
+      env: { ...process.env, HOME: tmpHome, DOT_HOME: dotDir },
+      cwd: tmpHome,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout as ReadableStream).text(),
+      new Response(proc.stderr as ReadableStream).text(),
+    ]);
+    const exitCode = await proc.exited;
+    return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+  } finally {
+    rmSync(tmpHome, { recursive: true, force: true });
+  }
+}
+
+// @ts-expect-error Bun supports describe(label, options, fn) at runtime
+describe("built bundle: nested --help (issue #238)", { timeout: 60_000 }, () => {
+  beforeAll(async () => {
+    await build();
+  });
+  afterAll(() => {
+    rmSync(BUNDLE, { force: true });
+  });
+
+  // One case per import shape that feeds the help registry:
+  //   - account / chain / hash: import withHelp directly from platform/cli.ts
+  //   - verifiable: imports withHelp via the platform/index.ts re-export barrel
+  //     (the barrel import is what triggered the bundler to duplicate the module
+  //     and split the registry — keep it covered).
+  const cases: { args: string[]; needle: string }[] = [
+    { args: ["account", "add", "--help"], needle: "dot account add" },
+    { args: ["account", "inspect", "--help"], needle: "dot account inspect" },
+    { args: ["chain", "add", "--help"], needle: "dot chain add" },
+    { args: ["hash", "blake2b256", "--help"], needle: "dot hash" },
+    { args: ["verifiable", "prove", "--help"], needle: "dot verifiable" },
+    { args: ["parachain", "1000", "--help"], needle: "dot parachain" },
+  ];
+  for (const { args, needle } of cases) {
+    test(`${args.join(" ")} prints usage and exits 0`, async () => {
+      const { stdout, stderr, exitCode } = await runBuilt(args);
+      expect(exitCode).toBe(0);
+      expect(stdout + stderr).toContain(needle);
+    });
+  }
+
+  test("required-positional commands still print help, not an arg error", async () => {
+    const metadata = await runBuilt(["metadata", "--help"]);
+    expect(metadata.exitCode).toBe(0);
+    const completions = await runBuilt(["completions", "--help"]);
+    expect(completions.exitCode).toBe(0);
+  });
+});

--- a/src/platform/cli.ts
+++ b/src/platform/cli.ts
@@ -1,18 +1,20 @@
 import type { CAC, Command } from "cac";
 
 /**
- * Per-command `--help` text printers, keyed by the command's first name token
- * (e.g. `account`, `chain`, `sign`). Commands register their rich usage block
- * here so `--help` prints proper usage for nested subcommands
- * (`dot account add --help`, `dot chain add --help`, …) instead of running the
- * action and failing on the missing positional argument.
+ * Symbol under which a command's `--help` printer is stashed directly on the
+ * `cac` Command object. We attach the printer to the command instance rather
+ * than keeping a module-level Map: `bun build` can duplicate this module in the
+ * bundle (it is imported both directly and re-exported via `platform/index.ts`),
+ * and a module-level Map would then split — `withHelp` writing to one copy while
+ * `printMatchedCommandHelp` reads an empty other copy, silently dropping all
+ * help. Issue #238 regressed exactly this way in the published bundle even
+ * though the source and tests were correct. A `Symbol.for` lives in the global
+ * registry, so duplicated module copies still resolve to the same key, and the
+ * state lives on the single command instance.
  */
-const commandHelpPrinters = new Map<string, () => void>();
+const HELP_PRINTER = Symbol.for("polkadot-cli.helpPrinter");
 
-/** Extract the leading command-name token (e.g. `account` from `account [action] [...names]`). */
-function commandKey(command: Command): string {
-  return command.name.split(/\s+/)[0] ?? command.name;
-}
+type WithHelpPrinter = Command & { [HELP_PRINTER]?: () => void };
 
 /**
  * Associate a help printer with a `cac` command so `--help` prints proper usage
@@ -21,7 +23,7 @@ function commandKey(command: Command): string {
  * auto-generated per-command help. Returns the command for chaining.
  */
 export function withHelp(command: Command, printHelp?: () => void): Command {
-  commandHelpPrinters.set(commandKey(command), printHelp ?? (() => command.outputHelp()));
+  (command as WithHelpPrinter)[HELP_PRINTER] = printHelp ?? (() => command.outputHelp());
   return command;
 }
 
@@ -33,9 +35,8 @@ export function withHelp(command: Command, printHelp?: () => void): Command {
  * can fall through to running them.
  */
 export function printMatchedCommandHelp(cli: CAC): boolean {
-  const matched = (cli as unknown as { matchedCommand?: Command }).matchedCommand;
-  if (!matched) return false;
-  const printer = commandHelpPrinters.get(commandKey(matched));
+  const matched = (cli as unknown as { matchedCommand?: WithHelpPrinter }).matchedCommand;
+  const printer = matched?.[HELP_PRINTER];
   if (!printer) return false;
   printer();
   return true;


### PR DESCRIPTION
Follow-up to #244. The nested `--help` fix worked in source and in tests but was **a no-op in the published beta** — `dot account add --help` still printed `Account name is required` and exited 1.

## Root cause

The per-command help registry in #244 kept its printers in a module-level `Map`. `bun build` **duplicates** `src/platform/cli.ts` in the bundle, because the module is imported both directly (`../platform/cli.ts`) and via the `platform/index.ts` re-export barrel (used by `verifiable/register.ts`). The result in `dist/cli.mjs`:

- `withHelp()` populated one copy of the Map (`commandHelpPrinters`)
- `printMatchedCommandHelp()` read a *second, empty* copy (`commandHelpPrinters2`)

Every lookup missed → fell through to `runMatchedCommand()` → the action ran → arg error. Confirmed by inspecting the published beta bundle and by a fresh local `bun build`.

The source-level tests stayed green because `runCli` spawns the **unbundled TypeScript** via `bun` — a single module instance, one shared Map. The bug only existed in the bundle.

## Fix

Stop using module-level shared state. The help printer is now stored **on the `cac` command instance** under a `Symbol.for("polkadot-cli.helpPrinter")` key. There is exactly one command instance regardless of module duplication, and `Symbol.for` resolves to the same key across duplicate copies — so the registry can no longer split.

## Regression guard

`src/cli.smoke.test.ts` builds the bundle the same way `bun run build` does and runs it under `node`, the way the published binary actually runs — closing the blind spot. Verified it **fails on the pre-fix code (6/7)** and **passes on the fix**.

## Verification

Ran the real `bun run build` and executed `dist/cli.mjs` directly:

| Command | exit | output |
| --- | --- | --- |
| `dot account add --help` | 0 | usage |
| `dot account inspect --help` | 0 | usage |
| `dot chain add --help` | 0 | usage |
| `dot hash blake2b256 --help` | 0 | usage |
| `dot verifiable prove --help` | 0 | usage (barrel-import path) |
| `dot metadata --help` | 0 | usage |
| `dot completions --help` | 0 | usage |

`bun run typecheck` clean; the new/changed files pass Biome. Full affected suites: 208 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)