### PR TITLE
feat(cli): print full help when a command is run incompletely

### DIFF
--- a/.changeset/incomplete-prints-help.md
+++ b/.changeset/incomplete-prints-help.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Incomplete commands now print full help instead of a terse error. When a command is invoked without a required positional argument — `dot account add`, `dot account inspect`, `dot chain add`, `dot chain update`, `dot metadata`, `dot completions`, etc. — the CLI now prints the command's complete usage block (the same one shown by `--help`) to stderr and exits 1, rather than a one-line "X is required" hint or a raw `missing required args` error. A short reason (e.g. `Account name is required.`) still leads the output so it's clear what was missing. Explicit `--help` is unchanged: it prints to stdout and exits 0. Missing/invalid options (e.g. `dot chain add foo` without `--rpc`, `dot sign msg` without `--from`) keep their specific targeted errors.

--- a/src/cli.smoke.test.ts
+++ b/src/cli.smoke.test.ts
@@ -99,4 +99,30 @@ describe("built bundle: nested --help (issue #238)", { timeout: 60_000 }, () => 
     const completions = await runBuilt(["completions", "--help"]);
     expect(completions.exitCode).toBe(0);
   });
+
+  // Incomplete invocation → full help on stderr, exit 1. This MUST be checked
+  // against the built bundle: the UsageError path is detected by `.name` rather
+  // than `instanceof` precisely because `bun build` duplicates utils/errors.ts,
+  // and an in-process source test can't see that duplication. `account add`
+  // exercises our UsageError path; `metadata` exercises cac's missing-args path.
+  const incompleteCases: { args: string[]; reason: string; needle: string }[] = [
+    { args: ["account", "add"], reason: "Account name is required", needle: "dot account add" },
+    { args: ["chain", "add"], reason: "Chain name is required", needle: "dot chain add" },
+  ];
+  for (const { args, reason, needle } of incompleteCases) {
+    test(`${args.join(" ")} → full help on stderr, exit 1`, async () => {
+      const { stdout, stderr, exitCode } = await runBuilt(args);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain(reason); // leading one-line reason
+      expect(stderr).toContain(needle); // ...followed by the full usage block
+      expect(stdout).toBe("");
+    });
+  }
+
+  test("metadata (no chain) → full help on stderr, exit 1", async () => {
+    const { stdout, stderr, exitCode } = await runBuilt(["metadata"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("metadata");
+    expect(stdout).toBe("");
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -421,6 +421,29 @@ if (process.argv[2] === "__complete") {
   }
 
   async function handleError(err: unknown): Promise<never> {
+    // A command invoked without its required positional input prints the full
+    // help block to stderr (exit 1), instead of a terse one-liner. Both our own
+    // UsageError and cac's "missing required args" error reach here; treat them
+    // the same so e.g. `dot account add`, `dot metadata`, `dot completions` all
+    // show usage. Explicit `--help` is handled earlier and exits 0 on stdout.
+    //
+    // Detect UsageError by `name`, not `instanceof`: `bun build` can duplicate
+    // utils/errors.ts in the bundle (it is imported very widely), and an
+    // `instanceof` against one copy fails for an error thrown from another —
+    // the `.name` string survives duplication. (Same hazard that split the help
+    // registry; see platform/cli.ts.)
+    const isUsageError = err instanceof Error && err.name === "UsageError";
+    const isCacMissingArgs =
+      err instanceof Error && /missing required args? for command/i.test(err.message);
+    if (isUsageError || isCacMissingArgs) {
+      if (isUsageError) console.error(`${(err as Error).message}\n`);
+      if (!printMatchedCommandHelp(cli, { stream: "stderr" })) {
+        // No registered help (shouldn't happen for these commands) — fall back
+        // to the original message so the user still gets something actionable.
+        console.error(`Error: ${formatRuntimeError(err as Error)}`);
+      }
+      return showUpdateAndExit(1);
+    }
     if (err instanceof CliError) {
       console.error(`Error: ${err.message}`);
     } else if (err instanceof Error) {

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -50,6 +50,7 @@ import {
   type SovereignAccountType,
 } from "../core/parachain.ts";
 import { withHelp } from "../platform/cli.ts";
+import { UsageError } from "../utils/errors.ts";
 
 const ACCOUNT_HELP = `
 ${BOLD}Usage:${RESET}
@@ -209,9 +210,7 @@ async function accountCreate(
   opts: { path?: string; output?: string; json?: boolean },
 ) {
   if (!name) {
-    console.error("Account name is required.\n");
-    console.error("Usage: dot account create <name>");
-    process.exit(1);
+    throw new UsageError("Account name is required.");
   }
 
   if (isDevAccount(name)) {
@@ -279,9 +278,7 @@ async function accountImport(
   opts: { secret?: string; env?: string; path?: string; output?: string; json?: boolean },
 ) {
   if (!name) {
-    console.error("Account name is required.\n");
-    console.error('Usage: dot account import <name> --secret "mnemonic or hex seed"');
-    process.exit(1);
+    throw new UsageError("Account name is required.");
   }
 
   if (opts.secret && opts.env) {
@@ -378,9 +375,7 @@ async function accountAddWatchOnly(
   } = {},
 ) {
   if (!name) {
-    console.error("Account name is required.\n");
-    console.error("Usage: dot account add <name> <ss58-address|0x-public-key>");
-    process.exit(1);
+    throw new UsageError("Account name is required.");
   }
 
   const sovereignSource = resolveSovereignSource(opts);
@@ -392,13 +387,7 @@ async function accountAddWatchOnly(
   }
 
   if (!sovereignSource && !address) {
-    console.error("Address is required.\n");
-    console.error("Usage: dot account add <name> <ss58-address|0x-public-key>");
-    console.error(
-      "       dot account add <name> --parachain <id> --parachain-type <child|sibling>",
-    );
-    console.error("       dot account add <name> --pallet-id <8 chars or 0x hex>");
-    process.exit(1);
+    throw new UsageError("Address is required.");
   }
 
   if (isDevAccount(name)) {
@@ -556,15 +545,11 @@ async function accountDerive(
   opts: { path?: string; output?: string; json?: boolean },
 ) {
   if (!sourceName) {
-    console.error("Source account name is required.\n");
-    console.error("Usage: dot account derive <source> <new-name> --path <derivation>");
-    process.exit(1);
+    throw new UsageError("Source account name is required.");
   }
 
   if (!newName) {
-    console.error("New account name is required.\n");
-    console.error("Usage: dot account derive <source> <new-name> --path <derivation>");
-    process.exit(1);
+    throw new UsageError("New account name is required.");
   }
 
   if (!opts.path) {
@@ -824,9 +809,7 @@ async function accountList(opts: { output?: string; json?: boolean } = {}) {
 
 async function accountRemove(names: string[], opts: { output?: string; json?: boolean } = {}) {
   if (names.length === 0) {
-    console.error("At least one account name is required.\n");
-    console.error("Usage: dot account remove <name> [name2] ...");
-    process.exit(1);
+    throw new UsageError("At least one account name is required.");
   }
 
   // Validate all names upfront before deleting anything
@@ -898,13 +881,7 @@ async function accountInspect(
   }
 
   if (!sovereignSource && !input) {
-    console.error("Input is required.\n");
-    console.error("Usage: dot account inspect <name|ss58-address|0x-public-key> [--prefix <N>]");
-    console.error("       dot account inspect --pallet-id <id> [--prefix <N>]");
-    console.error(
-      "       dot account inspect --parachain <id> --parachain-type <child|sibling> [--prefix <N>]",
-    );
-    process.exit(1);
+    throw new UsageError("Input is required.");
   }
 
   const prefix = opts.prefix != null ? Number(opts.prefix) : 42;

--- a/src/commands/chain.test.ts
+++ b/src/commands/chain.test.ts
@@ -177,10 +177,14 @@ describe("dot chain", () => {
     expect(stderr).toContain('Unknown action "default"');
   });
 
-  test("update (no name, no --all) errors with usage", async () => {
-    const { stderr, exitCode } = await runCli(["chain", "update"]);
+  test("update (no name, no --all) prints full help to stderr and exits 1", async () => {
+    const { stdout, stderr, exitCode } = await runCli(["chain", "update"]);
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("Usage: dot chain update");
+    expect(stderr).toContain("Chain name is required");
+    // Full help (not a terse one-liner) — every chain subcommand is listed.
+    expect(stderr).toContain("dot chain update <name>");
+    expect(stderr).toContain("dot chain add");
+    expect(stdout).toBe("");
   });
 
   test("remove kusama succeeds", async () => {
@@ -975,10 +979,12 @@ describe("dot chain", () => {
     expect(stderr).toContain("nonexistent-chain");
   });
 
-  test("info (no name) errors with usage", async () => {
-    const { stderr, exitCode } = await runCli(["chain", "info"]);
+  test("info (no name) prints full help to stderr and exits 1", async () => {
+    const { stdout, stderr, exitCode } = await runCli(["chain", "info"]);
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("Usage: dot chain info");
+    expect(stderr).toContain("Chain name is required");
+    expect(stderr).toContain("dot chain info <name>");
+    expect(stdout).toBe("");
   });
 
   test("info case-insensitive name resolution", async () => {

--- a/src/commands/chain.ts
+++ b/src/commands/chain.ts
@@ -35,6 +35,7 @@ import {
 import { fetchRpcMethods } from "../core/rpc.ts";
 import { inferFamily, RPC_REGISTRY } from "../data/rpc-registry.ts";
 import { withHelp } from "../platform/cli.ts";
+import { UsageError } from "../utils/errors.ts";
 
 const CHAIN_HELP = `
 ${BOLD}Usage:${RESET}
@@ -168,9 +169,7 @@ async function chainAdd(
   },
 ) {
   if (!name) {
-    console.error("Chain name is required.\n");
-    console.error("Usage: dot chain add <name> --rpc <url>");
-    process.exit(1);
+    throw new UsageError("Chain name is required.");
   }
   if (!opts.rpc) {
     console.error("Must provide --rpc <url>.\n");
@@ -245,8 +244,7 @@ async function chainRemove(
   opts: { output?: string; json?: boolean } = {},
 ) {
   if (!name) {
-    console.error("Usage: dot chain remove <name>");
-    process.exit(1);
+    throw new UsageError("Chain name is required.");
   }
 
   const config = await loadConfig();
@@ -363,8 +361,7 @@ function printChainLine(
 
 async function chainInfo(name: string | undefined, opts: { output?: string; json?: boolean } = {}) {
   if (!name) {
-    console.error("Usage: dot chain info <name>");
-    process.exit(1);
+    throw new UsageError("Chain name is required.");
   }
 
   const config = await loadConfig();
@@ -470,8 +467,7 @@ async function chainUpdate(
   }
 
   if (!name) {
-    console.error("Usage: dot chain update <name> | --all");
-    process.exit(1);
+    throw new UsageError("Chain name is required (or use --all).");
   }
 
   const { name: chainName, chain: chainConfig } = resolveChain(config, name);

--- a/src/commands/global.test.ts
+++ b/src/commands/global.test.ts
@@ -146,4 +146,29 @@ describe("global CLI", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  // An incomplete invocation (a required positional missing) prints the FULL
+  // help block to stderr and exits 1 — not a terse one-liner, and not exit 0.
+  // Explicit `--help` (tested above) prints to stdout and exits 0. Covers both
+  // our own UsageError path (account/chain) and cac's missing-required-args
+  // path (metadata/completions).
+  describe("incomplete command prints full help (stderr, exit 1)", () => {
+    const cases: { args: string[]; reason: RegExp; needle: string }[] = [
+      { args: ["account", "add"], reason: /Account name is required/, needle: "dot account add" },
+      { args: ["account", "inspect"], reason: /Input is required/, needle: "dot account inspect" },
+      { args: ["chain", "add"], reason: /Chain name is required/, needle: "dot chain add" },
+      { args: ["metadata"], reason: /missing required|Usage/i, needle: "metadata" },
+      { args: ["completions"], reason: /missing required|Usage/i, needle: "completions" },
+    ];
+    for (const { args, reason, needle } of cases) {
+      test(`${args.join(" ")} → full help on stderr, exit 1`, async () => {
+        const { stdout, stderr, exitCode } = await runCli(args, { noDefaultChain: true });
+        expect(exitCode).toBe(1);
+        expect(stderr).toMatch(reason);
+        expect(stderr).toContain(needle);
+        // Help is a diagnostic here — stdout stays clean for piping.
+        expect(stdout).toBe("");
+      });
+    }
+  });
 });

--- a/src/platform/cli.ts
+++ b/src/platform/cli.ts
@@ -33,12 +33,30 @@ export function withHelp(command: Command, printHelp?: () => void): Command {
  * without a registered printer — notably the default dot-path command, which
  * handles item-level help inside its own action — return false so the caller
  * can fall through to running them.
+ *
+ * `stream: "stderr"` routes the help to stderr (used when a command was invoked
+ * incompletely — the help is a diagnostic, not the requested output). Printers
+ * and `cac`'s own `outputHelp()` write via `console.log`, so we temporarily
+ * redirect it; this is the one place that needs to retarget their output.
  */
-export function printMatchedCommandHelp(cli: CAC): boolean {
+export function printMatchedCommandHelp(
+  cli: CAC,
+  options?: { stream?: "stdout" | "stderr" },
+): boolean {
   const matched = (cli as unknown as { matchedCommand?: WithHelpPrinter }).matchedCommand;
   const printer = matched?.[HELP_PRINTER];
   if (!printer) return false;
-  printer();
+  if (options?.stream === "stderr") {
+    const original = console.log;
+    console.log = (...args: unknown[]) => console.error(...args);
+    try {
+      printer();
+    } finally {
+      console.log = original;
+    }
+  } else {
+    printer();
+  }
   return true;
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,6 +5,20 @@ export class CliError extends Error {
   }
 }
 
+/**
+ * A command was invoked without a required positional argument (e.g.
+ * `dot account add` with no name). The top-level error handler prints the
+ * command's full help block to stderr and exits 1, rather than a terse one-line
+ * usage hint. Missing/invalid *options* keep their own targeted errors — full
+ * help there is noise — so this is reserved for missing primary input.
+ */
+export class UsageError extends CliError {
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageError";
+  }
+}
+
 export class ConnectionError extends CliError {
   constructor(message: string) {
     super(message);


### PR DESCRIPTION
Follow-up requested after #244/#248: make an **incomplete command print its full help** instead of a terse error — the same discovery affordance as `dot polkadot.tx.` listing pallets.

> **Stacked on #248** (the bundle fix). Base will auto-retarget to `main` once #248 merges. Review #248 first.

## Behavior

When a command is invoked without a **required positional argument**, it now prints the command's complete usage block to **stderr** and exits **1**, led by a one-line reason:

```console
$ dot account add
Account name is required.

Usage:
  $ dot account add <name> <ss58|hex>   Add a watch-only address (no secret)
  ... (full account usage block) ...
$ echo $?
1
```

| Command | Before | After |
| --- | --- | --- |
| `dot account add` | `1` — terse `Account name is required.` + 1-line usage | `1` — reason + **full help** (stderr) |
| `dot account inspect` | `1` — terse | `1` — full help |
| `dot chain add` / `update` / `info` / `remove` | `1` — 1-line usage | `1` — full help |
| `dot metadata` / `dot completions` | `1` — raw `missing required args`, **no usage** | `1` — full help |

Unchanged on purpose:
- **Explicit `--help`** → stdout, exit `0` (per the git/cargo convention chosen for this).
- **Missing/invalid options** (`dot chain add foo` without `--rpc`, `dot sign msg` without `--from`, flag-combination errors) keep their specific targeted messages — full help there is noise.

## Implementation

- `UsageError` marker (`utils/errors.ts`) = "a required positional is missing".
- `handleError` prints the matched command's full help to **stderr** + exit 1 for both `UsageError` and cac's `missing required args` error.
- `printMatchedCommandHelp(cli, { stream: "stderr" })` routes help to stderr.
- `account.ts` / `chain.ts` missing-positional checks throw `UsageError` and drop their hand-written short-usage blocks (net −code).

## The bundler gotcha (and the guard)

First cut worked in source but showed the terse fallback in `dist/cli.mjs`: `bun build` duplicates `utils/errors.ts`, so `err instanceof UsageError` in `handleError` checked a *different* class copy than the one `account.ts` threw — same module-duplication class as #248. Fix: detect by `err.name === "UsageError"` (a string survives duplication). The **smoke test now exercises the incomplete path against the built bundle**, so this can't regress unseen.

## Verification

- Ran `bun run build` and executed `dist/cli.mjs`: `account add` (3405 b help/stderr), `chain add` (1463 b), `account inspect`, `metadata` → all exit 1 with full help, clean stdout; `chain add foo` → targeted `Must provide --rpc`, exit 1; `account add --help` → stdout, exit 0.
- Full suite **1728 pass / 0 fail** (pre-feature), affected + smoke suites **290 pass / 0 fail** (post-feature). Typecheck clean; changed files pass Biome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)