### PR TITLE
docs: document {relay}-{parachain} chain naming convention

### DIFF
--- a/.changeset/relay-parachain-naming.md
+++ b/.changeset/relay-parachain-naming.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": patch
+---
+
+Document the recommended `{relay}-{parachain}` chain-naming convention for `dot chain add` and the relay/parachain topology feature. The docs site, README, and `dot-cli` skill now explain why relay-prefixed names (`polkadot-asset-hub`, `kusama-bridge-hub`, …) keep the `dot chain list` tree readable and disambiguate parachains whose IDs collide across relays. Docs-only — no behavior change.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ dot chain add kusama --rpc wss://kusama-rpc.polkadot.io
 dot chain add kusama --rpc wss://kusama-rpc.polkadot.io --rpc wss://kusama-rpc.dwellir.com
 
 # Add a parachain under a relay (auto-detects parachain ID)
-dot chain add local-asset-hub --rpc ws://localhost:9945 --relay local-relay
+# Name parachains `{relay}-{parachain}` — see "Naming convention" below
+dot chain add local-relay-asset-hub --rpc ws://localhost:9945 --relay local-relay
 
 # Add a parachain with explicit parachain ID
 dot chain add my-para --rpc wss://rpc.example.com --relay polkadot --parachain-id 2000
@@ -118,6 +119,24 @@ dot chain update --all      # updates all configured chains in parallel
 # Remove a chain (only user-added chains can be removed)
 dot chain remove kusama
 ```
+
+#### Naming convention
+
+Name chains `{relay}-{parachain}`: the parent relay's name, a hyphen, then the parachain's role. Every preconfigured chain already follows this pattern (`polkadot-asset-hub`, `polkadot-bridge-hub`, `paseo-people`, …), and reusing it for chains you add keeps the relay/parachain topology readable.
+
+| Chain kind | Recommended name | Examples |
+|------------|------------------|----------|
+| Relay chain | `{relay}` | `polkadot`, `kusama`, `paseo` |
+| Parachain | `{relay}-{parachain}` | `polkadot-asset-hub`, `kusama-bridge-hub`, `paseo-people` |
+
+The relay prefix is what keeps chains distinct: parachain IDs collide across relays (Asset Hub is `1000` on both Polkadot and Paseo), so the name — not the ID — is how you select a chain (`dot polkadot-asset-hub.query…`). A relay-prefixed name also mirrors the `dot chain list` tree, which groups parachains under their relay.
+
+```bash
+# Recommended — relay-prefixed name
+dot chain add kusama-asset-hub --rpc wss://asset-hub-kusama-rpc.polkadot.io --relay kusama --parachain-id 1000
+```
+
+Use lowercase, hyphen-separated names (chain names resolve case-insensitively).
 
 #### Chain topology
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -117,16 +117,38 @@ dot chain add kusama --rpc wss://kusama-rpc.polkadot.io
 dot chain add kusama --rpc wss://kusama-rpc.polkadot.io --rpc wss://kusama-rpc.dwellir.com
 ```
 
+#### Naming convention
+
+Name chains as `{relay}-{parachain}`: the parent relay's name, a hyphen, then the parachain's role. This is the pattern every preconfigured chain already follows — `polkadot-asset-hub`, `polkadot-bridge-hub`, `paseo-coretime`, and so on — and the one to reuse for chains you add.
+
+| Chain kind | Recommended name | Examples |
+|------------|------------------|----------|
+| Relay chain | `{relay}` | `polkadot`, `kusama`, `paseo` |
+| Parachain | `{relay}-{parachain}` | `polkadot-asset-hub`, `kusama-bridge-hub`, `paseo-people` |
+
+Why it matters for the relay/parachain topology:
+
+- **The tree reads cleanly.** `dot chain list` groups parachains under their relay (see [Chain topology](#chain-topology)). When names share the relay prefix, the tree mirrors the names and the whole config is scannable at a glance.
+- **Names disambiguate, IDs don't.** Several relays reuse the same parachain ID — Asset Hub is `1000` on both Polkadot and Paseo. The relay prefix is what keeps `polkadot-asset-hub` and `paseo-asset-hub` distinct as chain names (the `relay` + `parachainId` fields carry the topology; the name is how *you* select the chain in `dot polkadot-asset-hub.query…`).
+- **It composes.** A consistent prefix makes chains easy to filter, tab-complete, and reason about across a multi-chain setup.
+
+Use lowercase, hyphen-separated names (chain names resolve case-insensitively). Following the same example as below, a Kusama Asset Hub would be `kusama-asset-hub`:
+
+```
+# Recommended — relay-prefixed name
+dot chain add kusama-asset-hub --rpc wss://asset-hub-kusama-rpc.polkadot.io --relay kusama --parachain-id 1000
+```
+
 #### Adding parachains
 
-Use `--relay` to declare a chain's parent relay chain. The CLI auto-detects the parachain ID from on-chain `ParachainInfo` storage. Use `--parachain-id` to set it explicitly:
+Use `--relay` to declare a chain's parent relay chain. The CLI auto-detects the parachain ID from on-chain `ParachainInfo` storage. Use `--parachain-id` to set it explicitly. Name the chain `{relay}-{parachain}` (see [Naming convention](#naming-convention)):
 
 ```
 # Add a relay chain (e.g. local zombienet)
 dot chain add local-relay --rpc ws://localhost:9944
 
-# Add a parachain under it (auto-detects parachain ID)
-dot chain add local-asset-hub --rpc ws://localhost:9945 --relay local-relay
+# Add a parachain under it — `{relay}-{parachain}` name, auto-detects parachain ID
+dot chain add local-relay-asset-hub --rpc ws://localhost:9945 --relay local-relay
 
 # Explicit parachain ID
 dot chain add my-para --rpc wss://rpc.example.com --relay polkadot --parachain-id 2000

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -132,7 +132,7 @@ Why it matters for the relay/parachain topology:
 - **Names disambiguate, IDs don't.** Several relays reuse the same parachain ID — Asset Hub is `1000` on both Polkadot and Paseo. The relay prefix is what keeps `polkadot-asset-hub` and `paseo-asset-hub` distinct as chain names (the `relay` + `parachainId` fields carry the topology; the name is how *you* select the chain in `dot polkadot-asset-hub.query…`).
 - **It composes.** A consistent prefix makes chains easy to filter, tab-complete, and reason about across a multi-chain setup.
 
-Use lowercase, hyphen-separated names (chain names resolve case-insensitively). Following the same example as below, a Kusama Asset Hub would be `kusama-asset-hub`:
+Use lowercase, hyphen-separated names (chain names resolve case-insensitively). For example, a Kusama Asset Hub would be `kusama-asset-hub`:
 
 ```
 # Recommended — relay-prefixed name

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -47,6 +47,14 @@ dot chain add kusama --rpc wss://kusama-rpc.polkadot.io
 # ✓ kusama
 ```
 
+**Naming convention:** name relay chains `{relay}` and parachains `{relay}-{parachain}` (e.g. `kusama-asset-hub`, `polkadot-bridge-hub`) — the same pattern the preconfigured chains use. Use `--relay` to attach a parachain to its relay; the parachain ID is auto-detected from `ParachainInfo` (override with `--parachain-id`). The relay prefix keeps chains distinct (parachain IDs collide across relays — Asset Hub is `1000` on both Polkadot and Paseo) and makes the `dot chain list` tree match the names. Use lowercase, hyphen-separated names (they resolve case-insensitively):
+
+```bash
+dot chain add kusama-asset-hub --rpc wss://asset-hub-kusama-rpc.polkadot.io --relay kusama --parachain-id 1000
+# Then select it by name:
+dot kusama-asset-hub.query.System.Number
+```
+
 List configured chains; the default output is a compact tree with relay/parachain structure only. Pass `-v` to also print RPC endpoints, or use `dot chain info <name>` for full per-chain detail:
 
 ```bash


### PR DESCRIPTION
Closes #159.

## What

Documents the recommended `{relay}-{parachain}` chain-naming convention for `dot chain add` and the relay/parachain topology feature. This is the pattern every preconfigured chain already follows (`polkadot-asset-hub`, `polkadot-bridge-hub`, `paseo-people`, …) but it was never stated as guidance — so users adding their own parachains had no documented convention to follow.

Updated three docs surfaces consistently (cross-referenced, not duplicated):

- **`docs/content/_index.md`** — new "Naming convention" subsection under Chains, with a kind→name table, the rationale (tree readability + ID collisions across relays), and a copy-pasteable example. The "Adding parachains" example now uses a relay-prefixed name and links back to it.
- **`README.md`** — matching "Naming convention" subsection in the Manage chains section.
- **`dot-cli/SKILL.md`** — a concise naming-convention note so the Claude skill teaches it, with an executable example.
- **`.changeset/`** — `patch` changeset (docs-only, matches repo convention for docs changes).

No CLI behavior changes.

## The guidance

| Chain kind | Recommended name | Examples |
|------------|------------------|----------|
| Relay chain | `{relay}` | `polkadot`, `kusama`, `paseo` |
| Parachain | `{relay}-{parachain}` | `polkadot-asset-hub`, `kusama-bridge-hub`, `paseo-people` |

The relay prefix is what keeps chains distinct: parachain IDs collide across relays (Asset Hub is `1000` on both Polkadot and Paseo), so the *name* — not the ID — is how you select a chain. A relay-prefixed name also mirrors the `dot chain list` topology tree.

Example `dot chain add` using the convention:

```bash
dot chain add kusama-asset-hub --rpc wss://asset-hub-kusama-rpc.polkadot.io --relay kusama --parachain-id 1000
```

## Verification

- Examples grounded in real behavior: confirmed `dot chain --help`, `dot chains` (tree output), and the built-in chain definitions in `src/config/types.ts` (which already use `{relay}-{parachain}` names with `relay` + `parachainId`).
- `bun run lint`, `bun run typecheck`, `bun run build` all pass.
- `bun test` passes (the husky pre-commit hook ran the full suite green; intermittent live-network timeouts are pre-existing flake unrelated to this docs change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)