### PR TITLE
feat(inspect): forgiving dot-paths — tolerate kind segments (#255)

### DIFF
--- a/.changeset/forgiving-inspect.md
+++ b/.changeset/forgiving-inspect.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Make `dot inspect` (and its `explore` alias) forgiving about dot-paths. Previously `dot inspect polkadot.tx.System.remark` threw `Invalid target ... Expected format: Pallet, Pallet.Item, or Chain.Pallet.Item` even though that exact path is valid for *invoking* a call — `inspect` had no notion of a `kind` segment. Now `parseTarget` (under `allowPalletOnly`) tolerates and ignores a `kind` segment (`tx`/`query`/`const`/`events`/`errors` and their aliases) appearing right after an optional chain prefix, so `dot inspect polkadot.tx.System.remark` describes the `System.remark` call just like `dot inspect polkadot.System.remark`. Partial paths continue to degrade to discovery rather than erroring (`dot inspect polkadot.query.System` lists the pallet's items). Genuinely-malformed input still errors with a helpful message. Closes #255.

--- a/README.md
+++ b/README.md
@@ -797,6 +797,8 @@ dot polkadot.const.Balances.ExistentialDeposit --json | jq
 
 Works offline from cached metadata after the first fetch. The chain is required. Prefer the chain-prefix-on-target form (`dot inspect polkadot.System`); `--chain` is equivalent. Note that `dot polkadot.inspect.X` does **not** parse — `inspect` is a top-level command, not a dotpath category.
 
+`inspect` is **forgiving**: it accepts the same dot-paths you use to invoke a call and degrades to discovery rather than erroring. A `kind` segment (`tx`/`query`/`const`/`events`/`errors`/…) is tolerated and ignored — so `dot inspect polkadot.tx.System.remark` describes the `System.remark` call just like `dot inspect polkadot.System.remark` does. Partial paths list rather than fail: `dot inspect polkadot.query.System` (and the bare `dot inspect System`) list the pallet's items.
+
 Output is **width-aware**: short type signatures stay on a single line, longer ones expand across multiple lines with field names aligned. Composite struct fields, enum variants, and call arguments are color-coded (cyan field names, yellow primitives, magenta container keywords like `Vec`/`Option`, green enum variants) when stdout is a TTY; piped output stays plain.
 
 ```bash

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1034,6 +1034,8 @@ Browse chain metadata offline (uses the cached copy after the first fetch). Show
 
 The chain is required: pass it with `--chain` or as a prefix on the inspect target (e.g. `dot inspect polkadot.System`).
 
+`inspect` is **forgiving** — it accepts the same dot-paths you use to invoke a call and prefers discovery over erroring. A `kind` segment (`tx`/`query`/`const`/`events`/`errors`/…) is tolerated and ignored, so `dot inspect polkadot.tx.System.remark` describes the `System.remark` call exactly as `dot inspect polkadot.System.remark` does. Partial paths list instead of failing: `dot inspect polkadot.query.System` (and the bare `dot inspect System`) list the pallet's items.
+
 Output is **width-aware**: short type signatures stay on a single line, long ones expand across multiple lines with field names aligned by colon. Composite struct fields and call arguments are color-coded (cyan field names, yellow primitives, magenta container keywords like `Vec`/`Option`, green enum variants) when stdout is a TTY; piped output stays plain.
 
 ```

--- a/src/commands/inspect.test.ts
+++ b/src/commands/inspect.test.ts
@@ -415,6 +415,43 @@ describe("dot inspect", () => {
     expect(stdout).toContain("(Storage)");
   });
 
+  // --- Forgiving dot-paths with a kind segment (#255) ---
+
+  test("inspect polkadot.tx.System.remark inspects the call (kind stripped)", async () => {
+    const { stdout, exitCode } = await runCli(["inspect", "polkadot.tx.System.remark"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("System.remark");
+    expect(stdout).toContain("(Call)");
+    expect(stdout).toContain("Args:");
+  });
+
+  test("inspect tx.System.remark inspects the call (no chain prefix)", async () => {
+    const { stdout, exitCode } = await runCli(["inspect", "tx.System.remark"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("System.remark");
+    expect(stdout).toContain("(Call)");
+  });
+
+  test("inspect polkadot.query.System degrades to listing the pallet", async () => {
+    const { stdout, exitCode } = await runCli(["inspect", "polkadot.query.System"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("System Pallet");
+    expect(stdout).toContain("Storage Items:");
+  });
+
+  test("inspect const.System degrades to listing the pallet (no chain prefix)", async () => {
+    const { stdout, exitCode } = await runCli(["inspect", "const.System"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("System Pallet");
+  });
+
+  test("inspect polkadot.events.Balances.Transfer inspects the event", async () => {
+    const { stdout, exitCode } = await runCli(["inspect", "polkadot.events.Balances.Transfer"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("(Event)");
+    expect(stdout).toContain("Fields:");
+  });
+
   // --json output tests
   test("--json lists all pallets as JSON", async () => {
     const { stdout, exitCode } = await runCli(["inspect", "--json"]);

--- a/src/utils/parse-dot-path.ts
+++ b/src/utils/parse-dot-path.ts
@@ -33,7 +33,12 @@ const CATEGORY_ALIASES: Record<string, DotCategory> = {
   rpc: "rpc",
 };
 
-function matchCategory(segment: string): DotCategory | undefined {
+/**
+ * Match a segment against the known category aliases (`tx`, `query`, `const`,
+ * `events`, `errors`, `apis`, `extensions`, `rpc`, …). Case-insensitive.
+ * Returns the canonical category, or `undefined` if the segment is not a kind.
+ */
+export function matchCategory(segment: string): DotCategory | undefined {
   return CATEGORY_ALIASES[segment.toLowerCase()];
 }
 

--- a/src/utils/parse-target.test.ts
+++ b/src/utils/parse-target.test.ts
@@ -78,12 +78,85 @@ describe("parseTarget (allowPalletOnly)", () => {
     });
   });
 
-  test("4-segment throws", () => {
+  test("4-segment without a kind segment throws", () => {
     expect(() => parseTarget("a.b.c.d", { allowPalletOnly: true })).toThrow(/Expected format/);
   });
 
   test("empty 1-segment throws", () => {
     expect(() => parseTarget("", { allowPalletOnly: true })).toThrow(/Expected format/);
+  });
+
+  // Forgiving inspect: tolerate a `kind` segment (tx/query/const/events/errors)
+  // so the same dot-path that invokes a call also inspects it (#255).
+  test("Chain.kind.Pallet.Item strips the kind", () => {
+    expect(
+      parseTarget("polkadot.tx.System.remark", { knownChains, allowPalletOnly: true }),
+    ).toEqual({
+      chain: "polkadot",
+      pallet: "System",
+      item: "remark",
+    });
+  });
+
+  test("Chain.kind.Pallet strips the kind and degrades to pallet listing", () => {
+    expect(parseTarget("polkadot.query.System", { knownChains, allowPalletOnly: true })).toEqual({
+      chain: "polkadot",
+      pallet: "System",
+    });
+  });
+
+  test("kind.Pallet.Item (no chain) strips the kind", () => {
+    expect(parseTarget("tx.System.remark", { knownChains, allowPalletOnly: true })).toEqual({
+      pallet: "System",
+      item: "remark",
+    });
+  });
+
+  test("kind.Pallet (no chain) strips the kind", () => {
+    expect(parseTarget("const.System", { knownChains, allowPalletOnly: true })).toEqual({
+      pallet: "System",
+    });
+  });
+
+  test("kind aliases are recognized (events/errors/consts)", () => {
+    expect(parseTarget("polkadot.events.Balances", { knownChains, allowPalletOnly: true })).toEqual(
+      { chain: "polkadot", pallet: "Balances" },
+    );
+    expect(parseTarget("errors.Balances", { knownChains, allowPalletOnly: true })).toEqual({
+      pallet: "Balances",
+    });
+    expect(parseTarget("polkadot.consts.System", { knownChains, allowPalletOnly: true })).toEqual({
+      chain: "polkadot",
+      pallet: "System",
+    });
+  });
+
+  test("kind matching is case-insensitive", () => {
+    expect(
+      parseTarget("polkadot.TX.System.remark", { knownChains, allowPalletOnly: true }),
+    ).toEqual({ chain: "polkadot", pallet: "System", item: "remark" });
+  });
+
+  test("a kind in the wrong position is NOT stripped (Pallet.kind.Item)", () => {
+    // "System" is not a known chain, so this stays a 3-segment Chain.Pallet.Item
+    // and does not get the kind stripped — genuinely-odd input is preserved.
+    expect(parseTarget("System.tx.Account", { knownChains, allowPalletOnly: true })).toEqual({
+      chain: "System",
+      pallet: "tx",
+      item: "Account",
+    });
+  });
+
+  test("a kind-named pallet without a following segment is treated as the pallet", () => {
+    // Bare "tx" has nothing after it, so it is taken as a pallet name to list,
+    // not stripped as a kind.
+    expect(parseTarget("tx", { knownChains, allowPalletOnly: true })).toEqual({ pallet: "tx" });
+  });
+
+  test("still throws on too many segments after stripping the kind", () => {
+    expect(() => parseTarget("polkadot.tx.a.b.c", { knownChains, allowPalletOnly: true })).toThrow(
+      /Expected format/,
+    );
   });
 });
 

--- a/src/utils/parse-target.ts
+++ b/src/utils/parse-target.ts
@@ -4,15 +4,49 @@ export interface Target {
   item?: string;
 }
 
+import { matchCategory } from "./parse-dot-path.ts";
+
 export interface ParseTargetOptions {
   knownChains?: string[];
   allowPalletOnly?: boolean;
 }
 
+/**
+ * Strip an optional "kind" segment (`tx`/`query`/`const`/`events`/`errors`/…)
+ * from a dot-path so `inspect` can tolerate the same paths used to invoke a
+ * call. The kind is only meaningful right after an optional chain prefix
+ * (position 0 for `kind.Pallet…`, position 1 for `Chain.kind.Pallet…`), and is
+ * dropped because inspection describes a pallet/item regardless of call kind.
+ *
+ * Returns the remaining segments. A kind in any other position is left in place
+ * so genuinely-malformed input (e.g. `System.tx.Account`) still errors.
+ */
+function stripKindSegment(parts: string[], knownChains: string[]): string[] {
+  // Chain.kind.… → drop index 1 when index 0 is a known chain and index 1 a kind.
+  if (
+    parts.length >= 3 &&
+    parts[0] &&
+    knownChains.some((c) => c.toLowerCase() === parts[0]!.toLowerCase()) &&
+    parts[1] &&
+    matchCategory(parts[1]!)
+  ) {
+    return [parts[0]!, ...parts.slice(2)];
+  }
+  // kind.… → drop the leading kind (only when something follows it).
+  if (parts.length >= 2 && parts[0] && matchCategory(parts[0]!)) {
+    return parts.slice(1);
+  }
+  return parts;
+}
+
 export function parseTarget(input: string, options?: ParseTargetOptions): Target {
-  const parts = input.split(".");
+  let parts = input.split(".");
 
   if (options?.allowPalletOnly) {
+    // Be generous: tolerate a `kind` segment (e.g. `polkadot.tx.System.remark`)
+    // so the same dot-path that invokes a call also inspects it.
+    parts = stripKindSegment(parts, options.knownChains ?? []);
+
     switch (parts.length) {
       case 1:
         if (!parts[0]) {
@@ -44,7 +78,8 @@ export function parseTarget(input: string, options?: ParseTargetOptions): Target
 
       default:
         throw new Error(
-          `Invalid target "${input}". Expected format: Pallet, Pallet.Item, or Chain.Pallet.Item`,
+          `Invalid target "${input}". Expected format: Pallet, Pallet.Item, Chain.Pallet.Item, ` +
+            `or a dot-path with a kind segment (e.g. polkadot.tx.System.remark)`,
         );
     }
   }


### PR DESCRIPTION
Closes #255

## Problem

`dot inspect` was too restrictive. The reporter ran:

```
dot inspect polkadot.tx.System.remark
```

and got an error, even though that exact dot-path is valid for *invoking* the call (`dot polkadot.tx.System.remark`). `inspect` should be generous/exploratory.

## Root cause

The error originates in `src/utils/parse-target.ts → parseTarget()` (the `default:` case). Its grammar only modeled 1–3 dot-segments (`Pallet` / `Pallet.Item` / `Chain.Pallet.Item`) and had **no notion of a `kind` segment** (`tx`/`query`/`const`/`events`/`errors`). So the 4-segment `polkadot.tx.System.remark` fell through and threw — inconsistent with the dotpath invocation command (`src/cli.ts`), which accepts the same path.

## Fix

Under `allowPalletOnly` (the inspect path), `parseTarget` now strips an optional `kind` segment appearing right after an optional chain prefix, then falls through to the existing logic. The recognized kinds reuse the **canonical category matcher** from `parse-dot-path.ts` (single source of truth — `matchCategory` is now exported), so inspect and invoke stay in sync (including aliases like `consts`, `event`, `error`).

- `Chain.kind.Pallet.Item` → `{chain, pallet, item}` (inspect the item)
- `Chain.kind.Pallet` / `kind.Pallet` → `{…, pallet}` (degrade to listing the pallet)
- A kind in the wrong position (e.g. `System.tx.Account`) is left untouched, so genuinely-odd input is preserved/errors.
- A bare kind-named pallet with nothing after it (e.g. `tx`) is still treated as a pallet to list, not stripped.

Inspect already degraded to listing for partial paths (bare pallet, `Chain.Pallet`); that behavior is unchanged. The `default:` error message is also more helpful now.

## Before / after

**Before:**

```
$ dot inspect polkadot.tx.System.remark
Error: Invalid target "polkadot.tx.System.remark". Expected format: Pallet, Pallet.Item, or Chain.Pallet.Item
```

**After** (real output from a local run):

```
$ dot inspect polkadot.tx.System.remark

System.remark (Call)

  Args: (remark: Vec<u8>)

  Make some on-chain remark.

Can be executed by every `origin`.
```

## Scope note — the optional `src/cli.ts` discovery half

Per the issue triage this was optional and explicitly to be skipped if it risks touching invocation semantics. I did **not** touch it: the `dot <chain>` / `dot <chain>.<kind>` invocation paths in `src/cli.ts` go through `parseDotPath` and the category handlers, and making bare/partial dotpaths *list instead of error* there would change invocation semantics and risk scope-creep. The required, must-do fix (`inspect`/`parseTarget`) fully resolves the reported bug. Follow-up for the invoke-side discovery half can be tracked separately if desired.

## Tests / checks

- New unit tests in `src/utils/parse-target.test.ts` cover the accepted forms (`Chain.kind.Pallet.Item`, `Chain.kind.Pallet`, `kind.Pallet[.Item]`, aliases, case-insensitivity) and the negative cases (wrong-position kind, bare kind-name, too-many-segments).
- New integration tests in `src/commands/inspect.test.ts` (offline fixture metadata) cover `polkadot.tx.System.remark`, `tx.System.remark`, `polkadot.query.System` → listing, `const.System`, and `polkadot.events.Balances.Transfer`.
- Existing behavior kept green; coverage does not decrease (net-new tests + all new branches covered).
- Local: `bun run typecheck` ✅ · `bun run lint` ✅ · `bun run build` ✅ · `bun test --concurrent --timeout 15000` ✅ (1753 pass / 0 fail).
- Changeset: `.changeset/forgiving-inspect.md` (**minor** — loosens/extends behavior).
- Docs: README "Inspect metadata" section and `docs/content/_index.md` updated to document the forgiving grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)