### PR TITLE
feat(bin): add `polkadot` as an alias for the `dot` command

### DIFF
--- a/.changeset/polkadot-alias.md
+++ b/.changeset/polkadot-alias.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Add `polkadot` as an alias for the `dot` command. Installing `polkadot-cli` (e.g. `npm install -g polkadot-cli`) now exposes both the `dot` and `polkadot` executables on your `PATH`; they resolve to the same CLI. Shell completions remain registered for `dot` only for now.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Each chain ships with multiple RPC endpoints from decentralized infrastructure p
 npm install -g polkadot-cli@latest
 ```
 
-This installs the `dot` command globally.
+This installs the CLI globally under two interchangeable command names: `dot` and `polkadot`. Use whichever you prefer — `dot query …` and `polkadot query …` are equivalent.
 
 ## Claude Code skill
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -37,7 +37,7 @@ Install globally via npm:
 npm install -g polkadot-cli@latest
 ```
 
-This installs the `dot` command globally. Ships with Polkadot and all system parachains preconfigured with multiple fallback RPC endpoints. Add any Substrate-based chain by pointing to its RPC endpoint(s).
+This installs the CLI globally under two interchangeable command names — `dot` and `polkadot` — both resolving to the same tool (use whichever you prefer; the docs use `dot`). Ships with Polkadot and all system parachains preconfigured with multiple fallback RPC endpoints. Add any Substrate-based chain by pointing to its RPC endpoint(s).
 
 ## Claude Code skill
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "CLI tool for querying Polkadot-ecosystem on-chain state",
   "type": "module",
   "bin": {
-    "dot": "dist/cli.mjs"
+    "dot": "dist/cli.mjs",
+    "polkadot": "dist/cli.mjs"
   },
   "files": [
     "dist"

--- a/src/cli.smoke.test.ts
+++ b/src/cli.smoke.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "./config/types.ts";
@@ -98,5 +98,23 @@ describe("built bundle: nested --help (issue #238)", { timeout: 60_000 }, () => 
     expect(metadata.exitCode).toBe(0);
     const completions = await runBuilt(["completions", "--help"]);
     expect(completions.exitCode).toBe(0);
+  });
+});
+
+// Packaging contract (issue #261): the published package exposes the CLI under
+// both the `dot` and `polkadot` executable names, both resolving to the same
+// built bundle. This guards against accidentally dropping or diverging an alias
+// when the `bin` map is edited.
+describe("package.json bin aliases (issue #261)", () => {
+  const pkg = JSON.parse(readFileSync(join(import.meta.dir, "..", "package.json"), "utf8")) as {
+    bin: Record<string, string>;
+  };
+
+  test("exposes both `dot` and `polkadot`", () => {
+    expect(Object.keys(pkg.bin).sort()).toEqual(["dot", "polkadot"]);
+  });
+
+  test("`polkadot` points at the same entry as `dot`", () => {
+    expect(pkg.bin.polkadot).toBe(pkg.bin.dot);
   });
 });


### PR DESCRIPTION
Closes #261.

Adds `polkadot` as an executable alias for the existing `dot` command. Per the owner's refinement on the issue: ship `polkadot` only (not `pcli`). Installing `polkadot-cli` (e.g. `npm install -g polkadot-cli`) now puts both `dot` and `polkadot` on `PATH`, both resolving to the same built bundle.

## `package.json` `bin` — before / after

```diff
   "bin": {
-    "dot": "dist/cli.mjs"
+    "dot": "dist/cli.mjs",
+    "polkadot": "dist/cli.mjs"
   },
```

`"files": ["dist"]` already ships the bundle the bins point at, so no other packaging change is needed.

## Proof the alias works

Simulated a global install by symlinking both bin names at the built bundle, then ran the alias:

```
$ polkadot --version
dot/1.21.0 darwin-arm64 node-v22.13.0

$ dot --version
dot/1.21.0 darwin-arm64 node-v22.13.0
```

Identical output — both names resolve to the same CLI.

Note: help/usage text still prints the program name `dot` (hardcoded via `cac("dot")`). That is acceptable for this scope; making the CLI fully name-agnostic was explicitly out of scope.

## Tests

Added a `package.json bin aliases (issue #261)` block to `src/cli.smoke.test.ts` asserting the `bin` map contains exactly `dot` and `polkadot` and that `polkadot` points at the same entry as `dot`. Full suite green (1741 pass / 0 fail).

## Docs

- `README.md` and `docs/content/_index.md`: install sections now say the CLI is available under both `dot` and `polkadot` after `npm install -g polkadot-cli`.

## Changeset

`minor` (new alias is a user-facing feature) — `.changeset/polkadot-alias.md`.

## Follow-up (out of scope)

`src/commands/completions.ts` hardcodes `dot` for zsh/bash/fish shell completions. The `polkadot` alias works functionally but won't get tab-completions until `completions` is parametrized by invoked name. Tracking as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
