### PR TITLE
ci: publish via paritytech/npm_publish_automation

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,71 @@
+name: NPM Release
+
+# Builds and packs the package, then hands the actual `npm publish` to
+# paritytech/npm_publish_automation, which publishes as the org-wide
+# `paritytech` npm account. This repo never runs `npm publish` itself.
+#
+# Triggered by release.yml (which creates the GitHub Release and dispatches
+# this workflow) or manually via workflow_dispatch with a tag input — handy to
+# re-run a publish after a transient failure without cutting a new tag.
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v1.2.3)"
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Set version from release tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION="${TAG#v}"
+          echo "Publishing version: $VERSION"
+          npm pkg set version="$VERSION"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Test
+        run: bun test --timeout 15000
+
+      - name: Pack
+        run: |
+          npm pack --ignore-scripts
+          mkdir -p packs
+          mv *.tgz packs/
+          ls -ltr packs
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ github.sha }}
+          path: packs
+
+      - name: Trigger npm_publish_automation
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/paritytech/npm_publish_automation/actions/workflows/publish.yml/dispatches
+          ref: main
+          inputs: '${{ format(''{{ "repo": "{0}", "run_id": "{1}" }}'', github.repository, github.run_id) }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NPM_PUBLISH_AUTOMATION_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,129 +1,89 @@
 name: Release
 
+# Changesets-driven release orchestration.
+#
+# On every push to main this:
+#   1. Opens/updates a "chore: version packages" PR that consumes pending
+#      changesets, bumps package.json and updates CHANGELOG.md.
+#   2. Once that PR is merged and no changesets remain, creates a GitHub
+#      Release for the new version and dispatches npm-release.yml, which packs
+#      the tarball and hands the actual `npm publish` to
+#      paritytech/npm_publish_automation (the org-wide publishing account).
+#
+# The real publish never happens from this repo — see npm-release.yml.
+
 on:
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "npm dist-tag for snapshot release (e.g. beta, next, canary)"
-        required: false
-        default: "beta"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
-  release:
-    if: github.event_name == 'push'
+  changesets:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      # npm trusted publishing requires npm >= 11.5.1 (Node >= 22.14)
+      - uses: oven-sh/setup-bun@v2
+
       - uses: actions/setup-node@v4
         with:
           node-version: 24
 
-      - uses: oven-sh/setup-bun@v2
-
       - run: bun install --frozen-lockfile
 
-      - run: bun run build
-
-      - name: Create release PR or publish
+      - uses: changesets/action@v1
         id: changesets
-        uses: changesets/action@v1
         with:
           version: bun run version
-          publish: bun run release
+          commit: "chore: version packages"
+          title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: "0"
 
       - name: Create GitHub Release
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.hasChangesets == 'false'
         uses: actions/github-script@v7
         with:
           script: |
-            const packages = JSON.parse('${{ steps.changesets.outputs.publishedPackages }}');
-            for (const pkg of packages) {
-              const tag = `v${pkg.version}`;
-              try {
-                await github.rest.repos.createRelease({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  tag_name: tag,
-                  name: tag,
-                  generate_release_notes: true,
-                });
-              } catch (err) {
-                if (err.status === 422) {
-                  const { data: releases } = await github.rest.repos.listReleases({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    per_page: 10,
-                  });
-                  const existing = releases.find(r => r.tag_name === tag);
-                  if (existing) {
-                    await github.rest.repos.updateRelease({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      release_id: existing.id,
-                      tag_name: tag,
-                      name: tag,
-                      generate_release_notes: true,
-                    });
-                    console.log(`Updated existing release for ${tag}`);
-                  }
-                } else {
-                  throw err;
-                }
-              }
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const tag = `v${pkg.version}`;
+
+            // Skip if a release for this tag already exists.
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tag,
+              });
+              console.log(`Release ${tag} already exists, skipping`);
+              return;
+            } catch (err) {
+              if (err.status !== 404) throw err;
             }
 
-  snapshot:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: tag,
+              generate_release_notes: true,
+            });
+            console.log(`Created release ${tag}`);
 
-      # npm trusted publishing requires npm >= 11.5.1 (Node >= 22.14)
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-
-      - uses: oven-sh/setup-bun@v2
-
-      - run: bun install --frozen-lockfile
-
-      - run: bun run build
-
-      - name: Version (snapshot)
-        run: npx changeset version --snapshot ${{ inputs.tag }}
-        env:
-          HUSKY: "0"
-
-      - name: Publish (snapshot)
-        run: npx changeset publish --tag ${{ inputs.tag }}
-
-      - name: Report published version
-        run: |
-          VERSION=$(jq -r '.version' package.json)
-          echo "## Snapshot Published" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** \`${VERSION}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** \`${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Install with:" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "npx polkadot-cli@${{ inputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+            // GITHUB_TOKEN can trigger workflow_dispatch in the same repo.
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'npm-release.yml',
+              ref: 'main',
+              inputs: { tag: tag },
+            });
+            console.log(`Dispatched npm-release workflow for ${tag}`);

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,11 @@
 # Releasing
 
-This project uses [Changesets](https://github.com/changesets/changesets) to manage versioning and publishing to npm.
+This project uses [Changesets](https://github.com/changesets/changesets) for
+versioning, and the org-wide [`paritytech/npm_publish_automation`](https://github.com/paritytech/npm_publish_automation)
+for the actual `npm publish`. The package is **never** published from a personal
+account or directly from this repo's CI — the publish always runs as the
+`paritytech` npm account inside the automation repo. This gives us a single,
+auditable publishing identity for all Parity packages.
 
 ## Adding a changeset
 
@@ -10,63 +15,58 @@ Before merging a PR that should result in a version bump, add a changeset:
 bun changeset
 ```
 
-Follow the prompts to select the bump type (`patch`, `minor`, `major`) and describe the change. This creates a markdown file in `.changeset/` that should be committed with your PR.
+Follow the prompts to pick the bump type (`patch`/`minor`/`major`) and describe
+the change. Commit the generated `.changeset/*.md` file with your PR.
 
-## Production release
+## How a release happens
 
-Production releases happen automatically when changes are pushed to `main`.
+Two workflows drive it:
 
-The [Release workflow](.github/workflows/release.yml) runs on every push to `main` and does the following:
+1. **`.github/workflows/release.yml`** runs on every push to `main`. Via
+   [`changesets/action`](https://github.com/changesets/action) it:
+   - opens (or updates) a **"chore: version packages"** PR that consumes the
+     pending changesets, bumps `package.json` and updates `CHANGELOG.md`;
+   - once that PR is merged and no changesets remain, creates a **GitHub
+     Release** for the new `vX.Y.Z` tag and dispatches `npm-release.yml`.
 
-1. If there are pending changesets, it opens (or updates) a **"Version Packages"** PR that bumps `package.json` and updates the changelog.
-2. When that PR is merged, the workflow detects there are no remaining changesets, builds the project, publishes to npm under the `latest` tag, and creates a GitHub Release with auto-generated release notes.
+2. **`.github/workflows/npm-release.yml`** runs on the release event. It builds,
+   `npm pack`s the tarball, uploads it as an artifact, and dispatches
+   `paritytech/npm_publish_automation`'s `publish.yml`, passing this repo and the
+   run id. That automation downloads the tarball and runs the real `npm publish`
+   as the `paritytech` account, under the `latest` dist-tag.
 
-This is handled by the [`changesets/action`](https://github.com/changesets/action) GitHub Action.
+### Normal flow
 
-### Steps
+1. Open PRs with changesets attached.
+2. Merge them into `main`.
+3. Review and merge the auto-created **"chore: version packages"** PR.
+4. The GitHub Release and npm publish happen automatically. Watch both:
+   - <https://github.com/paritytech/polkadot-cli/actions/workflows/npm-release.yml>
+   - <https://github.com/paritytech/npm_publish_automation/actions/workflows/publish.yml>
+5. Verify: `npm view polkadot-cli dist-tags` should show the new `latest`.
 
-1. Add changesets to your PRs as described above.
-2. Merge your PRs into `main`.
-3. Review and merge the auto-created "Version Packages" PR.
-4. The release is published automatically.
+### Re-running a publish without a new tag
 
-## Snapshot release
+If `npm-release.yml` failed transiently after the release was created, re-run it
+via **Actions → NPM Release → Run workflow** with `tag: vX.Y.Z`. The automation
+skips versions already on the registry, so this is safe.
 
-Snapshot releases publish a pre-release version from any branch, useful for testing changes before they land on `main`.
+## Pre-releases (betas)
 
-The [Snapshot Release workflow](.github/workflows/snapshot-release.yml) is triggered manually via `workflow_dispatch`.
+There is no automated snapshot/beta job — pre-releases are cut manually, the same
+way the `paritytech/verifiablejs` repo does it: bump to a `-beta.N` version on a
+release branch and `npm publish --tag beta` locally (requires npm publish rights
+on the package). Never publish a beta as `latest`.
 
-### Via GitHub UI
+## Prerequisites (one-time org setup)
 
-1. Go to **Actions** > **Snapshot Release**.
-2. Click **Run workflow**.
-3. Select the branch you want to publish from.
-4. Optionally change the dist-tag (defaults to `beta`; other useful values: `next`, `canary`).
-5. Click **Run workflow**.
+For the automated flow to work, these must be in place (see the PR that
+introduced this flow for the checklist):
 
-### Via GitHub CLI
-
-```sh
-gh workflow run snapshot-release.yml --ref <branch> --field tag=beta
-```
-
-### What it does
-
-1. Checks out the selected branch.
-2. Installs dependencies and builds.
-3. Runs `npx changeset version --snapshot <tag>` to generate a snapshot version (e.g. `1.2.0-beta-20260316120000`).
-4. Publishes to npm under the specified dist-tag.
-5. Reports the published version in the workflow summary.
-
-### Installing a snapshot
-
-```sh
-npx polkadot-cli@beta
-# or whatever tag you used:
-npx polkadot-cli@next
-npx polkadot-cli@canary
-```
-
-## Prerequisites
-
-- The `NPM_TOKEN` secret must be configured in the repository settings with publish access to the `polkadot-cli` package on npm.
+- `paritytech/polkadot-cli` is mapped to the `polkadot-cli` npm package in
+  `paritytech/npm_publish_automation`'s `packages.ts`.
+- The `paritytech` npm publishing account is an **owner** of the `polkadot-cli`
+  npm package.
+- The org-level `NPM_PUBLISH_AUTOMATION_TOKEN` secret is available to this repo.
+- GitHub Actions is allowed to create pull requests (Settings → Actions →
+  General → Workflow permissions).

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "test:coverage": "bun test --concurrent --coverage --coverage-reporter=lcov --coverage-dir=coverage",
     "prepare": "husky",
     "changeset": "changeset",
-    "version": "changeset version",
-    "release": "changeset publish"
+    "version": "changeset version"
   },
   "license": "MIT",
   "keywords": [
@@ -34,7 +33,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/peetzweg/polkadot-cli.git"
+    "url": "git+https://github.com/paritytech/polkadot-cli.git"
   },
   "dependencies": {
     "@noble/hashes": "^2.0.1",


### PR DESCRIPTION
## What

Switches the release flow to the **org-wide publishing setup** used by [`paritytech/verifiablejs`](https://github.com/paritytech/verifiablejs), now that this repo lives under `paritytech`.

Changesets still drives versioning, but the **actual `npm publish` no longer runs from this repo**. Instead it's handed to [`paritytech/npm_publish_automation`](https://github.com/paritytech/npm_publish_automation), which publishes as the single org-wide `paritytech` npm account. That gives us one auditable publishing identity instead of a personal account + OIDC trusted publisher.

### Two-workflow flow

- **`release.yml`** (push to `main`): `changesets/action` opens/updates the **"chore: version packages"** PR. When that PR merges and no changesets remain, it creates the `vX.Y.Z` GitHub Release and dispatches `npm-release.yml`.
- **`npm-release.yml`** (new, on release / manual): builds, `npm pack`s, uploads the tarball as an artifact, then dispatches `npm_publish_automation/publish.yml` with the org `NPM_PUBLISH_AUTOMATION_TOKEN` secret. The automation downloads the tarball and runs the real `npm publish` under `latest`.

### Also

- `package.json`: repository URL → `paritytech/polkadot-cli`; removed the now-unused `release` (`changeset publish`) script so nobody self-publishes around the org account.
- `RELEASE.md`: rewritten to document the new flow (and fixes a stale reference to a `snapshot-release.yml` that never existed).

### ⚠️ Behavior change: automated snapshot/beta job removed

The old `release.yml` had a `workflow_dispatch` **snapshot** job that self-published betas via OIDC. The company flow has no automated beta path, so I dropped it (matching `verifiablejs`, where betas are cut manually with `npm publish --tag beta`). Say the word if you'd rather keep an automated beta path and I'll add it back.

## Required manual setup (this PR alone does NOT make publishing work)

1. **Map the repo in `npm_publish_automation`.** Open a PR to [`paritytech/npm_publish_automation`](https://github.com/paritytech/npm_publish_automation) adding to `packages.ts`:
   ```ts
   "polkadot-cli": ["polkadot-cli"],
   ```
   An admin must review/merge it.
2. **Add the `paritytech` npm account as an owner of the `polkadot-cli` package.** It's currently owned only by the personal account `peetzweg <phil.czek@gmail.com>`. As that owner, run `npm owner add <paritytech-publishing-account> polkadot-cli` and have the CI/opstooling team **accept the invite** (npm owner adds are invitations). Without this the automation's publish will 403 — this exact issue bit `verifiablejs`.
3. **Confirm the org secret `NPM_PUBLISH_AUTOMATION_TOKEN` is available to this repo.** It's an org-level secret; if it's scoped to selected repos, add `paritytech/polkadot-cli` to its access list.
4. **Allow Actions to create PRs.** Settings → Actions → General → Workflow permissions → enable "Allow GitHub Actions to create and approve pull requests" (needed for the version PR).
5. **Optional cleanup:** once the org flow is verified, retire the old npm OIDC trusted-publisher config / `NPM_TOKEN` secret tied to the personal self-publish path.