### PR TITLE
chore(deps): upgrade cac from 6 to 7

### DIFF
--- a/.changeset/cac-v7.md
+++ b/.changeset/cac-v7.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": patch
+---
+
+Upgrade `cac` from `6.7.14` to `7.0.0` (major version bump of an internal dependency). cac v7 is ESM-only (the CLI is already ESM) and its auto-generated help/version output now writes via `console.info` instead of `console.log`. No user-visible CLI behavior changes: the same commands, flags, help text, version string, and exit codes are preserved.

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@polkadot-labs/hdkd": "^0.0.28",
         "@polkadot-labs/hdkd-helpers": "^0.0.29",
         "@scure/sr25519": "^1.0.0",
-        "cac": "^6.7.14",
+        "cac": "^7.0.0",
         "polkadot-api": "^2.1.7",
         "verifiablejs": "1.4.0",
         "yaml": "^2.8.3",
@@ -292,7 +292,7 @@
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
-    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+    "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@polkadot-labs/hdkd": "^0.0.28",
     "@polkadot-labs/hdkd-helpers": "^0.0.29",
     "@scure/sr25519": "^1.0.0",
-    "cac": "^6.7.14",
+    "cac": "^7.0.0",
     "polkadot-api": "^2.1.7",
     "verifiablejs": "1.4.0",
     "yaml": "^2.8.3"

--- a/src/platform/cli.test.ts
+++ b/src/platform/cli.test.ts
@@ -50,16 +50,23 @@ describe("platform/cli help registry", () => {
     withHelp(command); // no custom printer → cac auto-help
     cli.option("--help, -h", "help");
 
-    const original = console.log;
+    // cac v7's auto-generated help (Command.outputHelp) writes via
+    // console.info; capture both console.info and console.log so the assertion
+    // is robust regardless of which cac uses.
+    const originalInfo = console.info;
+    const originalLog = console.log;
     const lines: string[] = [];
-    console.log = (...args: unknown[]) => {
+    const capture = (...args: unknown[]) => {
       lines.push(args.join(" "));
     };
+    console.info = capture;
+    console.log = capture;
     try {
       cli.parse(["bun", "dot", "gadget", "--help"], { run: false });
       expect(printMatchedCommandHelp(cli)).toBe(true);
     } finally {
-      console.log = original;
+      console.info = originalInfo;
+      console.log = originalLog;
     }
     expect(lines.join("\n")).toContain("gadget");
   });


### PR DESCRIPTION
Closes #267

Upgrades the `cac` CLI argument parser to its latest major version.

## Version
`cac` **6.7.14 → 7.0.0** (latest 7.x; the version the issue links to).

## Breaking changes in cac v7 and how they were handled

| v7 breaking change | Impact here | Handling |
|---|---|---|
| **ESM-only** (CommonJS build removed) | None — the CLI is already `"type": "module"` and builds with `bun build … --target node --packages external`, resolving cac as ESM at runtime. | No change needed; verified build + `node dist/cli.mjs`. |
| **Node ≥ 20.19.0 required** | None — CI/runtime already on Node 22. | No change needed. |
| **`cli.on()` → `cli.addEventListener()`** | None — the repo never used cac's event API (only `process.on`). | No change needed. |
| **Auto-generated help/version now writes via `console.info`** (was `console.log`) | No user-visible change (both go to stdout). One in-process unit test stubbed `console.log` to capture cac's auto-help. | Adapted `src/platform/cli.test.ts` to capture `console.info` as well. |
| **New `checkUnusedArgs()` check** (errors on extra positionals) | None observed — all registered commands either are variadic (`[...args]`, `[...rest]`, `[...names]`) or are reached via the variadic default command. | Verified each command signature; no adaptation required. |

The full cac API surface used by the repo (`cac()`, `.command()`, `.option()`, `.action()`, `.version()`, `.help()`, `.parse(argv, { run })`, `cli.options`, `cli.matchedCommand`, `cli.runMatchedCommand()`, `Command.outputHelp()`, and the `CAC`/`Command` types) is unchanged in v7.

## Files touched
- `package.json` / `bun.lock` — bump `cac` to `^7.0.0`.
- `src/platform/cli.test.ts` — capture `console.info` (cac v7's help channel) in the help-registry fallback test.
- `.changeset/cac-v7.md` — patch changeset (internal-dependency major bump).

No `src/cli.ts` / `src/platform/cli.ts` logic changes were needed — the production code already worked unchanged against v7.

## CLI behaves identically (built bundle)

```
$ node dist/cli.mjs --version
dot/1.21.0 darwin-arm64 node-v22.13.0
```
(identical format to v6 — same `${platform}-${arch} node-${version}` suffix)

```
$ node dist/cli.mjs --help
dot/1.21.0 — Polkadot CLI

Usage:
  dot <category>[.Pallet[.Item]] [args] [options]
  dot [Chain.]<category>[.Pallet[.Item]] [args] [options]
  dot <file.yaml|file.json> [options]
  …
```

Also verified: `-h`, nested `dot chain add --help` / `dot account --help` / `dot hash --help`, required-positional `dot completions --help`, and the default dot-path parse (`dot query.System.Number` → graceful "no chain specified" error).

## Local checks
- **typecheck** (`tsc --noEmit`): pass
- **lint** (`biome check .`): pass (113 files, no fixes)
- **build** (`bun run build`): pass (bundled 59 modules)
- **test** (`bun test --timeout 15000`): **1739 pass / 0 fail** (5708 assertions, 53 files)
- **coverage**: unchanged — no source paths or test cases removed; the only test edit swaps which `console` method is stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)