### PR TITLE
ci: add manual beta release workflow

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,69 @@
+name: Beta Release
+
+# Manually publish a pre-release of any branch under a dist-tag (default: beta),
+# so a feature can be tested in the wild before a real `main` release.
+#
+# Same company publishing path as npm-release.yml: the actual `npm publish` runs
+# in paritytech/npm_publish_automation as the org `paritytech-ci` account. The
+# only difference is `npm_tag` — snapshot versions go out under `--tag beta`
+# (never `latest`), so normal installs are unaffected.
+#
+# Run it against the branch you want to ship:
+#   gh workflow run beta-release.yml --ref my-feature-branch
+# The branch needs at least one changeset — `changeset version --snapshot`
+# only bumps packages that have a pending changeset, producing a version like
+# 0.0.0-beta-<timestamp>. Install with `npm i polkadot-cli@beta`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "npm dist-tag to publish under"
+        required: true
+        default: beta
+
+jobs:
+  beta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - run: bun install --frozen-lockfile
+
+      - name: Snapshot version
+        run: |
+          bunx changeset version --snapshot ${{ inputs.tag }}
+          echo "Publishing $(node -p "require('./package.json').version")"
+
+      - name: Build
+        run: bun run build
+
+      - name: Test
+        run: bun test --timeout 15000
+
+      - name: Pack
+        run: |
+          npm pack --ignore-scripts
+          mkdir -p packs
+          mv *.tgz packs/
+          ls -ltr packs
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ github.sha }}
+          path: packs
+
+      - name: Trigger npm_publish_automation
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/paritytech/npm_publish_automation/actions/workflows/publish.yml/dispatches
+          ref: main
+          inputs: '${{ format(''{{ "repo": "{0}", "run_id": "{1}", "npm_tag": "{2}" }}'', github.repository, github.run_id, inputs.tag) }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NPM_PUBLISH_AUTOMATION_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 bun run lint
 bun run typecheck
-bun test --concurrent
+# Match CI's timeout: CLI-spawning + live-RPC tests exceed bun's 5s default.
+bun test --concurrent --timeout 15000

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,10 +53,33 @@ skips versions already on the registry, so this is safe.
 
 ## Pre-releases (betas)
 
-There is no automated snapshot/beta job — pre-releases are cut manually, the same
-way the `paritytech/verifiablejs` repo does it: bump to a `-beta.N` version on a
-release branch and `npm publish --tag beta` locally (requires npm publish rights
-on the package). Never publish a beta as `latest`.
+To test a feature in the wild before a real `main` release, publish a beta from
+its branch with **`.github/workflows/beta-release.yml`**. It uses the same
+company publishing path as `npm-release.yml` (the publish runs as `paritytech-ci`
+inside the automation repo) — the only difference is the `beta` dist-tag, so
+`latest` and normal installs are never touched.
+
+1. Make sure the branch has at least one changeset (`bun changeset`).
+   `changeset version --snapshot` only bumps packages that have a pending
+   changeset.
+2. Run it against the branch:
+
+   ```sh
+   gh workflow run beta-release.yml --ref my-feature-branch
+   ```
+
+   (or **Actions → Beta Release → Run workflow**, then pick the branch).
+3. The snapshot version looks like `0.0.0-beta-<timestamp>`. Because it sorts
+   below every real version, no `@latest` or semver-range install picks it up by
+   accident. Install it explicitly:
+
+   ```sh
+   npm i polkadot-cli@beta        # newest beta
+   npm i polkadot-cli@0.0.0-beta-<timestamp>   # a specific one
+   ```
+
+Nothing is committed back to the branch — the version bump only lives inside the
+CI run.
 
 ## Prerequisites (one-time org setup)
 


### PR DESCRIPTION
Adds a manual `beta-release.yml` to publish a pre-release of any branch under the `beta` dist-tag, for testing a feature in the wild before a real main release.

**Why:** the company-flow switch (#266) dropped the old automated snapshot/beta path, but we still need a way to ship test builds from a branch.

**How:** reuses the same `paritytech/npm_publish_automation` path as `npm-release.yml` (publishes as `paritytech-ci`), but computes a `changeset version --snapshot` version (`0.0.0-beta-<timestamp>`) and passes `npm_tag=beta`, so `latest` and normal installs are never touched. Run it with `gh workflow run beta-release.yml --ref <branch>`.

Also aligns the pre-commit hook test run with CI (`bun test --concurrent --timeout 15000`); it previously used bun's 5s default, which made CLI-spawning and live-RPC tests fail spuriously on loaded machines.