### PR TITLE
feat: make --ext override PAPI builtin extensions

### DIFF
--- a/.changeset/ext-overrides-builtins.md
+++ b/.changeset/ext-overrides-builtins.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Make `--ext` a generic override for every signed extension, including polkadot-api builtins. Naming a builtin (e.g. `CheckMortality`, `ChargeTransactionPayment`) in `--ext` now overrides the value polkadot-api would otherwise fill in automatically — previously such entries were silently ignored. `--asset` is now implemented as sugar over an `--ext` override of `ChargeAssetTxPayment`, so the two paths stay consistent. `dot <chain>.extensions.<Ext>` advertises the `--ext` override for builtins too.

--- a/README.md
+++ b/README.md
@@ -1123,10 +1123,10 @@ dot polkadot.extensions --json
 
 The list view tags each entry:
 
-- `[builtin]` — `polkadot-api` fills this in for you (e.g. `CheckMortality`, `CheckNonce`, `ChargeTransactionPayment`, `CheckMetadataHash`)
+- `[builtin]` — `polkadot-api` fills this in for you automatically (e.g. `CheckMortality`, `CheckNonce`, `ChargeTransactionPayment`, `CheckMetadataHash`). You normally never touch these, but you _can_ override any of them with `--ext` if you need to.
 - `[custom]` — you must provide a value with `--ext` when signing, for example `--ext '{"<Identifier>":{"value":<v>}}'`
 
-The detail view shows the extension's value type, its `additionalSigned` type, and a ready-to-adapt `--ext` snippet for custom extensions. Use this to discover what `--ext` payload a chain expects before submitting a `dot tx` command.
+The detail view shows the extension's value type, its `additionalSigned` type, and a ready-to-adapt `--ext` snippet — for both custom and builtin extensions. Use this to discover what `--ext` payload a chain expects before submitting a `dot tx` command.
 
 ### Raw JSON-RPC
 
@@ -1451,6 +1451,8 @@ For manual override, use `--ext` with a JSON object:
 ```bash
 dot polkadot.tx.System.remark 0xdeadbeef --from alice --ext '{"MyExtension":{"value":"..."}}'
 ```
+
+`--ext` is the generic escape hatch and works for **every** extension a chain declares — including `polkadot-api` builtins. Naming a builtin in `--ext` overrides the value `polkadot-api` would otherwise fill in automatically; omit it and the builtin default is used. Convenience flags like `--asset` (which overrides the `ChargeAssetTxPayment` builtin) are just sugar over an `--ext` override, so the two are always consistent.
 
 Not sure which extensions a chain exposes? Run `dot <chain>.extensions` (see [Transaction extensions](#transaction-extensions)) to list them all with value types and a `[builtin]` / `[custom]` marker.
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1441,7 +1441,11 @@ dot polkadot.extensions.CheckMortality
 #
 #   Value type:       enum(256 variants)
 #   AdditionalSigned: [u8; 32]
-#   Handled by:       polkadot-api (builtin)
+#   Handled by:       polkadot-api (builtin) — filled in automatically, override with --ext
+#
+# Usage:
+#   dot polkadot.tx.<Pallet>.<Call> --from <acc> --ext '{"CheckMortality":{"value":<v>}}'
+#   Builtin: polkadot-api sets a value by default; pass --ext only to override it.
 
 # Structured output for scripts / agents
 dot polkadot.extensions --json
@@ -1451,7 +1455,7 @@ dot polkadot.extensions --json
 
 Each entry is tagged:
 
-- `[builtin]` — `polkadot-api` handles this extension for you when signing. Examples: `CheckMortality`, `CheckNonce`, `ChargeTransactionPayment`, `CheckMetadataHash`, `StorageWeightReclaim`.
+- `[builtin]` — `polkadot-api` handles this extension for you when signing. Examples: `CheckMortality`, `CheckNonce`, `ChargeTransactionPayment`, `CheckMetadataHash`, `StorageWeightReclaim`. You can still override any builtin with `--ext` when you need to (e.g. `--asset` is just sugar over overriding `ChargeAssetTxPayment`).
 - `[custom]` — you must provide a value via `--ext` when signing. The detail view shows the value type and a ready-to-adapt snippet:
 
   ```

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -240,7 +240,7 @@ Use `--tip` to set a priority tip in plancks. `--nonce`, `--mortality`, and `--a
 dot polkadot.tx.System.remark 0xdead --from alice --tip 1000000 --dry-run
 ```
 
-For non-standard signed extensions, override with `--ext '{"<Identifier>":{"value":<v>}}'`. List the chain's extensions with `dot <chain>.extensions`.
+For signed extensions, override with `--ext '{"<Identifier>":{"value":<v>}}'`. This works for every extension the chain declares — non-standard `[custom]` ones and `polkadot-api` `[builtin]` ones alike (naming a builtin overrides the value PAPI would fill in; `--asset` is just sugar over overriding `ChargeAssetTxPayment`). List the chain's extensions with `dot <chain>.extensions`.
 
 ## Runtime APIs
 

--- a/src/commands/focused-inspect.test.ts
+++ b/src/commands/focused-inspect.test.ts
@@ -683,6 +683,14 @@ describe("dot extensions", () => {
     expect(stdout).toContain("polkadot-api (builtin)");
   });
 
+  test("builtin extension detail advertises the --ext override", async () => {
+    const { stdout, exitCode } = await runCli(["extensions.CheckMortality"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("override with --ext");
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain('--ext \'{"CheckMortality":{"value":<v>}}\'');
+  });
+
   test("extension alias works", async () => {
     const { stdout, exitCode } = await runCli(["extension.CheckMortality"]);
     expect(exitCode).toBe(0);

--- a/src/commands/focused-inspect.ts
+++ b/src/commands/focused-inspect.ts
@@ -837,13 +837,20 @@ export async function handleExtensions(
   console.log(`  ${BOLD}Value type:${RESET}       ${valueType}`);
   console.log(`  ${BOLD}AdditionalSigned:${RESET} ${addSigType}`);
   console.log(
-    `  ${BOLD}Handled by:${RESET}       ${described.isBuiltin ? "polkadot-api (builtin)" : "user (custom — provide via --ext)"}`,
+    `  ${BOLD}Handled by:${RESET}       ${
+      described.isBuiltin
+        ? "polkadot-api (builtin) — filled in automatically, override with --ext"
+        : "user (custom — provide via --ext)"
+    }`,
   );
-  if (!described.isBuiltin) {
-    console.log();
-    console.log(`${BOLD}Usage:${RESET}`);
+  console.log();
+  console.log(`${BOLD}Usage:${RESET}`);
+  console.log(
+    `  dot ${chainName}.tx.<Pallet>.<Call> --from <acc> --ext '{"${described.identifier}":{"value":<v>}}'`,
+  );
+  if (described.isBuiltin) {
     console.log(
-      `  dot ${chainName}.tx.<Pallet>.<Call> --from <acc> --ext '{"${described.identifier}":{"value":<v>}}'`,
+      `  ${DIM}Builtin: polkadot-api sets a value by default; pass --ext only to override it.${RESET}`,
     );
   }
   console.log();

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -1465,6 +1465,21 @@ describe("buildCustomSignedExtensions", () => {
     const result = buildCustomSignedExtensions(meta, {});
     expect(Object.keys(result).length).toBe(0);
   });
+
+  test("honors an explicit --ext override for a builtin extension", () => {
+    const override = { value: { type: "Immortal", value: undefined } };
+    const result = buildCustomSignedExtensions(meta, { CheckMortality: override });
+    expect(result.CheckMortality).toEqual(override);
+  });
+
+  test("only overrides the builtins named in --ext, leaving the rest to polkadot-api", () => {
+    const result = buildCustomSignedExtensions(meta, {
+      CheckMortality: { value: { type: "Immortal", value: undefined } },
+    });
+    expect(result).not.toHaveProperty("CheckNonce");
+    expect(result).not.toHaveProperty("ChargeTransactionPayment");
+    expect(Object.keys(result)).toEqual(["CheckMortality"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -335,28 +335,21 @@ export async function handleTx(
     if (!decodeOnly || opts.unsigned) {
       const userExtOverrides = parseExtOption(opts.ext);
 
-      // When --asset is specified, handle ChargeAssetTxPayment as a custom extension
-      // instead of letting PAPI handle it. PAPI's built-in path runs
+      // --asset is sugar over an explicit --ext override of the
+      // ChargeAssetTxPayment builtin. We handle it as a custom extension
+      // instead of letting PAPI handle it because PAPI's built-in path runs
       // `isAssetCompat(asset)` (packages/client/src/tx/tx.ts) against a typedef
       // derived from metadata; for XCM Location JSON on the unsafe API this
       // check rejects with "Incompatible runtime asset" even with fresh metadata.
-      // Bypassing it lets us SCALE-encode the asset directly via the metadata
-      // builder.
-      const skipBuiltins =
-        asset !== undefined
-          ? new Set([...PAPI_BUILTIN_EXTENSIONS].filter((e) => e !== "ChargeAssetTxPayment"))
-          : PAPI_BUILTIN_EXTENSIONS;
+      // Overriding the builtin lets us SCALE-encode the asset directly via the
+      // metadata builder. An explicit --ext for ChargeAssetTxPayment still wins.
       if (asset !== undefined) {
         userExtOverrides.ChargeAssetTxPayment ??= {
           value: { tip: tip ?? 0n, asset_id: asset },
         };
       }
 
-      const customSignedExtensions = buildCustomSignedExtensions(
-        meta,
-        userExtOverrides,
-        skipBuiltins,
-      );
+      const customSignedExtensions = buildCustomSignedExtensions(meta, userExtOverrides);
 
       const built: Record<string, any> = {};
       if (Object.keys(customSignedExtensions).length > 0)
@@ -1571,13 +1564,17 @@ function buildCustomSignedExtensions(
   const extensions = getSignedExtensions(meta);
 
   for (const ext of extensions) {
-    if (builtins.has(ext.identifier)) continue;
-
-    // User override takes priority
+    // An explicit --ext override always wins, even for PAPI builtins. This
+    // makes --ext the single generic mechanism for every extension and keeps
+    // it consistent with --asset (which is just sugar over overriding the
+    // ChargeAssetTxPayment builtin). Without an override, builtins are left to
+    // polkadot-api to fill in automatically.
     if (ext.identifier in userOverrides) {
       result[ext.identifier] = userOverrides[ext.identifier];
       continue;
     }
+
+    if (builtins.has(ext.identifier)) continue;
 
     // Auto-default based on type structure
     const valueEntry = meta.lookup(ext.type);


### PR DESCRIPTION
Closes #171.

Makes `--ext` a generic override that applies to **every** signed extension a chain declares, including polkadot-api builtins.

**Why:** `--asset` worked on the `ChargeAssetTxPayment` builtin, but naming any other builtin (e.g. `ChargeTransactionPayment`) in `--ext` was silently ignored — the two flags were inconsistent and `--ext` (the more generic one) couldn't reach builtins at all.

**How:** in `buildCustomSignedExtensions` an explicit `--ext` entry now takes priority over the builtin skip, so a named builtin is passed to polkadot-api's `customSignedExtensions`; un-named builtins are still auto-filled. `--asset` is now just sugar over an `--ext` override of `ChargeAssetTxPayment` (the bespoke skip-set juggling is gone). One judgment call: overriding builtins is a power-user escape hatch — the ergonomic flags (`--nonce`/`--tip`/`--mortality`/`--asset`) remain the normal path.

**Example** (real, executable — the detail view now advertises the override for builtins):

```
$ dot polkadot.extensions.CheckMortality

CheckMortality (Transaction Extension)

  Value type:       enum(256 variants)
  AdditionalSigned: [u8; 32]
  Handled by:       polkadot-api (builtin) — filled in automatically, override with --ext

Usage:
  dot polkadot.tx.<Pallet>.<Call> --from <acc> --ext '{"CheckMortality":{"value":<v>}}'
  Builtin: polkadot-api sets a value by default; pass --ext only to override it.
```

Force an immortal era on any call by overriding the builtin:

```
dot polkadot.tx.System.remark 0xdeadbeef --from alice \
  --ext '{"CheckMortality":{"value":{"type":"Immortal","value":null}}}'
```

Tests + changeset added; docs, skill and README updated. Full suite (1742 tests), lint, typecheck and build all green.