### PR TITLE
feat(verifiable): add `bandersnatch` as an alias for `verifiable`

### DIFF
--- a/.changeset/bandersnatch-alias.md
+++ b/.changeset/bandersnatch-alias.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Add `bandersnatch` as an alias for the `verifiable` command. `dot bandersnatch <action>` now resolves to the same handler as `dot verifiable <action>`, so users who think in terms of the underlying Bandersnatch/ring-VRF primitive find it. Every existing form and option works identically under either name.

--- a/README.md
+++ b/README.md
@@ -1925,6 +1925,9 @@ and supports `--output json`, so it pipes together and composes with any data
 (for example values you fetched on-chain with `dot` beforehand). It makes no
 assumptions and does no fetching or selection of its own.
 
+> `bandersnatch` is an alias for `verifiable` — `dot bandersnatch <action>` is
+> identical to `dot verifiable <action>` in every form and option.
+
 #### Two concepts you must not conflate
 
 ```

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -2502,6 +2502,8 @@ dot account inspect --parachain 1000 --parachain-type child --json
 
 `dot verifiable` is a set of composable, unopinionated primitives over the [`verifiablejs`](https://github.com/paritytech/verifiablejs) WASM library (Ring VRF on the Bandersnatch curve): derive member keys, sign, generate and verify ring-VRF proofs, and encode member sets. Every action is **bytes-in, bytes-out** — it takes hex / `--file` / `--stdin` input and supports `--output json`, so it pipes together and composes with any data (for example values you fetched on-chain with `dot` beforehand). It does no automated fetching or selection and assumes nothing about how the bytes were produced or where they go — feed the resulting signature/proof into a `dot` extrinsic or signed extension, or use it elsewhere. Runs offline.
 
+`bandersnatch` is an alias for `verifiable`: `dot bandersnatch <action>` is identical to `dot verifiable <action>` in every form and option.
+
 ### Two concepts you must not conflate
 
 ```

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -22,7 +22,7 @@ dot [chain.]<category>[.Pallet[.Item]] [args] [options]
 
 Categories: `query`, `tx`, `apis`, `const`, `events`, `errors`, `extensions`, `rpc`
 
-Top-level commands: `dot inspect`, `dot metadata`, `dot chain`, `dot account`, `dot sign`, `dot hash`, `dot verifiable`, `dot init`, `dot which`.
+Top-level commands: `dot inspect`, `dot metadata`, `dot chain`, `dot account`, `dot sign`, `dot hash`, `dot verifiable` (alias: `dot bandersnatch`), `dot init`, `dot which`.
 
 State (accounts, custom chains, metadata cache) lives in a config root resolved per run: `DOT_HOME` env var → a local `.polkadot/` workspace discovered from cwd → global `~/.polkadot`. Run `dot which` to see which one is active, and see [Local Workspaces](#local-workspaces) for isolated per-directory setups. Set `DOT_DRY_RUN=1` to force every extrinsic to dry-run instead of submitting (see [Submitting Transactions](#submitting-transactions)).
 
@@ -668,7 +668,7 @@ dot polkadot.tx.System.remark 0xdeadbeef --to-yaml
 
 ## Verifiable (Bandersnatch / Ring-VRF)
 
-`dot verifiable` is raw, unopinionated Bandersnatch/Ring-VRF crypto — bytes in, bytes out, no chain knowledge (like `dot sign` is just sr25519). It does no fetching: you supply the members/context/message (e.g. read from chain with `dot` first), and use the resulting signature/proof however you need — e.g. as a value in a `dot` extrinsic or signed extension. All actions take `--output json` and hex / `--file` / `--stdin` input, so they compose.
+`dot verifiable` is raw, unopinionated Bandersnatch/Ring-VRF crypto — bytes in, bytes out, no chain knowledge (like `dot sign` is just sr25519). It does no fetching: you supply the members/context/message (e.g. read from chain with `dot` first), and use the resulting signature/proof however you need — e.g. as a value in a `dot` extrinsic or signed extension. All actions take `--output json` and hex / `--file` / `--stdin` input, so they compose. `dot bandersnatch` is an alias for `dot verifiable` (identical in every form).
 
 Two distinct inputs — do not conflate:
 - `--entropy-key <text|0xhex>`: keyed-blake2b key turning the mnemonic into member entropy. Omit = lite person; `candidate` = full person. NOT a derivation path, NOT the ring context.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -409,7 +409,9 @@ if (process.argv[2] === "__complete") {
     console.log(
       "  parachain          Derive parachain sovereign accounts (deprecated — use `account inspect --parachain`)",
     );
-    console.log("  verifiable         Bandersnatch member keys, ring-VRF proofs, sign/verify");
+    console.log(
+      "  verifiable         Bandersnatch member keys, ring-VRF proofs, sign/verify (alias: bandersnatch)",
+    );
     console.log("  completions <sh>   Generate shell completions (zsh, bash, fish)");
     console.log("  init               Initialize a local .polkadot workspace in this directory");
     console.log(

--- a/src/features/verifiable/commands.test.ts
+++ b/src/features/verifiable/commands.test.ts
@@ -436,4 +436,31 @@ describe("dot verifiable alias / sign / prove / verify", { timeout: 20_000 }, ()
     // compact(2)=0x08 prefix + 2*32 bytes => 65 bytes => 130 hex chars + "0x"
     expect(result.members).toMatch(/^0x08[0-9a-f]{128}$/);
   });
+
+  // `bandersnatch` is a command alias for `verifiable` (issue #192). These
+  // mirror the primary tests above to prove the alias reaches the same handler
+  // and produces identical output.
+  describe("bandersnatch alias", () => {
+    test("no account shows the same help as verifiable", async () => {
+      const { stdout, exitCode } = await runCli(["bandersnatch"]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("dot verifiable");
+      expect(stdout).toContain("--entropy-key");
+    });
+
+    test("bandersnatch alice derives the member key", async () => {
+      const { stdout, exitCode } = await runCli(["bandersnatch", "alice"]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Bandersnatch Member Key");
+      expect(stdout).toContain("Member Key:");
+    });
+
+    test("bandersnatch output is byte-identical to verifiable", async () => {
+      const viaAlias = await runCli(["bandersnatch", "alice", "--output", "json"]);
+      const viaVerifiable = await runCli(["verifiable", "alice", "--output", "json"]);
+      expect(viaAlias.exitCode).toBe(0);
+      expect(viaVerifiable.exitCode).toBe(0);
+      expect(viaAlias.stdout).toBe(viaVerifiable.stdout);
+    });
+  });
 });

--- a/src/features/verifiable/register.ts
+++ b/src/features/verifiable/register.ts
@@ -13,6 +13,8 @@ ${BOLD}Usage:${RESET}
   $ dot verifiable [account] [--entropy-key <key>]       Derive the member key (default action)
   $ dot verifiable <action> [account] [options]
 
+  ${BOLD}bandersnatch${RESET} is an alias for ${BOLD}verifiable${RESET} — every form below works with either name.
+
 ${BOLD}Actions:${RESET}
   member <account>      Derive the Bandersnatch member key (default if omitted)
   alias  <account>      Derive the alias for a 32-byte ring context
@@ -101,6 +103,9 @@ export function registerVerifiableCommands(cli: CAC) {
       "verifiable [action] [...rest]",
       "Bandersnatch member keys, ring-VRF proofs, signing and verification",
     )
+    // `bandersnatch` is an alias for users who think in terms of the underlying
+    // curve/primitive rather than the "verifiable" framing (issue #192).
+    .alias("bandersnatch")
     .option("--entropy-key <key>", "Entropy-derivation key (omit = lite, 'candidate' = full)")
     .option("--context <value>", "32-byte ring/proof context (alias/prove/verify)")
     .option("--message <data>", "Message to sign/bind/verify (text or 0x hex)")


### PR DESCRIPTION
Closes #192. Adds `bandersnatch` as a command alias for `verifiable`.

**Why:** Users think of this command in terms of the underlying primitive ("bandersnatch" / ring-VRF) rather than the "verifiable" framing, and expect `dot bandersnatch ...` to exist.

**How:** One `.alias("bandersnatch")` on the existing `verifiable` command in `src/features/verifiable/register.ts`, following the convention already used for `inspect`→`explore`, `account`→`accounts`, and `chain`→`chains`. Same handler, same options, no new mechanism. Help text, README, docs, and the dot-cli skill note the alias; tests assert byte-identical output between the two names.

Try it from a fresh checkout (`bun install`):

```
$ bun src/cli.ts bandersnatch alice --output json
$ bun src/cli.ts verifiable  alice --output json
# identical output; also: dot bandersnatch alias/sign/prove/verify … all work
```

Out of scope (follow-up): the issue also asks "should we also somehow include it in the account commands?" — this PR does not touch account commands; that remains an open design question.