### PR TITLE
feat(chain): `dot chain properties <name>` (slice 1 of #199)

### DIFF
--- a/.changeset/chain-properties.md
+++ b/.changeset/chain-properties.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Add `dot chain properties <name>` command that returns a chain's `tokenDecimals`, `tokenSymbol`, and `ss58Format`. It tries `system_properties` (universally implemented) and falls back to the modern `chainSpec_v1_properties`, preserves array-typed responses from multi-token chains as-is, and handles empty `{}` properties gracefully as nulls. Lets scripts replace hardcoded `NATIVE_DECIMALS=12` with `NATIVE_DECIMALS=$(dot chain properties polkadot --json | jq .tokenDecimals)`.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,35 @@ All built-in system parachains are preconfigured with their relay chain and para
 
 Removing a relay chain that has parachains prints a warning listing the orphaned chains. The parachains remain in the config and can be re-associated later.
 
+#### Chain properties
+
+`dot chain properties <name>` asks the node for its `tokenDecimals`, `tokenSymbol`, and `ss58Format` — so scripts stop hardcoding per-chain decimals. It queries `system_properties` (universally implemented) and falls back to the modern `chainSpec_v1_properties` if the node doesn't expose it.
+
+```bash
+dot chain properties polkadot
+
+# polkadot
+#   token decimals: 10
+#   token symbol: DOT
+#   ss58 format: 0
+```
+
+The `--json` form emits a stable `{ tokenDecimals, tokenSymbol, ss58Format }` object, which is what you want for scripting:
+
+```bash
+dot chain properties polkadot --json
+# {
+#   "tokenDecimals": 10,
+#   "tokenSymbol": "DOT",
+#   "ss58Format": 0
+# }
+
+# Replace a hardcoded NATIVE_DECIMALS=12 with the value the chain reports:
+NATIVE_DECIMALS=$(dot chain properties polkadot --json | jq .tokenDecimals)
+```
+
+Some chains list multiple native-ish tokens and return `tokenDecimals`/`tokenSymbol` as arrays — these are preserved verbatim in the JSON (not collapsed to the first element). Minimal chains that return no properties surface `null` for each field rather than erroring.
+
 #### Selecting a chain
 
 Every chain-consuming command must specify a chain explicitly. Prefer the dotpath chain prefix; the `--chain <name>` flag is equivalent. There is no hidden default; running a command without a chain errors out with a message listing the configured chains.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -253,7 +253,22 @@ polkadot-asset-hub
     not cached — run `dot chain update polkadot-asset-hub`
 ```
 
-`dot chain <name>` is a bare-noun shortcut for `dot chain info <name>`. Known action verbs (`add`, `remove`, `update`, `list`, `export`, `import`, `info`) take precedence over chain names if there's ever a clash. Names resolve case-insensitively. `dot chain info <name> --json` emits the same data as a structured object — `metadata` is `null` when no fingerprint is cached.
+`dot chain <name>` is a bare-noun shortcut for `dot chain info <name>`. Known action verbs (`add`, `remove`, `update`, `list`, `export`, `import`, `info`, `properties`) take precedence over chain names if there's ever a clash. Names resolve case-insensitively. `dot chain info <name> --json` emits the same data as a structured object — `metadata` is `null` when no fingerprint is cached.
+
+### Chain properties
+
+Ask a chain for its token decimals, symbol, and ss58 prefix instead of hardcoding them per environment. `dot chain properties <name>` queries `system_properties` and falls back to the modern `chainSpec_v1_properties`:
+
+```
+dot chain properties polkadot --json
+# {
+#   "tokenDecimals": 10,
+#   "tokenSymbol": "DOT",
+#   "ss58Format": 0
+# }
+```
+
+This is the recommended way for scripts to obtain decimals — for example `NATIVE_DECIMALS=$(dot chain properties polkadot --json | jq .tokenDecimals)`. Chains that list multiple native-ish tokens return `tokenDecimals`/`tokenSymbol` as arrays, preserved as-is; minimal chains that expose no properties return `null` for each field.
 
 ### Update metadata
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -73,6 +73,22 @@ dot chain info polkadot --json | jq -r '.metadata.specVersion // "uncached"'
 # 1003000
 ```
 
+Ask the chain for its token decimals, symbol, and ss58 prefix instead of hardcoding them — `dot chain properties <name>` wraps `system_properties` (with a `chainSpec_v1_properties` fallback):
+
+```bash
+dot chain properties polkadot --json
+# {
+#   "tokenDecimals": 10,
+#   "tokenSymbol": "DOT",
+#   "ss58Format": 0
+# }
+
+# Scripts should derive decimals rather than baking in NATIVE_DECIMALS=12:
+NATIVE_DECIMALS=$(dot chain properties polkadot --json | jq .tokenDecimals)
+```
+
+Some chains return `tokenDecimals`/`tokenSymbol` as arrays (multiple native-ish tokens); the JSON preserves them as-is. Minimal chains that expose no properties return `null` for each field.
+
 Every chain-consuming command needs an explicit chain — prefer the dotpath prefix:
 
 ```bash

--- a/dot-cli/references/scripting-patterns.md
+++ b/dot-cli/references/scripting-patterns.md
@@ -95,6 +95,15 @@ dot chain add people --rpc "$RPC_PEOPLE" 2>/dev/null || true
 
 Scripts then use `dot people.query...` regardless of environment.
 
+**Prefer deriving `NATIVE_DECIMALS` over hardcoding it.** The `NATIVE_DECIMALS=12` / `NATIVE_DECIMALS=10` overrides above are a footgun: run a script against the wrong environment and every balance is off by orders of magnitude. Ask the chain instead:
+
+```bash
+NATIVE_DECIMALS=$(dot chain properties people --json | jq .tokenDecimals)
+# 10
+```
+
+`dot chain properties <name>` returns `{ tokenDecimals, tokenSymbol, ss58Format }` from the node (`system_properties`, falling back to `chainSpec_v1_properties`). Keep the env override only as a fallback for chains that expose no properties (the field comes back `null`).
+
 ## XCM Locations (JSON Arguments)
 
 Many pallets use XCM `Location` types as keys. These are JSON objects passed as a single arg:

--- a/src/commands/chain.test.ts
+++ b/src/commands/chain.test.ts
@@ -994,4 +994,181 @@ describe("dot chain", () => {
     expect(stdout).toContain("dot chain info <name>");
     expect(stdout).toContain("dot chain <name>");
   });
+
+  test("help text mentions properties action", async () => {
+    const { stdout, exitCode } = await runCli(["chain"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("dot chain properties <name>");
+  });
+});
+
+/**
+ * Minimal JSON-RPC-over-WebSocket server so the properties command can be
+ * exercised end-to-end (through the real one-shot RPC client) without a live
+ * node. `responder` maps a method name to either a result value or an Error
+ * (returned as a JSON-RPC error, mimicking an unsupported method).
+ */
+function startRpcServer(responder: (method: string) => unknown): {
+  url: string;
+  stop: () => void;
+} {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, srv) {
+      if (srv.upgrade(req)) return undefined;
+      return new Response("expected websocket", { status: 426 });
+    },
+    websocket: {
+      message(ws, raw) {
+        const msg = JSON.parse(String(raw)) as { id: number | string; method: string };
+        // The polkadot-api ws provider probes `rpc_methods` on connect to pick
+        // its legacy/modern routing — answer it before delegating to responder.
+        if (msg.method === "rpc_methods") {
+          ws.send(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: {
+                methods: ["system_properties", "chainSpec_v1_properties", "rpc_methods"],
+                version: 1,
+              },
+            }),
+          );
+          return;
+        }
+        let payload: unknown;
+        try {
+          const result = responder(msg.method);
+          if (result instanceof Error) throw result;
+          payload = { jsonrpc: "2.0", id: msg.id, result };
+        } catch (err) {
+          payload = {
+            jsonrpc: "2.0",
+            id: msg.id,
+            error: { code: -32601, message: err instanceof Error ? err.message : "error" },
+          };
+        }
+        ws.send(JSON.stringify(payload));
+      },
+    },
+  });
+  return {
+    url: `ws://127.0.0.1:${server.port}`,
+    stop: () => server.stop(true),
+  };
+}
+
+describe("dot chain properties", () => {
+  test("no name errors with usage", async () => {
+    const { stderr, exitCode } = await runCli(["chain", "properties"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Usage: dot chain properties");
+  });
+
+  test("unknown chain errors before any RPC call", async () => {
+    const { stderr, exitCode } = await runCli(["chain", "properties", "nonexistent-chain"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("nonexistent-chain");
+  });
+
+  test("--json returns scalar properties from system_properties", async () => {
+    const server = startRpcServer((method) => {
+      if (method === "system_properties") {
+        return { tokenDecimals: 10, tokenSymbol: "DOT", ss58Format: 0 };
+      }
+      return new Error("Method not found");
+    });
+    try {
+      const { stdout, exitCode } = await runCli(
+        ["chain", "properties", "polkadot", "--rpc", server.url, "--json"],
+        { noDefaultChain: true },
+      );
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toEqual({ tokenDecimals: 10, tokenSymbol: "DOT", ss58Format: 0 });
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("--json preserves array-typed properties (multi-token chains)", async () => {
+    const server = startRpcServer((method) => {
+      if (method === "system_properties") {
+        return { tokenDecimals: [12, 10], tokenSymbol: ["ACA", "AUSD"], ss58Format: 10 };
+      }
+      return new Error("Method not found");
+    });
+    try {
+      const { stdout, exitCode } = await runCli(
+        ["chain", "properties", "polkadot", "--rpc", server.url, "--json"],
+        { noDefaultChain: true },
+      );
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.tokenDecimals).toEqual([12, 10]);
+      expect(parsed.tokenSymbol).toEqual(["ACA", "AUSD"]);
+      expect(parsed.ss58Format).toBe(10);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("--json handles empty {} properties as nulls", async () => {
+    const server = startRpcServer((method) => {
+      if (method === "system_properties") return {};
+      return new Error("Method not found");
+    });
+    try {
+      const { stdout, exitCode } = await runCli(
+        ["chain", "properties", "polkadot", "--rpc", server.url, "--json"],
+        { noDefaultChain: true },
+      );
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toEqual({ tokenDecimals: null, tokenSymbol: null, ss58Format: null });
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("falls back to chainSpec_v1_properties when system_properties is unavailable", async () => {
+    const server = startRpcServer((method) => {
+      if (method === "chainSpec_v1_properties") {
+        return { tokenDecimals: 12, tokenSymbol: "KSM", ss58Format: 2 };
+      }
+      return new Error("Method not found");
+    });
+    try {
+      const { stdout, exitCode } = await runCli(
+        ["chain", "properties", "polkadot", "--rpc", server.url, "--json"],
+        { noDefaultChain: true },
+      );
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toEqual({ tokenDecimals: 12, tokenSymbol: "KSM", ss58Format: 2 });
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("human-readable output shows labels", async () => {
+    const server = startRpcServer((method) => {
+      if (method === "system_properties") {
+        return { tokenDecimals: 10, tokenSymbol: "DOT", ss58Format: 0 };
+      }
+      return new Error("Method not found");
+    });
+    try {
+      const { stdout, exitCode } = await runCli(
+        ["chain", "properties", "polkadot", "--rpc", server.url],
+        { noDefaultChain: true },
+      );
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("token decimals");
+      expect(stdout).toContain("DOT");
+      expect(stdout).toContain("ss58 format");
+    } finally {
+      server.stop();
+    }
+  });
 });

--- a/src/commands/chain.ts
+++ b/src/commands/chain.ts
@@ -16,6 +16,7 @@ import {
   type Config,
   DEFAULT_CONFIG,
 } from "../config/types.ts";
+import { fetchChainProperties } from "../core/chain-properties.ts";
 import { createChainClient, getParachainId } from "../core/client.ts";
 import { fetchMetadataFromChain } from "../core/metadata.ts";
 import {
@@ -44,6 +45,7 @@ ${BOLD}Usage:${RESET}
   $ dot chain update --all              Re-fetch metadata for all configured chains
   $ dot chain list                      List configured chains
   $ dot chain info <name>               Show details for a single chain
+  $ dot chain properties <name>         Show token decimals/symbol and ss58 prefix
   $ dot chain <name>                    Shortcut for \`chain info <name>\`
   $ dot chain export [names...]         Export chain configuration to stdout
   $ dot chain import <file>             Import chain configuration from a file
@@ -57,6 +59,8 @@ ${BOLD}Examples:${RESET}
   $ dot chains -v
   $ dot chain info polkadot
   $ dot chain polkadot
+  $ dot chain properties polkadot
+  $ dot chain properties polkadot --json
   $ dot chain update kusama
   $ dot chain update --all
   $ dot chain remove kusama
@@ -116,6 +120,8 @@ export function registerChainCommands(cli: CAC) {
             return chainList(opts);
           case "info":
             return chainInfo(names[0], opts);
+          case "properties":
+            return chainProperties(names[0], opts);
           case "update":
             return chainUpdate(names[0], opts);
           case "export":
@@ -447,6 +453,39 @@ async function chainInfo(name: string | undefined, opts: { output?: string; json
   } else {
     console.log(`    ${DIM}not cached — run \`dot chain update ${resolved}\`${RESET}`);
   }
+}
+
+async function chainProperties(
+  name: string | undefined,
+  opts: { rpc?: string | string[]; output?: string; json?: boolean } = {},
+) {
+  if (!name) {
+    console.error("Usage: dot chain properties <name>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const { name: resolved, chain } = resolveChain(config, name);
+  const rpcUrl = opts.rpc ?? chain.rpc;
+
+  process.stderr.write(`Fetching properties for ${resolved}...\n`);
+  const { properties } = await fetchChainProperties(rpcUrl);
+
+  if (isJsonOutput(opts)) {
+    console.log(formatJson(properties));
+    return;
+  }
+
+  printHeading(resolved);
+  printProperty("token decimals", properties.tokenDecimals);
+  printProperty("token symbol", properties.tokenSymbol);
+  printProperty("ss58 format", properties.ss58Format);
+}
+
+function printProperty(label: string, value: unknown) {
+  const rendered =
+    value == null ? `${DIM}—${RESET}` : Array.isArray(value) ? value.join(", ") : String(value);
+  console.log(`  ${CYAN}${label}:${RESET} ${rendered}`);
 }
 
 function countByFamily(methods: string[]): Record<string, number> {

--- a/src/completions/complete.ts
+++ b/src/completions/complete.ts
@@ -52,7 +52,7 @@ const NAMED_COMMANDS = [
   "which",
 ];
 
-const CHAIN_SUBCOMMANDS = ["add", "info", "list", "remove", "update"];
+const CHAIN_SUBCOMMANDS = ["add", "info", "list", "properties", "remove", "update"];
 const ACCOUNT_SUBCOMMANDS = [
   "add",
   "create",

--- a/src/core/chain-properties.test.ts
+++ b/src/core/chain-properties.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  fetchChainProperties,
+  normalizeProperties,
+  type RpcRequestFn,
+} from "./chain-properties.ts";
+
+describe("normalizeProperties", () => {
+  test("preserves scalar decimals/symbol and ss58 format", () => {
+    expect(normalizeProperties({ tokenDecimals: 10, tokenSymbol: "DOT", ss58Format: 0 })).toEqual({
+      tokenDecimals: 10,
+      tokenSymbol: "DOT",
+      ss58Format: 0,
+    });
+  });
+
+  test("preserves array-typed decimals/symbol (multi-token chains)", () => {
+    expect(
+      normalizeProperties({
+        tokenDecimals: [12, 10],
+        tokenSymbol: ["ACA", "AUSD"],
+        ss58Format: 10,
+      }),
+    ).toEqual({
+      tokenDecimals: [12, 10],
+      tokenSymbol: ["ACA", "AUSD"],
+      ss58Format: 10,
+    });
+  });
+
+  test("empty {} yields all nulls", () => {
+    expect(normalizeProperties({})).toEqual({
+      tokenDecimals: null,
+      tokenSymbol: null,
+      ss58Format: null,
+    });
+  });
+
+  test("partial properties fill missing fields with null", () => {
+    expect(normalizeProperties({ ss58Format: 42 })).toEqual({
+      tokenDecimals: null,
+      tokenSymbol: null,
+      ss58Format: 42,
+    });
+  });
+
+  test("non-object responses degrade to all nulls", () => {
+    expect(normalizeProperties(null)).toEqual({
+      tokenDecimals: null,
+      tokenSymbol: null,
+      ss58Format: null,
+    });
+  });
+});
+
+describe("fetchChainProperties", () => {
+  test("uses system_properties when it succeeds", async () => {
+    const calls: string[] = [];
+    const request = (async (_url, method) => {
+      calls.push(method);
+      return { tokenDecimals: 10, tokenSymbol: "DOT", ss58Format: 0 };
+    }) as RpcRequestFn;
+
+    const { properties, source } = await fetchChainProperties("wss://example", request);
+
+    expect(calls).toEqual(["system_properties"]);
+    expect(source).toBe("system_properties");
+    expect(properties.tokenSymbol).toBe("DOT");
+  });
+
+  test("falls back to chainSpec_v1_properties when system_properties is unavailable", async () => {
+    const calls: string[] = [];
+    const request = (async (_url, method) => {
+      calls.push(method);
+      if (method === "system_properties") {
+        throw new Error("Method not found");
+      }
+      return { tokenDecimals: [12, 10], tokenSymbol: ["ACA", "AUSD"], ss58Format: 10 };
+    }) as RpcRequestFn;
+
+    const { properties, source } = await fetchChainProperties("wss://example", request);
+
+    expect(calls).toEqual(["system_properties", "chainSpec_v1_properties"]);
+    expect(source).toBe("chainSpec_v1_properties");
+    expect(properties.tokenDecimals).toEqual([12, 10]);
+  });
+
+  test("returns empty properties when the node reports {}", async () => {
+    const request = (async () => ({})) as RpcRequestFn;
+    const { properties } = await fetchChainProperties("wss://example", request);
+    expect(properties).toEqual({ tokenDecimals: null, tokenSymbol: null, ss58Format: null });
+  });
+
+  test("throws the last error when every method fails", async () => {
+    const request = (async (_url, method) => {
+      throw new Error(`boom ${method}`);
+    }) as RpcRequestFn;
+
+    expect(fetchChainProperties("wss://example", request)).rejects.toThrow(
+      "boom chainSpec_v1_properties",
+    );
+  });
+});

--- a/src/core/chain-properties.ts
+++ b/src/core/chain-properties.ts
@@ -1,0 +1,71 @@
+import { rpcRequest } from "./rpc.ts";
+
+/**
+ * Chain properties as surfaced by `system_properties` / `chainSpec_v1_properties`.
+ *
+ * `tokenDecimals` and `tokenSymbol` are intentionally left wide: some chains
+ * return scalars, others return arrays (multiple native-ish tokens). We preserve
+ * whatever the node returns rather than silently picking the first element, so
+ * `--json` faithfully reflects the chain's response shape. Missing fields are
+ * normalized to `null` so the JSON schema is stable for `jq`.
+ */
+export interface ChainProperties {
+  tokenDecimals: number | number[] | null;
+  tokenSymbol: string | string[] | null;
+  ss58Format: number | null;
+}
+
+/**
+ * RPC methods that expose chain properties, in the order we try them.
+ *
+ * `system_properties` is the legacy method but is universally implemented by
+ * Substrate nodes, so we try it first and fall back to the modern chainHead
+ * `chainSpec_v1_properties` only if the node doesn't expose it. Both return the
+ * same `{ tokenDecimals, tokenSymbol, ss58Format }` shape.
+ */
+export const PROPERTY_METHODS = ["system_properties", "chainSpec_v1_properties"] as const;
+
+/**
+ * Extract the three canonical property fields from a raw RPC response,
+ * preserving scalar-vs-array shape and defaulting missing fields to `null`.
+ * Handles empty `{}` responses gracefully (all nulls).
+ */
+export function normalizeProperties(raw: unknown): ChainProperties {
+  const props = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  return {
+    tokenDecimals: (props.tokenDecimals as number | number[] | undefined) ?? null,
+    tokenSymbol: (props.tokenSymbol as string | string[] | undefined) ?? null,
+    ss58Format: (props.ss58Format as number | undefined) ?? null,
+  };
+}
+
+export type RpcRequestFn = <T>(
+  rpcUrl: string | string[],
+  method: string,
+  params: unknown[],
+) => Promise<T>;
+
+/**
+ * Fetch chain properties from a node, trying each method in {@link PROPERTY_METHODS}
+ * in order and falling back to the next on failure. `source` reports which method
+ * actually answered. Throws the last error if every method fails.
+ *
+ * `request` is injectable for testing; it defaults to the real one-shot RPC call.
+ */
+export async function fetchChainProperties(
+  rpcUrl: string | string[],
+  request: RpcRequestFn = rpcRequest,
+): Promise<{ properties: ChainProperties; source: string }> {
+  let lastError: unknown;
+  for (const method of PROPERTY_METHODS) {
+    try {
+      const raw = await request<unknown>(rpcUrl, method, []);
+      return { properties: normalizeProperties(raw), source: method };
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Failed to fetch chain properties from the node.");
+}


### PR DESCRIPTION
Implements **slice 1 of #199** — a thin, self-contained `dot chain properties <name>` command. (Deliberately not "Closes": #199 tracks slices 2–5 and open decisions, so it stays open.)

**Why:** `dot` doesn't surface a chain's `properties` block, so users and the dot-cli skill hardcode token decimals per chain (`NATIVE_DECIMALS=12` vs `10`). Run a script against the wrong network and every balance is off by orders of magnitude. The chain knows the answer — ask it.

**How:** New `src/core/chain-properties.ts` fetches via `system_properties` and falls back to `chainSpec_v1_properties` (see defaults below), normalizing to `{ tokenDecimals, tokenSymbol, ss58Format }`. `chain.ts` adds a `properties` subcommand that resolves the chain by its saved name (like `chain info`/`update`) and prints JSON or a human-readable block.

Real output (`dot chain properties polkadot --json`):

```json
{
  "tokenDecimals": 10,
  "tokenSymbol": "DOT",
  "ss58Format": 0
}
```

So scripts can do: `NATIVE_DECIMALS=$(dot chain properties polkadot --json | jq .tokenDecimals)`.

**Defaults chosen for the issue's open questions:**
- **RPC source:** try `system_properties` first (universally implemented → fewest failed round-trips), fall back to `chainSpec_v1_properties`. Both return the same shape.
- **Multi-token / array responses:** preserved verbatim in the JSON (not collapsed to the first element).
- **Empty `{}` properties:** each field degrades to `null`; no crash.

**Out of scope / still open:** slices 2–5 (persist to `config.json`, balance rendering, `--from-spec`, full chain-spec import) and the caching-policy decision remain in #199. The RPC-source and array-handling choices above are proposed defaults, not final rulings.

Tests: unit tests for the fetch/normalize logic (scalar, array, empty, fallback, all-fail) plus end-to-end command tests driving the real RPC client against a local WebSocket JSON-RPC server. Changeset + README + SKILL + scripting-patterns docs updated with executable examples.
