### PR TITLE
feat(tx): show applied transaction extensions when submitting/dry-running

### DIFF
--- a/.changeset/show-tx-extensions.md
+++ b/.changeset/show-tx-extensions.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Show the transaction extensions applied to an extrinsic in both the `dot tx ... --dry-run` and submit output (human-readable and `--json`). A new `Extensions:` section lists every signed extension the chain declares in its metadata — so it is correct per-chain — with the effective value for the ones the CLI controls (`CheckNonce`, `ChargeTransactionPayment`, `CheckMortality`, `ChargeAssetTxPayment`), including their defaults, clearly marked. Values you set via `--nonce`/`--tip`/`--mortality`/`--asset`/`--ext` are shown as user-set; the rest are marked as filled in by polkadot-api. This makes it transparent which extensions run and what values they carry, even when left at their defaults. Visibility only — signing behaviour is unchanged.

--- a/README.md
+++ b/README.md
@@ -1202,7 +1202,9 @@ Build, sign, and submit transactions. Pass a `Pallet.Call` with arguments, or a 
 
 ```bash
 # Estimate fees without submitting (no broadcast). The Decode block shows
-# the call name on the header line and indented JSON below it.
+# the call name on the header line and indented JSON below it, and the
+# Extensions block lists every transaction extension applied to the tx —
+# with the effective value (including defaults) for the ones you can steer.
 dot polkadot.tx.System.remark 0xdeadbeef --from alice --dry-run
 # Output:
 #   Chain:  polkadot
@@ -1212,6 +1214,12 @@ dot polkadot.tx.System.remark 0xdeadbeef --from alice --dry-run
 #     {
 #       "remark": "0xdeadbeef"
 #     }
+#   Extensions:
+#     CheckMortality            mortal (default)                   [builtin]
+#     CheckNonce                auto-fetched from chain (default)  [builtin]
+#     ChargeTransactionPayment  tip 0 (default)                    [builtin]
+#     CheckMetadataHash         filled in by polkadot-api          [builtin]
+#     ...                                                          (per-chain)
 #   Estimated fees: 125598975
 
 # Transfer (amount in plancks). Method names are snake_case.
@@ -1486,7 +1494,28 @@ dot polkadot.tx.System.remark 0xdead --from alice --at 0x1234...abcd
 dot polkadot.tx.System.remark 0xdead --from alice --nonce 5 --tip 500000 --wait broadcast
 ```
 
-When set, nonce / tip / mortality / at are shown in both `--dry-run` and submission output. These flags are silently ignored with `--encode`, `--to-yaml`, and `--to-json` (which return before signing).
+`--at` is shown in both `--dry-run` and submission output when set; nonce / tip / mortality / asset now surface in the `Extensions:` block (see below), whether you set them or leave them at their defaults. These flags are silently ignored with `--encode`, `--to-yaml`, and `--to-json` (which return before signing).
+
+#### Applied transaction extensions
+
+Both `--dry-run` and submit print an `Extensions:` section listing every signed extension the chain applies to the transaction. The set is read from the chain's runtime metadata, so it reflects exactly what that chain declares — extensions and their defaults differ across chains (e.g. `ChargeAssetTxPayment`, `StorageWeightReclaim`, `PrevalidateAttests` appear only where the runtime declares them). For the extensions the CLI controls the effective value is shown, including the default when you didn't override it:
+
+```bash
+dot polkadot.tx.System.remark 0xdeadbeef --from alice --tip 1000000 --dry-run
+# Output (excerpt):
+#   Extensions:
+#     CheckMortality            mortal (default)                   [builtin]
+#     CheckNonce                auto-fetched from chain (default)  [builtin]
+#     ChargeTransactionPayment  tip 1000000                        [builtin]   ← your --tip
+#     CheckMetadataHash         filled in by polkadot-api          [builtin]
+#     AuthorizeCall             auto-default (override via --ext)   [custom]
+```
+
+- Values you set with `--nonce`, `--tip`, `--mortality`, `--asset`, or `--ext` show without the `(default)` marker.
+- `[builtin]` extensions with no user-facing value read as `filled in by polkadot-api`.
+- `[custom]` extensions are auto-defaulted and can be steered with `--ext`.
+
+Under `--json`, the same information is an `extensions` array of `{ identifier, isBuiltin, source, value }` (where `source` is `"user"`, `"default"`, or `"runtime"`), present on both the dry-run object and the final submit event.
 
 #### Pay fees in an alternative asset
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -193,11 +193,18 @@ dot polkadot.tx.Balances.transfer_keep_alive 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZ
 #       "dest": { "type": "Id", "value": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty" },
 #       "value": 1000000000
 #     }
+#   Extensions:
+#     CheckMortality            mortal (default)                   [builtin]
+#     CheckNonce                auto-fetched from chain (default)  [builtin]
+#     ChargeTransactionPayment  tip 0 (default)                    [builtin]
+#     ...                                                          (per-chain)
 #   Estimated fees: 158403157
 
 # Submit (omit --dry-run). Method names are snake_case as defined in the runtime.
 dot polkadot.tx.Balances.transfer_keep_alive bob 1000000000 --from alice
 ```
+
+The `Extensions:` block (shown on both dry-run and submit, human + `--json`) lists every transaction extension the chain applies, with the effective value — including defaults — for the ones you can steer (`--nonce`, `--tip`, `--mortality`, `--asset`, `--ext`). The set comes from chain metadata, so it differs per chain. Under `--json` it is an `extensions` array of `{ identifier, isBuiltin, source, value }`.
 
 **Global dry-run safety net.** Set the `DOT_DRY_RUN` env var (truthy: `1`/`true`/`yes`/`on`) to force EVERY tx to dry-run instead of submitting — handy when scripting or demoing so nothing accidentally lands on-chain. A hint is printed to stderr (stdout stays clean for `--json`):
 

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -5,14 +5,17 @@ import { join } from "node:path";
 import { isCompatible, mapLookupToTypedef } from "@polkadot-api/metadata-compatibility";
 import { Binary } from "polkadot-api";
 import { DEFAULT_CONFIG } from "../config/types.ts";
+import { PAPI_BUILTIN_EXTENSIONS } from "../core/metadata.ts";
 import { getTestMetadata } from "./__fixtures__/load-metadata.ts";
 import { runCli } from "./__fixtures__/run-cli.ts";
 import {
+  appliedExtensionJson,
   autoDefaultForType,
   buildCustomSignedExtensions,
   buildGeneralTx,
   decodeCallFallback,
   decodeCallToFileFormat,
+  describeAppliedExtensions,
   fileArgsToStrings,
   formatDispatchError,
   formatEventValue,
@@ -1464,6 +1467,98 @@ describe("buildCustomSignedExtensions", () => {
   test("returns empty for standard polkadot metadata (all extensions are builtins)", () => {
     const result = buildCustomSignedExtensions(meta, {});
     expect(Object.keys(result).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeAppliedExtensions
+// ---------------------------------------------------------------------------
+
+describe("describeAppliedExtensions", () => {
+  const byId = (exts: ReturnType<typeof describeAppliedExtensions>, id: string) => {
+    const found = exts.find((e) => e.identifier === id);
+    if (!found) throw new Error(`extension ${id} not found in fixture`);
+    return found;
+  };
+
+  test("lists every signed extension the chain's metadata declares", () => {
+    const exts = describeAppliedExtensions(meta);
+    const ids = exts.map((e) => e.identifier);
+    // Fixture is polkadot metadata — these are always present.
+    expect(ids).toContain("CheckMortality");
+    expect(ids).toContain("CheckNonce");
+    expect(ids).toContain("ChargeTransactionPayment");
+    expect(exts.length).toBeGreaterThan(0);
+  });
+
+  test("marks builtins vs custom via PAPI_BUILTIN_EXTENSIONS", () => {
+    for (const e of describeAppliedExtensions(meta)) {
+      expect(e.isBuiltin).toBe(PAPI_BUILTIN_EXTENSIONS.has(e.identifier));
+    }
+  });
+
+  test("shows defaults when no options are passed", () => {
+    const exts = describeAppliedExtensions(meta);
+    const nonce = byId(exts, "CheckNonce");
+    expect(nonce.source).toBe("default");
+    expect(nonce.value).toContain("auto");
+
+    const tip = byId(exts, "ChargeTransactionPayment");
+    expect(tip.source).toBe("default");
+    expect(tip.value).toBe("tip 0");
+
+    const mortality = byId(exts, "CheckMortality");
+    expect(mortality.source).toBe("default");
+    expect(mortality.value).toBe("mortal");
+  });
+
+  test("reflects user-set nonce/tip as source=user", () => {
+    const exts = describeAppliedExtensions(meta, { nonce: 7, tip: 1_000_000n });
+    const nonce = byId(exts, "CheckNonce");
+    expect(nonce.source).toBe("user");
+    expect(nonce.value).toBe("7");
+
+    const tip = byId(exts, "ChargeTransactionPayment");
+    expect(tip.source).toBe("user");
+    expect(tip.value).toBe("tip 1000000");
+  });
+
+  test("reflects immortal and mortal-period mortality", () => {
+    const immortal = byId(
+      describeAppliedExtensions(meta, { mortality: { mortal: false } }),
+      "CheckMortality",
+    );
+    expect(immortal.source).toBe("user");
+    expect(immortal.value).toBe("immortal");
+
+    const mortal = byId(
+      describeAppliedExtensions(meta, { mortality: { mortal: true, period: 64 } }),
+      "CheckMortality",
+    );
+    expect(mortal.value).toBe("mortal (period 64)");
+  });
+
+  test("an --ext override wins over the default and reads as user-set", () => {
+    const exts = describeAppliedExtensions(meta, {
+      userExtOverrides: { CheckNonce: { value: 42 } },
+    });
+    const nonce = byId(exts, "CheckNonce");
+    expect(nonce.source).toBe("user");
+    expect(nonce.value).toBe("42");
+  });
+
+  test("appliedExtensionJson maps empty value to null", () => {
+    const exts = describeAppliedExtensions(meta);
+    const runtimeOne = exts.find((e) => e.value === "");
+    // polkadot fixture has void-typed builtins (e.g. CheckWeight) with no value
+    expect(runtimeOne).toBeDefined();
+    const json = appliedExtensionJson(runtimeOne!);
+    expect(json.value).toBeNull();
+    expect(json.source).toBe("runtime");
+
+    const nonceJson = appliedExtensionJson(byId(exts, "CheckNonce"));
+    expect(nonceJson.value).toBe("auto-fetched from chain");
+    expect(nonceJson.isBuiltin).toBe(true);
   });
 });
 

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -440,6 +440,17 @@ export async function handleTx(
     const decodedStr = decodeCall(meta, callHex);
     const decodedObj = decodeCallObject(meta, callHex);
 
+    // Transaction extensions applied to this (signed) tx, with their effective
+    // values including defaults — derived from chain metadata so it's per-chain
+    // correct. Shown in the signed dry-run and submit output below.
+    const appliedExtensions = describeAppliedExtensions(meta, {
+      nonce,
+      tip,
+      asset,
+      mortality,
+      userExtOverrides: parseExtOption(opts.ext),
+    });
+
     // --- Unsigned dry-run ---
     if (opts.dryRun && opts.unsigned) {
       if (isJsonOutput(opts)) {
@@ -485,6 +496,7 @@ export async function handleTx(
           from: { name: opts.from, address: signerAddress },
           callHex,
           decoded: decodedStr,
+          extensions: appliedExtensions.map(appliedExtensionJson),
           estimatedFees,
         };
         if (estimationError !== undefined) result.estimationError = estimationError;
@@ -502,13 +514,7 @@ export async function handleTx(
       console.log(`  ${BOLD}From:${RESET}   ${opts.from} (${signerAddress})`);
       console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
       printDecodedCall(decodedObj, decodedStr);
-      if (nonce !== undefined) console.log(`  ${BOLD}Nonce:${RESET} ${nonce}`);
-      if (tip !== undefined) console.log(`  ${BOLD}Tip:${RESET}   ${tip}`);
-      if (asset !== undefined) console.log(`  ${BOLD}Asset:${RESET} ${JSON.stringify(asset)}`);
-      if (mortality !== undefined)
-        console.log(
-          `  ${BOLD}Mortality:${RESET} ${mortality.mortal ? `mortal (period ${mortality.period})` : "immortal"}`,
-        );
+      printAppliedExtensions(appliedExtensions);
       if (at !== undefined) console.log(`  ${BOLD}At:${RESET}    ${at}`);
 
       if (estimatedFees !== undefined) {
@@ -676,6 +682,7 @@ export async function handleTx(
         blockHash,
         txHash: result.txHash,
         ok: result.ok,
+        extensions: appliedExtensions.map(appliedExtensionJson),
         events: result.events?.map((e: any) => ({
           pallet: e.type,
           name: e.value?.type,
@@ -702,13 +709,7 @@ export async function handleTx(
     console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
     console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
     printDecodedCall(decodedObj, decodedStr);
-    if (nonce !== undefined) console.log(`  ${BOLD}Nonce:${RESET} ${nonce}`);
-    if (tip !== undefined) console.log(`  ${BOLD}Tip:${RESET}   ${tip}`);
-    if (asset !== undefined) console.log(`  ${BOLD}Asset:${RESET} ${JSON.stringify(asset)}`);
-    if (mortality !== undefined)
-      console.log(
-        `  ${BOLD}Mortality:${RESET} ${mortality.mortal ? `mortal (period ${mortality.period})` : "immortal"}`,
-      );
+    printAppliedExtensions(appliedExtensions);
     if (at !== undefined) console.log(`  ${BOLD}At:${RESET}    ${at}`);
     console.log(`  ${BOLD}Tx:${RESET}     ${result.txHash}`);
 
@@ -1561,6 +1562,136 @@ function parseExtOption(ext: string | undefined): Record<string, any> {
 
 /** Sentinel value: type could not be auto-defaulted */
 const NO_DEFAULT = Symbol("no-default");
+
+// --- Applied transaction-extension visibility ---
+
+/**
+ * One transaction (signed) extension applied to a tx, as shown to the user.
+ * The extension SET is derived from chain metadata, so it is correct per-chain.
+ */
+export interface AppliedExtension {
+  identifier: string;
+  /** True when polkadot-api fills this in automatically. */
+  isBuiltin: boolean;
+  /**
+   * Human-readable effective value. Empty string means the extension carries
+   * no user-facing value on this path (filled entirely by the runtime / papi).
+   */
+  value: string;
+  /** Whether the value was chosen by the user, is a default, or set by the runtime. */
+  source: "user" | "default" | "runtime";
+}
+
+function formatExtOverrideValue(raw: unknown): string {
+  if (raw === undefined || raw === null) return "null";
+  if (typeof raw === "bigint") return raw.toString();
+  if (typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean") {
+    return String(raw);
+  }
+  return JSON.stringify(raw, (_k, v) => (typeof v === "bigint" ? v.toString() : v));
+}
+
+/**
+ * Describe the transaction extensions applied to a tx and their effective
+ * values, INCLUDING defaults. The extension set is read from the chain's
+ * metadata so it reflects exactly what this chain declares. For the extensions
+ * the CLI controls (nonce/tip/mortality/asset) the concrete value (or its
+ * default) is shown; the rest are marked as filled in by polkadot-api / the
+ * runtime. This is visibility only — it mirrors, and does not change, signing.
+ */
+export function describeAppliedExtensions(
+  meta: MetadataBundle,
+  applied: {
+    nonce?: number;
+    tip?: bigint;
+    asset?: Record<string, unknown>;
+    mortality?: MortalityOption;
+    userExtOverrides?: Record<string, any>;
+  } = {},
+): AppliedExtension[] {
+  const { nonce, tip, asset, mortality, userExtOverrides = {} } = applied;
+
+  return getSignedExtensions(meta).map((ext): AppliedExtension => {
+    const identifier = ext.identifier;
+    const isBuiltin = PAPI_BUILTIN_EXTENSIONS.has(identifier);
+
+    // An explicit --ext override wins for display, whatever the extension is.
+    if (identifier in userExtOverrides) {
+      const override = userExtOverrides[identifier];
+      const raw =
+        override && typeof override === "object" && "value" in override ? override.value : override;
+      return { identifier, isBuiltin, source: "user", value: formatExtOverrideValue(raw) };
+    }
+
+    switch (identifier) {
+      case "CheckNonce":
+        return nonce !== undefined
+          ? { identifier, isBuiltin, source: "user", value: String(nonce) }
+          : { identifier, isBuiltin, source: "default", value: "auto-fetched from chain" };
+      case "ChargeTransactionPayment":
+        return tip !== undefined
+          ? { identifier, isBuiltin, source: "user", value: `tip ${tip}` }
+          : { identifier, isBuiltin, source: "default", value: "tip 0" };
+      case "ChargeAssetTxPayment":
+        return asset !== undefined
+          ? { identifier, isBuiltin, source: "user", value: `asset ${JSON.stringify(asset)}` }
+          : { identifier, isBuiltin, source: "default", value: "native token for fees" };
+      case "CheckMortality":
+        if (mortality === undefined)
+          return { identifier, isBuiltin, source: "default", value: "mortal" };
+        return mortality.mortal
+          ? { identifier, isBuiltin, source: "user", value: `mortal (period ${mortality.period})` }
+          : { identifier, isBuiltin, source: "user", value: "immortal" };
+      default:
+        // Custom (non-builtin) extensions the CLI auto-defaults can still be
+        // steered with --ext; builtins are handled entirely by polkadot-api.
+        return isBuiltin
+          ? { identifier, isBuiltin, source: "runtime", value: "" }
+          : {
+              identifier,
+              isBuiltin,
+              source: "default",
+              value: "auto-default (override via --ext)",
+            };
+    }
+  });
+}
+
+/** Shape an AppliedExtension for `--json` output. */
+export function appliedExtensionJson(e: AppliedExtension): {
+  identifier: string;
+  isBuiltin: boolean;
+  source: string;
+  value: string | null;
+} {
+  return {
+    identifier: e.identifier,
+    isBuiltin: e.isBuiltin,
+    source: e.source,
+    value: e.value === "" ? null : e.value,
+  };
+}
+
+/** Print the "Extensions:" section for human-readable tx output. */
+function printAppliedExtensions(extensions: AppliedExtension[]): void {
+  if (extensions.length === 0) return;
+  console.log(`  ${BOLD}Extensions:${RESET}`);
+  const width = Math.max(...extensions.map((e) => e.identifier.length));
+  for (const e of extensions) {
+    const name = `${CYAN}${e.identifier.padEnd(width)}${RESET}`;
+    const tag = e.isBuiltin ? `${DIM}[builtin]${RESET}` : `${YELLOW}[custom]${RESET}`;
+    let value: string;
+    if (e.value === "") {
+      value = `${DIM}filled in by polkadot-api${RESET}`;
+    } else if (e.source === "default" && !e.value.includes("(")) {
+      // Flag defaulted values, unless the value already carries its own hint.
+      value = `${e.value} ${DIM}(default)${RESET}`;
+    } else {
+      value = e.value;
+    }
+    console.log(`    ${name}  ${value}  ${tag}`);
+  }
+}
 
 function buildCustomSignedExtensions(
   meta: MetadataBundle,


### PR DESCRIPTION
Closes #240

Surfaces the transaction (signed) extensions applied to an extrinsic — and their values, including defaults — in both the `dot tx ... --dry-run` and submit output (human and `--json`).

**Why:** it wasn't transparent what transaction extensions even run or what values they carry. We only printed `Nonce`/`Tip`/`Mortality` lines when you explicitly passed the matching flag, so defaults were invisible and the full per-chain extension set never appeared on the tx path (only `dot <chain>.extensions` listed them, decoupled from a real tx).

**How:** a new `describeAppliedExtensions(meta, {nonce, tip, asset, mortality, userExtOverrides})` reads the extension set straight from chain metadata (`getSignedExtensions` / `PAPI_BUILTIN_EXTENSIONS`, reusing the #171 machinery) so it's correct per-chain, and reports the effective value for the ones the CLI controls. The scattered conditional value lines are replaced by one `Extensions:` section; `--json` gains an `extensions` array of `{identifier, isBuiltin, source, value}`. Visibility only — signing is untouched.

**Before / after** (real, executable):

```
# before
dot polkadot.tx.System.remark 0xdeadbeef --from alice --dry-run
#   Chain:  polkadot
#   From:   alice (5Grw...)
#   Call:   0x000010deadbeef
#   Decode: System.remark
#     { "remark": "0xdeadbeef" }
#   Estimated fees: 125491411

# after
dot polkadot.tx.System.remark 0xdeadbeef --from alice --dry-run
#   Chain:  polkadot
#   From:   alice (5Grw...)
#   Call:   0x000010deadbeef
#   Decode: System.remark
#     { "remark": "0xdeadbeef" }
#   Extensions:
#     AuthorizeCall             auto-default (override via --ext)   [custom]
#     CheckNonZeroSender        filled in by polkadot-api           [builtin]
#     CheckSpecVersion          filled in by polkadot-api           [builtin]
#     CheckTxVersion            filled in by polkadot-api           [builtin]
#     CheckGenesis              filled in by polkadot-api           [builtin]
#     CheckMortality            mortal (default)                    [builtin]
#     CheckNonce                auto-fetched from chain (default)   [builtin]
#     CheckWeight               filled in by polkadot-api           [builtin]
#     ChargeTransactionPayment  tip 0 (default)                     [builtin]
#     PrevalidateAttests        filled in by polkadot-api           [builtin]
#     CheckMetadataHash         filled in by polkadot-api           [builtin]
#   Estimated fees: 125491411
```

Setting `--tip 1000000 --nonce 5 --mortality immortal` flips those rows to the user-set values (no `(default)` marker). The list is metadata-derived, so it varies per chain — note `AuthorizeCall` (a custom, non-builtin extension) already shows up on live Polkadot, which also answers the issue: defaults/presence are chain-dependent.

Tests: added `describeAppliedExtensions` / `appliedExtensionJson` unit coverage (defaults, user-set, mortality variants, `--ext` override, JSON null-mapping). Full suite + lint + typecheck + build green locally. Changeset + README + SKILL updated.
