### PR TITLE
feat: external subcommand dispatch (dot-<name> plugins)

### DIFF
--- a/.changeset/heavy-pandas-dispatch.md
+++ b/.changeset/heavy-pandas-dispatch.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Add git/cargo-style external subcommand dispatch (plugins). When the first CLI token is not a built-in command, category, or dot-path, `dot <name> …` looks for an executable named `dot-<name>` on PATH and runs it with the remaining arguments forwarded verbatim, stdio inherited, and the plugin's exit code passed through. Plugins receive `DOT_BIN` pointing at the dispatching `dot` entry script (cargo's `CARGO` convention) so they can call back into the same installation. Dotted tokens (`foo.bar`) and file paths are never dispatched, so dot-path syntax and file input are unaffected; built-in commands always win over a same-named plugin. Unknown-command errors now mention the `dot-<name>` convention when the token could have been a plugin.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ To pull the latest skill updates:
 /plugin marketplace update polkadot-cli
 ```
 
+## Plugins
+
+`dot` supports git/cargo-style external subcommands: any executable named `dot-<name>` on your PATH runs as `dot <name>`, with the remaining arguments forwarded verbatim, stdio inherited, and the plugin's exit code passed through.
+
+```bash
+npm install -g dot-example     # ships a `dot-example` binary
+dot example status --json      # runs: dot-example status --json
+```
+
+This is how domain-specific tooling extends `dot` without the CLI loading third-party code into its own process. Plugins are ordinary child processes — the intended pattern is that a plugin invokes `dot` itself for anything chain- or signing-related (e.g. `dot tx.… --from <account>`), so key handling stays inside `dot`.
+
+Plugins receive a `DOT_BIN` environment variable pointing at the entry script of the `dot` that dispatched them (the same convention as cargo's `CARGO`), so they can invoke the exact same installation rather than whatever `dot` is first on PATH.
+
+Notes:
+
+- Only a bare first token dispatches: `dot foo.bar` is always dot-path syntax, `./file.yaml` is always file input — neither will hit the plugin lookup.
+- Built-in commands and categories always win over a plugin of the same name.
+
 ## Usage
 
 ### Manage chains

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,11 @@ import { handleTx } from "./commands/tx.ts";
 import { registerWorkspaceCommands } from "./commands/workspace.ts";
 import { loadConfig } from "./config/store.ts";
 import { isGlobalDryRun, printGlobalDryRunHint, resolveDryRun } from "./core/dry-run.ts";
+import {
+  findExternalCommand,
+  isExternalCommandCandidate,
+  runExternalCommand,
+} from "./core/external-command.ts";
 import { isFilePath, loadCommandFile, parseVarFlags } from "./core/file-loader.ts";
 import {
   getUpdateNotification,
@@ -209,8 +214,21 @@ if (process.argv[2] === "__complete") {
         try {
           parsed = parseDotPath(dotpath, knownChains);
         } catch {
+          // External plugin dispatch (git/cargo-style): `dot foo …` execs
+          // `dot-foo …` if found on PATH. Only when the unknown word is the
+          // first CLI token, so the forwarded argv is exactly what the user
+          // typed after the plugin name (flags untouched by our parsing).
+          if (process.argv[2] === dotpath) {
+            const externalBin = findExternalCommand(dotpath);
+            if (externalBin) {
+              process.exit(runExternalCommand(externalBin, process.argv.slice(3)));
+            }
+          }
+          const pluginHint = isExternalCommandCandidate(dotpath)
+            ? ` No "dot-${dotpath}" plugin found on PATH.`
+            : "";
           throw new CliError(
-            `Unknown command "${dotpath}". Run "dot --help" for available commands.`,
+            `Unknown command "${dotpath}". Run "dot --help" for available commands.${pluginHint}`,
           );
         }
 
@@ -414,6 +432,11 @@ if (process.argv[2] === "__complete") {
     console.log("  init               Initialize a local .polkadot workspace in this directory");
     console.log(
       "  which              Show the active config root (workspace, DOT_HOME, or global)",
+    );
+    console.log();
+    console.log("Plugins:");
+    console.log(
+      '  dot <name> …       Runs a "dot-<name>" executable found on PATH (git/cargo-style)',
     );
     console.log();
     console.log("Global options:");

--- a/src/core/external-command.test.ts
+++ b/src/core/external-command.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runCli } from "../commands/__fixtures__/run-cli.ts";
+import { findExternalCommand, isExternalCommandCandidate } from "./external-command.ts";
+
+describe("isExternalCommandCandidate", () => {
+  test("accepts bare words", () => {
+    expect(isExternalCommandCandidate("fellowship")).toBe(true);
+    expect(isExternalCommandCandidate("my-plugin")).toBe(true);
+    expect(isExternalCommandCandidate("plugin_2")).toBe(true);
+  });
+
+  test("rejects dot-paths, file paths, options, and empty input", () => {
+    expect(isExternalCommandCandidate("query.System")).toBe(false);
+    expect(isExternalCommandCandidate("polkdot.query.System.Account")).toBe(false);
+    expect(isExternalCommandCandidate("./transfer.yaml")).toBe(false);
+    expect(isExternalCommandCandidate("some/path")).toBe(false);
+    expect(isExternalCommandCandidate("--json")).toBe(false);
+    expect(isExternalCommandCandidate("-x")).toBe(false);
+    expect(isExternalCommandCandidate("")).toBe(false);
+  });
+});
+
+describe("findExternalCommand", () => {
+  let pluginDir: string;
+  let savedPath: string | undefined;
+
+  beforeAll(() => {
+    pluginDir = mkdtempSync(join(tmpdir(), "dot-plugin-unit-"));
+    const bin = join(pluginDir, "dot-unittestplugin");
+    writeFileSync(bin, "#!/bin/sh\nexit 0\n");
+    chmodSync(bin, 0o755);
+    savedPath = process.env.PATH;
+    process.env.PATH = `${pluginDir}:${savedPath}`;
+  });
+
+  afterAll(() => {
+    process.env.PATH = savedPath;
+    rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  test("resolves dot-<name> on PATH", () => {
+    expect(findExternalCommand("unittestplugin")).toBe(join(pluginDir, "dot-unittestplugin"));
+  });
+
+  test("returns null for missing plugins and non-candidates", () => {
+    expect(findExternalCommand("no-such-plugin-xyz")).toBeNull();
+    expect(findExternalCommand("query.System")).toBeNull();
+  });
+});
+
+// @ts-expect-error Bun supports describe(label, options, fn) at runtime
+describe("external subcommand dispatch (end to end)", { timeout: 30_000 }, () => {
+  let pluginDir: string;
+
+  beforeAll(() => {
+    pluginDir = mkdtempSync(join(tmpdir(), "dot-plugin-e2e-"));
+    const bin = join(pluginDir, "dot-testplugin");
+    // Echoes its argv and DOT_BIN, then exits 7 — covers arg forwarding,
+    // env contract, and exit-code passthrough in one fixture.
+    writeFileSync(bin, '#!/bin/sh\necho "plugin-ran args=[$@]"\necho "DOT_BIN=$DOT_BIN"\nexit 7\n');
+    chmodSync(bin, 0o755);
+  });
+
+  afterAll(() => {
+    rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  const pathEnv = () => ({ PATH: `${pluginDir}:${process.env.PATH}` });
+
+  test("dot <name> runs dot-<name>, forwards args verbatim, passes exit code through", async () => {
+    const { stdout, exitCode } = await runCli(["testplugin", "vote", "312", "--json"], {
+      env: pathEnv(),
+      noDefaultChain: true,
+    });
+    expect(stdout).toContain("plugin-ran args=[vote 312 --json]");
+    expect(exitCode).toBe(7);
+  });
+
+  test("sets DOT_BIN for the plugin", async () => {
+    const { stdout } = await runCli(["testplugin"], { env: pathEnv(), noDefaultChain: true });
+    expect(stdout).toMatch(/DOT_BIN=\S+/);
+  });
+
+  test("forwards --help to the plugin instead of handling it", async () => {
+    const { stdout, exitCode } = await runCli(["testplugin", "--help"], {
+      env: pathEnv(),
+      noDefaultChain: true,
+    });
+    expect(stdout).toContain("plugin-ran args=[--help]");
+    expect(exitCode).toBe(7);
+  });
+
+  test("dotted tokens are never dispatched, even with a matching plugin on PATH", async () => {
+    // "testplugin.foo" is dot-path syntax, not a plugin invocation.
+    const { stderr, exitCode } = await runCli(["testplugin.foo"], {
+      env: pathEnv(),
+      noDefaultChain: true,
+    });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unknown command");
+  });
+
+  test("unknown command without a plugin mentions the dot-<name> convention", async () => {
+    const { stderr, exitCode } = await runCli(["fellowsh1p"], {
+      env: pathEnv(),
+      noDefaultChain: true,
+    });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Unknown command "fellowsh1p"');
+    expect(stderr).toContain('No "dot-fellowsh1p" plugin found on PATH');
+  });
+});

--- a/src/core/external-command.ts
+++ b/src/core/external-command.ts
@@ -1,0 +1,45 @@
+/**
+ * External subcommand dispatch (git/cargo-style plugins).
+ *
+ * When the first CLI token is not a built-in command, a known category, or a
+ * valid dot-path, `dot foo …` looks for an executable named `dot-foo` on PATH
+ * and execs it with the remaining arguments. Like `cargo-*` / `git-*`, this
+ * lets domain-specific tooling extend `dot` without the CLI loading any
+ * third-party code into its own process: plugins are ordinary child processes
+ * that talk to `dot` the same way a user does.
+ */
+
+export const PLUGIN_PREFIX = "dot-";
+
+/**
+ * A token may name an external plugin only if it is a bare word: no dots
+ * (dot-path syntax), no path separators (file input), no leading dash
+ * (options). This keeps typos like `polkdot.query.System` on the normal
+ * unknown-command error path instead of hitting the filesystem.
+ */
+export function isExternalCommandCandidate(name: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(name);
+}
+
+/** Resolve `dot-<name>` on PATH. Returns the absolute path, or null. */
+export function findExternalCommand(name: string): string | null {
+  if (!isExternalCommandCandidate(name)) return null;
+  // Pass PATH explicitly: Bun.which snapshots the environment at startup and
+  // would miss runtime process.env.PATH changes otherwise.
+  return Bun.which(`${PLUGIN_PREFIX}${name}`, { PATH: process.env.PATH ?? "" });
+}
+
+/**
+ * Run a resolved plugin with stdio inherited and return its exit code.
+ *
+ * `DOT_BIN` is set to the entry script of the running `dot` (cargo sets
+ * `CARGO` the same way) so plugins can invoke the exact same installation
+ * instead of whatever `dot` happens to be first on PATH.
+ */
+export function runExternalCommand(binPath: string, args: string[]): number {
+  const result = Bun.spawnSync([binPath, ...args], {
+    stdio: ["inherit", "inherit", "inherit"],
+    env: { ...process.env, DOT_BIN: process.argv[1] ?? "dot" },
+  });
+  return result.exitCode ?? 1;
+}


### PR DESCRIPTION
## What

git/cargo-style external subcommands: when the first CLI token is not a built-in command, category, or dot-path, `dot <name> …` looks for an executable named `dot-<name>` on PATH and runs it with the remaining arguments forwarded verbatim, stdio inherited, and the plugin's exit code passed through.

```bash
npm install -g dot-example   # ships a dot-example binary
dot example status --json    # runs: dot-example status --json
```

Same convention as `cargo-*`, `git-*`, `kubectl-*`, and `docker` cli-plugins. Plugins receive `DOT_BIN` pointing at the dispatching entry script (cargo's `CARGO` convention) so they can invoke the exact same installation rather than whatever `dot` is first on PATH.

## Why

`dot` is deliberately generic — metadata-driven, any pallet on any chain. Domain-specific workflows (governance, fellowship, staking, …) deserve sugar, but baking every domain into the core CLI doesn't scale. External dispatch lets the ecosystem build that layer without polkadot-cli owning it or loading third-party code into its own process:

- **No API surface commitment.** The only contract with plugins is the CLI interface `dot` already promises to humans and agents. No plugin SDK, no version skew, nothing to maintain.
- **Keys stay in `dot`.** The intended pattern is that plugins shell back into `dot` for anything chain- or signing-related (`dot tx.… --from <account>`), so account handling, `DOT_DRY_RUN`, workspaces, and chain config are inherited rather than reimplemented. Complements the concerns in #276 — plugins have no reason to touch `.polkadot/`. In-process plugin loading would be strictly worse here, sharing memory with the account store.
- Fits the agent-ready direction (#63): domain plugins can expose the same `--json`-first discipline on top of `dot` primitives.

Concrete first consumer: I'm building `dot-fellowship` — Polkadot Fellowship workflows (to-do triage from on-chain state, ranked-collective voting, salary register/payout) as a thin CLI that drives `dot` for all chain I/O and signing. With this PR it reads as `dot fellowship todo`; without it, `dot-fellowship todo` still works — dispatch just makes the ecosystem convention official.

## Behavior details

- Only a bare first token dispatches (`^[A-Za-z0-9][A-Za-z0-9_-]*$`). Dotted tokens (`foo.bar`) stay on dot-path parsing, file paths stay on file input, and registered commands match before the default command — built-ins always win over a same-named plugin.
- Dispatch happens exactly where the CLI previously gave up (`parseDotPath` failure on the default command), so no existing resolution order changes.
- Unknown-command errors now append `No "dot-<name>" plugin found on PATH.` when the token could have named a plugin.
- `--help` after a plugin name is forwarded to the plugin, not swallowed.

## Testing

- Unit tests for candidate validation and PATH resolution (including the `Bun.which` env-snapshot gotcha — PATH is passed explicitly).
- End-to-end tests spawning the real CLI with a shell-script plugin: arg forwarding, `DOT_BIN`, exit-code passthrough, `--help` forwarding, dotted-token non-dispatch, and the error hint.
- README section + help text + changeset (minor).

## Possible follow-ups (out of scope here)

- `dot --list` / completions enumerating `dot-*` executables on PATH.
- Env hygiene when spawning plugins, tied into #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)