### PR TITLE
Surface the active config root in chain commands

### DIFF
--- a/src/commands/chain.ts
+++ b/src/commands/chain.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import type { CAC } from "cac";
 import {
+  describeConfigDir,
   findChainName,
   loadConfig,
   loadMetadataFingerprint,
@@ -233,7 +234,7 @@ async function chainAdd(
     if (isJsonOutput(opts)) {
       console.log(formatJson(result));
     } else {
-      console.log(`Chain "${name}" added successfully.`);
+      console.log(`Chain "${name}" added successfully to ${describeConfigDir()}.`);
     }
   } finally {
     clientHandle.destroy();
@@ -277,7 +278,7 @@ async function chainRemove(
   if (isJsonOutput(opts)) {
     console.log(formatJson({ action: "removed", chain: resolved }));
   } else {
-    console.log(`Chain "${resolved}" removed.`);
+    console.log(`Chain "${resolved}" removed from ${describeConfigDir()}.`);
   }
 }
 
@@ -298,6 +299,7 @@ async function chainList(opts: { output?: string; json?: boolean; verbose?: bool
   const verbose = opts.verbose === true;
 
   printHeading("Configured Chains");
+  console.log(`  ${DIM}${describeConfigDir()}${RESET}\n`);
 
   const parachainsByRelay = new Map<string, [string, ChainConfig][]>();
   const standalone: [string, ChainConfig][] = [];

--- a/src/commands/workspace.test.ts
+++ b/src/commands/workspace.test.ts
@@ -1,5 +1,13 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { patchStdout } from "../test-helpers/patch-stdout.ts";
@@ -77,6 +85,31 @@ describe("initWorkspace", () => {
         expect(result.warnings).toHaveLength(1);
         expect(result.warnings[0]).toContain(`shadows ${join(parent, ".polkadot")}`);
         expect(existsSync(join(nested, ".polkadot"))).toBe(true);
+      },
+      { DOT_HOME: undefined },
+    );
+  });
+
+  test("warns that custom chains in the shadowed global config will disappear", async () => {
+    const home = scratch("dot-init-shadow-chains-");
+    const cwd = join(home, "project");
+    mkdirSync(cwd);
+    // Simulate chains previously added to the global config that the new
+    // workspace is about to shadow — a builtin plus a user-added chain.
+    mkdirSync(join(home, ".polkadot"), { recursive: true });
+    writeFileSync(
+      join(home, ".polkadot", "config.json"),
+      JSON.stringify({ chains: { polkadot: { rpc: "wss://x" }, mychain: { rpc: "wss://y" } } }),
+    );
+    await withDotHome(
+      "ignored",
+      async () => {
+        const result = await initWorkspace(cwd, home);
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings[0]).toContain("1 custom chain(s)");
+        expect(result.warnings[0]).toContain("mychain");
+        // The builtin must not be counted as a custom chain.
+        expect(result.warnings[0]).not.toContain("polkadot,");
       },
       { DOT_HOME: undefined },
     );

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -2,7 +2,8 @@ import { mkdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { CAC } from "cac";
-import { type ResolvedConfigDir, resolveConfigDir } from "../config/store.ts";
+import { peekConfiguredChains, type ResolvedConfigDir, resolveConfigDir } from "../config/store.ts";
+import { BUILTIN_CHAIN_NAMES } from "../config/types.ts";
 import { canonicalPath, findWorkspace, WORKSPACE_DIR_NAME } from "../config/workspace.ts";
 import { isJsonOutput, writeStdout } from "../core/output.ts";
 import { withHelp } from "../platform/cli.ts";
@@ -50,6 +51,23 @@ export async function initWorkspace(cwd: string, home: string = homedir()): Prom
     warnings.push(
       `DOT_HOME is set (${dotHome}) and takes precedence — this workspace will not be picked up until you unset it.`,
     );
+  } else {
+    // With no DOT_HOME the new workspace becomes the active root, shadowing
+    // whatever was resolved from here before it existed (a parent workspace,
+    // or the global ~/.polkadot). Chains added there won't be visible from
+    // this workspace even though they remain on disk — warn so it isn't a
+    // silent disappearance (the exact footgun this warning exists to prevent).
+    const shadowedPath = parentWorkspace ?? join(home, WORKSPACE_DIR_NAME);
+    const userChains = (await peekConfiguredChains(shadowedPath)).filter(
+      (name) => !BUILTIN_CHAIN_NAMES.has(name),
+    );
+    if (userChains.length > 0) {
+      warnings.push(
+        `${userChains.length} custom chain(s) in the shadowed config ${shadowedPath} ` +
+          `(${userChains.join(", ")}) will not be visible from this workspace. ` +
+          "Re-add them here, or migrate with `dot chain export` / `dot chain import`.",
+      );
+    }
   }
 
   await mkdir(workspacePath, { recursive: true });

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -113,6 +113,23 @@ export async function saveConfig(config: Config): Promise<void> {
   await writeFile(getConfigPath(), `${JSON.stringify(config, null, 2)}\n`);
 }
 
+/**
+ * Read the chain names present in the `config.json` under `dir` without the
+ * side effects of `loadConfig` (no default seeding, no directory creation).
+ * Returns `[]` when there is no readable config there. Used to peek at a root
+ * that a new workspace is about to shadow.
+ */
+export async function peekConfiguredChains(dir: string): Promise<string[]> {
+  const path = join(dir, "config.json");
+  if (!(await fileExists(path))) return [];
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf-8")) as Config;
+    return parsed.chains && typeof parsed.chains === "object" ? Object.keys(parsed.chains) : [];
+  } catch {
+    return [];
+  }
+}
+
 export async function loadMetadata(chainName: string): Promise<Uint8Array | null> {
   const path = getMetadataPath(chainName);
   if (await fileExists(path)) {


### PR DESCRIPTION
Makes `dot` tell you *which* config root it is reading from or writing to.

**Why:** the config root (`DOT_HOME` / discovered workspace / global `~/.polkadot`) is resolved silently from your cwd on every command, but `chain add`/`remove`/`list` never named it. A chain added under one root looks lost when read from another — it is still on disk, just in a root you are not looking at. This is exactly the confusion `dot which` exists to resolve, only nobody thinks to run it mid-flow.

**How:** name the active root on `chain add`/`remove` and in the `chains` list header via the existing `describeConfigDir()`, and have `dot init` warn when the config it shadows already holds custom chains (new side-effect-free `peekConfiguredChains` helper). Output-only and `--json` is untouched, so scripts are unaffected. One regression test added.