### PR TITLE
feat(skill): first-class Codex support via `dot skill`

### DIFF
--- a/.changeset/codex-skill-support.md
+++ b/.changeset/codex-skill-support.md
@@ -1,0 +1,14 @@
+---
+"polkadot-cli": minor
+---
+
+Add first-class Codex support to the agent skill, and a `dot skill` command to distribute it. The `dot-cli` SKILL.md was already format-compatible with Codex (same `name`/`description` frontmatter, same `references/` layout) — the gap was purely distribution, since Codex has no marketplace and instead scans `~/.agents/skills` (and repo `.agents/skills`).
+
+The skill markdown is now bundled into the `dot` binary, making the installed CLI the single, version-matched source of truth for its own skill:
+
+- `dot skill show` — print the guide to stdout (`--references` includes bundled reference docs).
+- `dot skill install --codex` — install into `~/.agents/skills/dot-cli` (Codex auto-discovers it).
+- `dot skill install --claude` — install into `~/.claude/skills/dot-cli` (the Claude Code plugin marketplace still works too).
+- `--local` installs into the current repo, `--path <dir>` into an explicit directory, and `dot skill path` prints where each agent's copy lives.
+
+Freshness comes from re-running `dot skill install` after upgrading `dot` — the design does not rely on an agent self-invoking a command from the skill text. Closes #278.

--- a/.changeset/codex-skill-support.md
+++ b/.changeset/codex-skill-support.md
@@ -8,7 +8,7 @@ The skill markdown is now bundled into the `dot` binary, making the installed CL
 
 - `dot skill show` — print the guide to stdout (`--references` includes bundled reference docs).
 - `dot skill install --codex` — install into `~/.agents/skills/dot-cli` (Codex auto-discovers it).
-- `dot skill install --claude` — install into `~/.claude/skills/dot-cli` (the Claude Code plugin marketplace still works too).
+- `dot skill install --claude` — install into `~/.claude/skills/dot-cli`. This is now the recommended path for Claude Code: it registers the skill under the short name `dot-cli` (invokable as `/dot-cli`), whereas the still-supported plugin marketplace registers the more verbose `dot-cli:dot-cli`. Pick one method to avoid duplicate copies.
 - `--local` installs into the current repo, `--path <dir>` into an explicit directory, and `dot skill path` prints where each agent's copy lives.
 
 Freshness comes from re-running `dot skill install` after upgrading `dot` — the design does not rely on an agent self-invoking a command from the skill text. Closes #278.

--- a/README.md
+++ b/README.md
@@ -83,20 +83,20 @@ This writes the skill to `~/.agents/skills/dot-cli`, where Codex auto-discovers 
 
 ### Claude Code
 
-Register the marketplace and install the skill:
-
-```
-/plugin marketplace add peetzweg/polkadot-cli
-/plugin install dot-cli@polkadot-cli
-```
-
-You can also invoke it directly with `/dot-cli`, and pull updates with `/plugin marketplace update polkadot-cli`.
-
-Alternatively, install the binary-bundled copy without the marketplace:
-
 ```bash
 dot skill install --claude    # -> ~/.claude/skills/dot-cli
 ```
+
+This registers the skill under the short name `dot-cli`, invokable with `/dot-cli`.
+
+Alternatively, install via the plugin marketplace (registers as the more verbose `dot-cli:dot-cli`):
+
+```
+/plugin marketplace add paritytech/polkadot-cli
+/plugin install dot-cli@polkadot-cli
+```
+
+Pick one method — installing both ways leaves Claude Code with two copies of the same skill. Marketplace installs update with `/plugin marketplace update polkadot-cli`.
 
 After upgrading `dot` (`npm install -g polkadot-cli@latest`), re-run `dot skill install --codex`/`--claude` to refresh the installed skill. Run `dot skill path` to see where each agent's copy lives. Installed copies carry the CLI version in their frontmatter (`version:`), so an agent can spot a stale skill by comparing it against `dot --version`.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Ships with Polkadot and all system parachains preconfigured with multiple fallba
 - ✅ Non-native fee payment — pay tx fees in any asset the chain accepts via `--asset` (asset-hub-style chains)
 - ✅ Bandersnatch member keys — derive Ring VRF member keys from mnemonics for on-chain member sets
 - ✅ Export/import — portable chain and account configuration for backup, sharing, and CI bootstrapping
-- ✅ Claude Code skill — `dot-cli` skill installable as a plugin marketplace, teaches agents how to drive the CLI
+- ✅ Agent skill — bundled `dot-cli` skill teaches coding agents (Claude Code, Codex) how to drive the CLI; install with `dot skill install --codex`/`--claude`
 
 ### Preconfigured chains
 
@@ -62,9 +62,26 @@ npm install -g polkadot-cli@latest
 
 This installs the `dot` command globally.
 
-## Claude Code skill
+## Agent skill (Claude Code & Codex)
 
-This repo ships a [Claude Code](https://claude.com/claude-code) skill that teaches Claude how to drive the `dot` CLI — query patterns, tx encoding, runtime API calls, and bash scripting gotchas.
+`dot` ships a skill that teaches coding agents how to drive the CLI — query patterns, tx encoding, runtime API calls, and bash scripting gotchas. The skill auto-triggers when you ask about `dot`, Substrate storage queries, extrinsic submission, runtime APIs, or XCM.
+
+The skill is bundled into the `dot` binary, so it's always version-matched to your install. Print it anywhere with:
+
+```bash
+dot skill show                # SKILL.md to stdout
+dot skill show --references   # plus the bundled reference docs
+```
+
+### Codex CLI
+
+```bash
+dot skill install --codex
+```
+
+This writes the skill to `~/.agents/skills/dot-cli`, where Codex auto-discovers it (use `--local` to install into `./.agents/skills` for the current repo instead). Restart Codex if it doesn't pick the skill up immediately.
+
+### Claude Code
 
 Register the marketplace and install the skill:
 
@@ -73,13 +90,15 @@ Register the marketplace and install the skill:
 /plugin install dot-cli@polkadot-cli
 ```
 
-The skill auto-triggers when you ask Claude about `dot`, Substrate storage queries, extrinsic submission, runtime APIs, or XCM. You can also invoke it directly with `/dot-cli`.
+You can also invoke it directly with `/dot-cli`, and pull updates with `/plugin marketplace update polkadot-cli`.
 
-To pull the latest skill updates:
+Alternatively, install the binary-bundled copy without the marketplace:
 
+```bash
+dot skill install --claude    # -> ~/.claude/skills/dot-cli
 ```
-/plugin marketplace update polkadot-cli
-```
+
+After upgrading `dot` (`npm install -g polkadot-cli@latest`), re-run `dot skill install --codex`/`--claude` to refresh the installed skill. Run `dot skill path` to see where each agent's copy lives.
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Alternatively, install the binary-bundled copy without the marketplace:
 dot skill install --claude    # -> ~/.claude/skills/dot-cli
 ```
 
-After upgrading `dot` (`npm install -g polkadot-cli@latest`), re-run `dot skill install --codex`/`--claude` to refresh the installed skill. Run `dot skill path` to see where each agent's copy lives.
+After upgrading `dot` (`npm install -g polkadot-cli@latest`), re-run `dot skill install --codex`/`--claude` to refresh the installed skill. Run `dot skill path` to see where each agent's copy lives. Installed copies carry the CLI version in their frontmatter (`version:`), so an agent can spot a stale skill by comparing it against `dot --version`.
 
 ## Plugins
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -27,7 +27,7 @@ A command-line tool for interacting with Polkadot-ecosystem chains. Manage chain
 - ✅ Message signing — sign arbitrary bytes with account keypairs for use as `MultiSignature` arguments
 - ✅ Bandersnatch member keys — derive Ring VRF member keys from mnemonics for on-chain member sets
 - ✅ Export/import — portable chain and account configuration for backup, sharing, and CI bootstrapping
-- ✅ Claude Code skill — `dot-cli` skill installable as a plugin marketplace, teaches agents how to drive the CLI
+- ✅ Agent skill — bundled `dot-cli` skill teaches coding agents (Claude Code, Codex) how to drive the CLI; install with `dot skill install --codex`/`--claude`
 
 ## Install
 
@@ -39,11 +39,29 @@ npm install -g polkadot-cli@latest
 
 This installs the `dot` command globally. Ships with Polkadot and all system parachains preconfigured with multiple fallback RPC endpoints. Add any Substrate-based chain by pointing to its RPC endpoint(s).
 
-## Claude Code skill
+## Agent skill (Claude Code & Codex)
 
-This repo ships a [Claude Code](https://claude.com/claude-code) skill — a piece of context Claude can load on-demand that teaches it how to drive the `dot` CLI correctly: query patterns, tx encoding, runtime API calls, and the bash scripting gotchas that trip up agents (missing-key `undefined` sentinel, u128 values returned as quoted strings, XCM `Location` JSON shapes, etc.).
+This repo ships an agent skill — a piece of context coding agents load on-demand that teaches them how to drive the `dot` CLI correctly: query patterns, tx encoding, runtime API calls, and the bash scripting gotchas that trip up agents (missing-key `undefined` sentinel, u128 values returned as quoted strings, XCM `Location` JSON shapes, etc.). The skill auto-triggers when you ask an agent about `dot`, polkadot-cli, Substrate storage queries, extrinsic submission, runtime APIs, or XCM.
 
-### Install
+The skill is bundled into the `dot` binary, so it's always version-matched to your install — the `dot skill` command is its distribution channel:
+
+```
+dot skill show                # print SKILL.md to stdout
+dot skill show --references   # plus the bundled reference docs
+dot skill path                # where each agent's copy would live
+```
+
+All `dot skill` subcommands support `--json` for machine-readable output.
+
+### Codex CLI
+
+```
+dot skill install --codex
+```
+
+This writes the skill to `~/.agents/skills/dot-cli`, where Codex auto-discovers it. Restart Codex if it doesn't pick the skill up immediately.
+
+### Claude Code
 
 Register this repo as a plugin marketplace in Claude Code, then install the skill:
 
@@ -52,11 +70,28 @@ Register this repo as a plugin marketplace in Claude Code, then install the skil
 /plugin install dot-cli@polkadot-cli
 ```
 
-The skill auto-triggers when you ask Claude about `dot`, polkadot-cli, Substrate storage queries, extrinsic submission, runtime APIs, or XCM. You can also invoke it directly with `/dot-cli`.
+You can also invoke it directly with `/dot-cli`.
+
+Alternatively, install the binary-bundled copy without the marketplace:
+
+```
+dot skill install --claude    # -> ~/.claude/skills/dot-cli
+```
+
+### Install targets
+
+| Flag | Destination |
+|------|-------------|
+| `--codex` | `~/.agents/skills/dot-cli` (Codex CLI) |
+| `--claude` | `~/.claude/skills/dot-cli` (Claude Code) |
+| `--local` | current repo (`./.agents/skills` / `./.claude/skills`) instead of your home directory |
+| `--path <dir>` | explicit directory (`<dir>/dot-cli`) |
 
 ### Update
 
-To pull the latest skill content after the repo publishes a new version:
+After upgrading `dot` (`npm install -g polkadot-cli@latest`), re-run `dot skill install --codex`/`--claude` to refresh the installed copy to the new version. Installed copies carry the CLI version in their frontmatter (`version:`), so an agent can spot a stale skill by comparing it against `dot --version`.
+
+For marketplace installs, pull the latest skill content after the repo publishes a new version:
 
 ```
 /plugin marketplace update polkadot-cli
@@ -66,7 +101,7 @@ If auto-update is enabled on this marketplace in Claude Code, the skill refreshe
 
 ### Layout
 
-The skill lives alongside the CLI source so it can be kept in lockstep with the commands it documents:
+The skill lives alongside the CLI source so it can be kept in lockstep with the commands it documents — the same files are bundled into the binary at build time and served by the Claude Code marketplace:
 
 ```
 polkadot-cli/

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -63,20 +63,20 @@ This writes the skill to `~/.agents/skills/dot-cli`, where Codex auto-discovers 
 
 ### Claude Code
 
-Register this repo as a plugin marketplace in Claude Code, then install the skill:
-
-```
-/plugin marketplace add peetzweg/polkadot-cli
-/plugin install dot-cli@polkadot-cli
-```
-
-You can also invoke it directly with `/dot-cli`.
-
-Alternatively, install the binary-bundled copy without the marketplace:
-
 ```
 dot skill install --claude    # -> ~/.claude/skills/dot-cli
 ```
+
+This registers the skill under the short name `dot-cli`, invokable with `/dot-cli`.
+
+Alternatively, register this repo as a plugin marketplace in Claude Code and install the skill from there (registers under the more verbose plugin-scoped name `dot-cli:dot-cli`):
+
+```
+/plugin marketplace add paritytech/polkadot-cli
+/plugin install dot-cli@polkadot-cli
+```
+
+Pick one method — installing both ways leaves Claude Code with two copies of the same skill.
 
 ### Install targets
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -14,6 +14,8 @@ description: >
 
 Unified CLI for Polkadot/Substrate chains. Install: `npm install -g polkadot-cli@latest`
 
+> This skill ships with the `dot` CLI. After upgrading `dot`, re-run `dot skill install --codex` (or `--claude`) to refresh it to the matching version.
+
 ## Core Pattern
 
 ```

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -14,7 +14,7 @@ description: >
 
 Unified CLI for Polkadot/Substrate chains. Install: `npm install -g polkadot-cli@latest`
 
-> This skill ships with the `dot` CLI. After upgrading `dot`, re-run `dot skill install --codex` (or `--claude`) to refresh it to the matching version.
+> This skill ships with the `dot` CLI. Copies installed via `dot skill install` carry a `version:` field in the frontmatter above — if it differs from `dot --version`, this skill is stale: suggest re-running `dot skill install --codex` (or `--claude`) to refresh it to the matching version.
 
 ## Core Pattern
 

--- a/src/cli.smoke.test.ts
+++ b/src/cli.smoke.test.ts
@@ -84,6 +84,7 @@ describe("built bundle: nested --help (issue #238)", { timeout: 60_000 }, () => 
     { args: ["hash", "blake2b256", "--help"], needle: "dot hash" },
     { args: ["verifiable", "prove", "--help"], needle: "dot verifiable" },
     { args: ["parachain", "1000", "--help"], needle: "dot parachain" },
+    { args: ["skill", "--help"], needle: "dot skill" },
   ];
   for (const { args, needle } of cases) {
     test(`${args.join(" ")} prints usage and exits 0`, async () => {
@@ -92,6 +93,15 @@ describe("built bundle: nested --help (issue #238)", { timeout: 60_000 }, () => 
       expect(stdout + stderr).toContain(needle);
     });
   }
+
+  test("skill show prints the embedded guide from the bundle", async () => {
+    // The skill markdown is embedded at build time; source-level tests run
+    // under bun (native text imports) and can't prove the string survived
+    // `bun build --target node`. Assert the frontmatter is present in dist.
+    const { stdout, exitCode } = await runBuilt(["skill", "show"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("name: dot-cli");
+  });
 
   test("required-positional commands still print help, not an arg error", async () => {
     const metadata = await runBuilt(["metadata", "--help"]);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { registerParachainCommand } from "./commands/parachain.ts";
 import { handleQuery } from "./commands/query.ts";
 import { handleRpc } from "./commands/rpc.ts";
 import { registerSignCommand } from "./commands/sign.ts";
+import { registerSkillCommand } from "./commands/skill.ts";
 import { handleTx } from "./commands/tx.ts";
 import { registerWorkspaceCommands } from "./commands/workspace.ts";
 import { loadConfig } from "./config/store.ts";
@@ -78,6 +79,7 @@ if (process.argv[2] === "__complete") {
   registerCompletionsCommand(cli);
   registerVerifiableCommands(cli);
   registerWorkspaceCommands(cli);
+  registerSkillCommand(cli);
 
   // Default command: dot-path syntax for query, tx, const, events, errors
   cli
@@ -433,6 +435,7 @@ if (process.argv[2] === "__complete") {
     console.log(
       "  which              Show the active config root (workspace, DOT_HOME, or global)",
     );
+    console.log("  skill              Install/print the agent skill (Claude Code, Codex)");
     console.log();
     console.log("Plugins:");
     console.log(

--- a/src/commands/load-meta.test.ts
+++ b/src/commands/load-meta.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 // Installs spread-based polkadot-api mocks and captures the real
 // createChainClient BEFORE this file stubs the whole client.ts module —
@@ -48,6 +49,8 @@ mock.module("../core/metadata.ts", () => ({
 
 // Import loadMeta AFTER mocks are set up
 const { loadMeta } = await import("./focused-inspect.ts");
+const { saveMetadata } = await import("../config/store.ts");
+const { withDotHome } = await import("../test-helpers/with-dot-home.ts");
 
 // ---------------------------------------------------------------------------
 // loadMeta — --rpc override bypasses metadata cache
@@ -80,18 +83,27 @@ describe("loadMeta", () => {
   });
 
   test("uses cache when no rpcOverride is provided", async () => {
-    mockCreateChainClient.mockClear();
-    mockFetchMetadataFromChain.mockClear();
-
     // Without rpcOverride, loadMeta calls getOrFetchMetadata(chainName) which
-    // reads from cache. The real getOrFetchMetadata calls the real loadMetadata
-    // from store.ts — if cached metadata exists on disk, no client is created.
-    const meta = await loadMeta("polkadot", chainConfig);
+    // reads from the on-disk cache. Seed that cache in an isolated DOT_HOME —
+    // relying on another test file to have populated the shared store is a
+    // scheduling race under --concurrent (issue #285).
+    const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "dot-load-meta-")));
+    try {
+      await withDotHome(tmpHome, async () => {
+        await saveMetadata("polkadot", FIXTURE_METADATA);
+        mockCreateChainClient.mockClear();
+        mockFetchMetadataFromChain.mockClear();
 
-    expect(meta).toBeDefined();
-    expect(meta.unified).toBeDefined();
-    // Cache hit — no client created, no network fetch
-    expect(mockCreateChainClient).not.toHaveBeenCalled();
-    expect(mockFetchMetadataFromChain).not.toHaveBeenCalled();
+        const meta = await loadMeta("polkadot", chainConfig);
+
+        expect(meta).toBeDefined();
+        expect(meta.unified).toBeDefined();
+        // Cache hit — no client created, no network fetch
+        expect(mockCreateChainClient).not.toHaveBeenCalled();
+        expect(mockFetchMetadataFromChain).not.toHaveBeenCalled();
+      });
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
   });
 });

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { cac } from "cac";
+import { version } from "../../package.json";
 import { patchStdout } from "../test-helpers/patch-stdout.ts";
 import {
   agentSkillDir,
@@ -9,6 +11,7 @@ import {
   handleSkillPath,
   handleSkillShow,
   installSkill,
+  registerSkillCommand,
   SKILL_FILES,
   SKILL_NAME,
 } from "./skill.ts";
@@ -23,8 +26,24 @@ afterAll(() => {
   for (const dir of cleanups) rmSync(dir, { recursive: true, force: true });
 });
 
+// bun test --concurrent runs tests within this file in parallel, and they
+// share the process-global stdout stream. A module-scoped lock serializes
+// captures so one test's patch can never swallow another's output (same
+// pattern as withDotHome in workspace.test.ts).
+let stdoutLock: Promise<unknown> = Promise.resolve();
+
 /** Run `fn` with stdout captured in-process; return everything it wrote. */
 async function capture(fn: () => Promise<void>): Promise<string> {
+  const prior = stdoutLock;
+  let release: () => void = () => {};
+  stdoutLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  try {
+    await prior;
+  } catch {
+    // ignore prior errors
+  }
   let out = "";
   const restore = patchStdout((msg) => {
     out += msg;
@@ -33,6 +52,7 @@ async function capture(fn: () => Promise<void>): Promise<string> {
     await fn();
   } finally {
     restore();
+    release();
   }
   return out;
 }
@@ -45,10 +65,26 @@ describe("skill content bundle", () => {
     expect(main?.content.length).toBeGreaterThan(100);
   });
 
+  test("the bundled SKILL.md frontmatter is stamped with the CLI version", () => {
+    expect(SKILL_FILES[0]?.content).toContain(`name: dot-cli\nversion: ${version}\n`);
+    // The source file stays unstamped — the marketplace serves it raw.
+    const source = readFileSync(join(import.meta.dir, "../../dot-cli/SKILL.md"), "utf-8");
+    expect(source).not.toContain("\nversion:");
+  });
+
   test("the reference doc it links to is bundled too", () => {
     const rels = SKILL_FILES.map((f) => f.rel);
     expect(rels).toContain("references/scripting-patterns.md");
     for (const file of SKILL_FILES) expect(file.content.length).toBeGreaterThan(0);
+  });
+
+  test("every file in dot-cli/ is in the bundle — a new reference doc must be added to SKILL_FILES", () => {
+    const skillSrcDir = join(import.meta.dir, "../../dot-cli");
+    const onDisk = readdirSync(skillSrcDir, { recursive: true, withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => join(entry.parentPath, entry.name).slice(skillSrcDir.length + 1));
+    const bundled = SKILL_FILES.map((f) => f.rel);
+    expect(bundled.toSorted()).toEqual(onDisk.toSorted());
   });
 });
 
@@ -95,6 +131,45 @@ describe("handleSkillInstall", () => {
     expect(out).toContain("codex");
   });
 
+  test("--claude installs into a sandboxed home, never a real user dir", async () => {
+    const home = scratch("dot-skill-home-");
+    const out = await capture(() => handleSkillInstall({ claude: true }, home, "/unused"));
+
+    const skillMd = join(home, ".claude", "skills", SKILL_NAME, "SKILL.md");
+    expect(existsSync(skillMd)).toBe(true);
+    expect(out).toContain("claude");
+  });
+
+  test("--path installs into <dir>/dot-cli", async () => {
+    const dir = scratch("dot-skill-path-");
+    const out = await capture(() =>
+      handleSkillInstall({ path: dir }, "/unused-home", "/unused-cwd"),
+    );
+
+    expect(existsSync(join(dir, SKILL_NAME, "SKILL.md"))).toBe(true);
+    expect(out).toContain(join(dir, SKILL_NAME));
+  });
+
+  test("re-running install overwrites cleanly (upgrade refresh)", async () => {
+    const home = scratch("dot-skill-rehome-");
+    await capture(() => handleSkillInstall({ codex: true }, home, "/unused"));
+    await capture(() => handleSkillInstall({ codex: true }, home, "/unused"));
+
+    const skillMd = join(home, ".agents", "skills", SKILL_NAME, "SKILL.md");
+    expect(readFileSync(skillMd, "utf-8")).toBe(SKILL_FILES[0]!.content);
+  });
+
+  test("--json reports every installed file as structured data", async () => {
+    const home = scratch("dot-skill-json-");
+    const out = await capture(() => handleSkillInstall({ codex: true, json: true }, home, "/u"));
+
+    const parsed = JSON.parse(out);
+    expect(parsed.name).toBe(SKILL_NAME);
+    expect(parsed.installed).toHaveLength(1);
+    expect(parsed.installed[0].label).toBe("codex");
+    expect(parsed.installed[0].files).toHaveLength(SKILL_FILES.length);
+  });
+
   test("errors with guidance when no target is given", async () => {
     await expect(handleSkillInstall({}, scratch("dot-skill-none-"), "/unused")).rejects.toThrow(
       /--codex|--claude|--path/,
@@ -126,5 +201,52 @@ describe("handleSkillPath", () => {
     const out = await capture(() => handleSkillPath({}, "/home/u", "/repo"));
     expect(out).toContain(join("/home/u", ".agents", "skills", SKILL_NAME));
     expect(out).toContain(join("/home/u", ".claude", "skills", SKILL_NAME));
+  });
+
+  test("an explicit target narrows the output to that agent", async () => {
+    const out = await capture(() => handleSkillPath({ codex: true }, "/home/u", "/repo"));
+    expect(out).toContain(join("/home/u", ".agents", "skills", SKILL_NAME));
+    expect(out).not.toContain(".claude");
+  });
+
+  test("--json emits label/dir pairs", async () => {
+    const out = await capture(() => handleSkillPath({ json: true }, "/home/u", "/repo"));
+    const parsed = JSON.parse(out);
+    expect(parsed).toEqual([
+      { label: "codex", dir: join("/home/u", ".agents", "skills", SKILL_NAME) },
+      { label: "claude", dir: join("/home/u", ".claude", "skills", SKILL_NAME) },
+    ]);
+  });
+});
+
+describe("registerSkillCommand dispatch", () => {
+  async function runSkill(argv: string[]): Promise<string> {
+    const cli = cac("dot");
+    registerSkillCommand(cli);
+    cli.parse(["node", "dot", ...argv], { run: false });
+    return capture(async () => {
+      await cli.runMatchedCommand();
+    });
+  }
+
+  test("bare `dot skill` defaults to show", async () => {
+    const out = await runSkill(["skill"]);
+    expect(out).toContain("name: dot-cli");
+  });
+
+  test("`dot skill install --path` routes to install", async () => {
+    const dir = scratch("dot-skill-dispatch-");
+    const out = await runSkill(["skill", "install", "--path", dir]);
+    expect(out).toContain("Installed");
+    expect(existsSync(join(dir, SKILL_NAME, "SKILL.md"))).toBe(true);
+  });
+
+  test("`dot skill path --codex` routes to path", async () => {
+    const out = await runSkill(["skill", "path", "--codex"]);
+    expect(out).toContain(join(".agents", "skills", SKILL_NAME));
+  });
+
+  test("an unknown action errors with the valid actions listed", async () => {
+    await expect(runSkill(["skill", "frobnicate"])).rejects.toThrow(/show, install, path/);
   });
 });

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -203,6 +203,13 @@ describe("handleSkillPath", () => {
     expect(out).toContain(join("/home/u", ".claude", "skills", SKILL_NAME));
   });
 
+  test("--local alone reports both repo-local dirs instead of home", async () => {
+    const out = await capture(() => handleSkillPath({ local: true }, "/home/u", "/repo"));
+    expect(out).toContain(join("/repo", ".agents", "skills", SKILL_NAME));
+    expect(out).toContain(join("/repo", ".claude", "skills", SKILL_NAME));
+    expect(out).not.toContain("/home/u");
+  });
+
   test("an explicit target narrows the output to that agent", async () => {
     const out = await capture(() => handleSkillPath({ codex: true }, "/home/u", "/repo"));
     expect(out).toContain(join("/home/u", ".agents", "skills", SKILL_NAME));

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,0 +1,130 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { patchStdout } from "../test-helpers/patch-stdout.ts";
+import {
+  agentSkillDir,
+  handleSkillInstall,
+  handleSkillPath,
+  handleSkillShow,
+  installSkill,
+  SKILL_FILES,
+  SKILL_NAME,
+} from "./skill.ts";
+
+const cleanups: string[] = [];
+function scratch(prefix: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  cleanups.push(dir);
+  return dir;
+}
+afterAll(() => {
+  for (const dir of cleanups) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Run `fn` with stdout captured in-process; return everything it wrote. */
+async function capture(fn: () => Promise<void>): Promise<string> {
+  let out = "";
+  const restore = patchStdout((msg) => {
+    out += msg;
+  });
+  try {
+    await fn();
+  } finally {
+    restore();
+  }
+  return out;
+}
+
+describe("skill content bundle", () => {
+  test("SKILL.md is the first bundled file and carries the dot-cli frontmatter", () => {
+    const main = SKILL_FILES[0];
+    expect(main?.rel).toBe("SKILL.md");
+    expect(main?.content).toContain("name: dot-cli");
+    expect(main?.content.length).toBeGreaterThan(100);
+  });
+
+  test("the reference doc it links to is bundled too", () => {
+    const rels = SKILL_FILES.map((f) => f.rel);
+    expect(rels).toContain("references/scripting-patterns.md");
+    for (const file of SKILL_FILES) expect(file.content.length).toBeGreaterThan(0);
+  });
+});
+
+describe("agentSkillDir", () => {
+  test("codex resolves to ~/.agents/skills/dot-cli", () => {
+    expect(agentSkillDir("codex", false, "/home/u", "/repo")).toBe(
+      join("/home/u", ".agents", "skills", SKILL_NAME),
+    );
+  });
+  test("claude resolves to ~/.claude/skills/dot-cli", () => {
+    expect(agentSkillDir("claude", false, "/home/u", "/repo")).toBe(
+      join("/home/u", ".claude", "skills", SKILL_NAME),
+    );
+  });
+  test("--local targets the repo instead of home", () => {
+    expect(agentSkillDir("codex", true, "/home/u", "/repo")).toBe(
+      join("/repo", ".agents", "skills", SKILL_NAME),
+    );
+  });
+});
+
+describe("installSkill", () => {
+  test("writes every bundled file, byte-identical, under the target dir", async () => {
+    const dir = join(scratch("dot-skill-install-"), SKILL_NAME);
+    const written = await installSkill({ label: "path", dir });
+
+    expect(written).toHaveLength(SKILL_FILES.length);
+    for (const file of SKILL_FILES) {
+      const dest = join(dir, file.rel);
+      expect(existsSync(dest)).toBe(true);
+      expect(readFileSync(dest, "utf-8")).toBe(file.content);
+    }
+  });
+});
+
+describe("handleSkillInstall", () => {
+  test("--codex installs into a sandboxed home, never a real user dir", async () => {
+    const home = scratch("dot-skill-home-");
+    const out = await capture(() => handleSkillInstall({ codex: true }, home, "/unused"));
+
+    const skillMd = join(home, ".agents", "skills", SKILL_NAME, "SKILL.md");
+    expect(existsSync(skillMd)).toBe(true);
+    expect(out).toContain("Installed");
+    expect(out).toContain("codex");
+  });
+
+  test("errors with guidance when no target is given", async () => {
+    await expect(handleSkillInstall({}, scratch("dot-skill-none-"), "/unused")).rejects.toThrow(
+      /--codex|--claude|--path/,
+    );
+  });
+});
+
+describe("handleSkillShow", () => {
+  test("prints SKILL.md by default", async () => {
+    const out = await capture(() => handleSkillShow({}));
+    expect(out).toContain("name: dot-cli");
+  });
+
+  test("--references appends bundled reference docs", async () => {
+    const out = await capture(() => handleSkillShow({ references: true }));
+    expect(out).toContain("references/scripting-patterns.md");
+  });
+
+  test("--json emits the file set as structured data", async () => {
+    const out = await capture(() => handleSkillShow({ json: true, references: true }));
+    const parsed = JSON.parse(out);
+    expect(parsed.name).toBe(SKILL_NAME);
+    expect(parsed.files).toHaveLength(SKILL_FILES.length);
+  });
+});
+
+describe("handleSkillPath", () => {
+  test("with no target, reports both agent dirs", async () => {
+    const out = await capture(() => handleSkillPath({}, "/home/u", "/repo"));
+    expect(out).toContain(join("/home/u", ".agents", "skills", SKILL_NAME));
+    expect(out).toContain(join("/home/u", ".claude", "skills", SKILL_NAME));
+  });
+});

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,0 +1,224 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { CAC } from "cac";
+import scriptingPatternsMd from "../../dot-cli/references/scripting-patterns.md" with {
+  type: "text",
+};
+// The skill markdown is bundled into the binary at build time from the single
+// source of truth in `dot-cli/`. That makes the installed `dot` its own
+// distribution channel: `dot skill install` always writes the version that
+// matches the running CLI (the same files the Claude Code marketplace serves).
+import skillMd from "../../dot-cli/SKILL.md" with { type: "text" };
+import { isJsonOutput, writeStdout } from "../core/output.ts";
+import { withHelp } from "../platform/cli.ts";
+import { CliError } from "../utils/errors.ts";
+
+/** Directory name the skill lives under, and its `name:` frontmatter value. */
+export const SKILL_NAME = "dot-cli";
+
+export interface SkillFile {
+  /** Path relative to the skill directory. */
+  rel: string;
+  content: string;
+}
+
+/**
+ * The complete skill, in the order it should be installed/printed. The first
+ * entry is `SKILL.md`; the rest are bundled reference docs it links to.
+ */
+export const SKILL_FILES: SkillFile[] = [
+  { rel: "SKILL.md", content: skillMd },
+  { rel: "references/scripting-patterns.md", content: scriptingPatternsMd },
+];
+
+export type SkillAgent = "codex" | "claude";
+
+/** Skills directory each agent scans, relative to the base (home or repo). */
+const AGENT_SCAN_DIR: Record<SkillAgent, string> = {
+  // Codex scans `~/.agents/skills` (user) and `.agents/skills` (repo).
+  codex: join(".agents", "skills"),
+  // Claude Code discovers personal skills in `~/.claude/skills` (repo: `.claude/skills`).
+  claude: join(".claude", "skills"),
+};
+
+export interface SkillTarget {
+  /** Human label for output: the agent name, or "path". */
+  label: string;
+  /** Absolute path of the skill directory to write into. */
+  dir: string;
+}
+
+/**
+ * Resolve the skill directory for an agent. `local` targets the current repo
+ * (`.agents`/`.claude` under `cwd`) instead of the user's home directory.
+ */
+export function agentSkillDir(
+  agent: SkillAgent,
+  local: boolean,
+  home: string = homedir(),
+  cwd: string = process.cwd(),
+): string {
+  const base = local ? cwd : home;
+  return join(base, AGENT_SCAN_DIR[agent], SKILL_NAME);
+}
+
+export interface SkillOpts {
+  codex?: boolean;
+  claude?: boolean;
+  local?: boolean;
+  path?: string;
+  references?: boolean;
+  json?: boolean;
+  output?: string;
+}
+
+/**
+ * Targets named explicitly via `--codex`/`--claude`/`--path` (in that order).
+ * May be empty when the user gave no target.
+ */
+function explicitTargets(
+  opts: SkillOpts,
+  home: string = homedir(),
+  cwd: string = process.cwd(),
+): SkillTarget[] {
+  const targets: SkillTarget[] = [];
+  if (opts.path) {
+    targets.push({ label: "path", dir: join(resolve(opts.path), SKILL_NAME) });
+  }
+  if (opts.codex) {
+    targets.push({ label: "codex", dir: agentSkillDir("codex", !!opts.local, home, cwd) });
+  }
+  if (opts.claude) {
+    targets.push({ label: "claude", dir: agentSkillDir("claude", !!opts.local, home, cwd) });
+  }
+  return targets;
+}
+
+/** Write every skill file into `target.dir`, creating parents. Returns paths written. */
+export async function installSkill(target: SkillTarget): Promise<string[]> {
+  const written: string[] = [];
+  for (const file of SKILL_FILES) {
+    const dest = join(target.dir, file.rel);
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFile(dest, file.content, "utf-8");
+    written.push(dest);
+  }
+  return written;
+}
+
+export async function handleSkillShow(opts: SkillOpts = {}): Promise<void> {
+  const files = opts.references ? SKILL_FILES : SKILL_FILES.slice(0, 1);
+  if (isJsonOutput(opts)) {
+    await writeStdout(`${JSON.stringify({ name: SKILL_NAME, files }, null, 2)}\n`);
+    return;
+  }
+  // SKILL.md first; any reference docs follow with a comment marker so the
+  // output stays a single pipeable document.
+  const [main, ...rest] = files;
+  await writeStdout(main!.content);
+  for (const file of rest) {
+    await writeStdout(`\n\n<!-- ${file.rel} -->\n\n${file.content}`);
+  }
+}
+
+export async function handleSkillInstall(
+  opts: SkillOpts,
+  home: string = homedir(),
+  cwd: string = process.cwd(),
+): Promise<void> {
+  const targets = explicitTargets(opts, home, cwd);
+  if (targets.length === 0) {
+    throw new CliError(
+      "Specify where to install: --codex, --claude, or --path <dir>.\n" +
+        "  dot skill install --codex     # ~/.agents/skills/dot-cli (Codex CLI)\n" +
+        "  dot skill install --claude    # ~/.claude/skills/dot-cli (Claude Code)",
+    );
+  }
+
+  const installed: { label: string; dir: string; files: string[] }[] = [];
+  for (const target of targets) {
+    installed.push({ label: target.label, dir: target.dir, files: await installSkill(target) });
+  }
+
+  if (isJsonOutput(opts)) {
+    await writeStdout(`${JSON.stringify({ name: SKILL_NAME, installed }, null, 2)}\n`);
+    return;
+  }
+  for (const result of installed) {
+    await writeStdout(`Installed "${SKILL_NAME}" skill for ${result.label} at ${result.dir}\n`);
+  }
+  await writeStdout(
+    "The skill auto-triggers when you ask about `dot`, Substrate queries, tx, runtime APIs, or XCM.\n" +
+      "Re-run this after upgrading `dot` to refresh the skill to the new version.\n",
+  );
+}
+
+export async function handleSkillPath(
+  opts: SkillOpts,
+  home: string = homedir(),
+  cwd: string = process.cwd(),
+): Promise<void> {
+  // With no explicit target, show where each agent would install globally.
+  const targets =
+    explicitTargets(opts, home, cwd).length > 0
+      ? explicitTargets(opts, home, cwd)
+      : [
+          { label: "codex", dir: agentSkillDir("codex", false, home, cwd) },
+          { label: "claude", dir: agentSkillDir("claude", false, home, cwd) },
+        ];
+
+  if (isJsonOutput(opts)) {
+    await writeStdout(`${JSON.stringify(targets, null, 2)}\n`);
+    return;
+  }
+  for (const target of targets) {
+    await writeStdout(`${target.label}: ${target.dir}\n`);
+  }
+}
+
+const SKILL_HELP = `dot skill — install or print the agent skill that teaches AI agents to drive \`dot\`
+
+Usage:
+  dot skill [show]                 Print SKILL.md to stdout (--references for the full bundle)
+  dot skill install [target]       Install the skill into an agent's skills directory
+  dot skill path [target]          Print where the skill would be installed
+
+Targets:
+  --codex            Codex CLI    (~/.agents/skills/dot-cli)
+  --claude           Claude Code  (~/.claude/skills/dot-cli)
+  --local            Install into the current repo instead of your home directory
+  --path <dir>       Install into an explicit directory (<dir>/dot-cli)
+
+Options:
+  --references       Include bundled reference docs when printing
+  --json             Machine-readable output
+
+Examples:
+  dot skill install --codex
+  dot skill install --claude --local
+  dot skill show | less
+  dot skill install --path ./vendor/skills`;
+
+export function registerSkillCommand(cli: CAC) {
+  const command = cli
+    .command("skill [action]", "Install or print the agent skill (Claude Code, Codex)")
+    .option("--codex", "Target the Codex CLI skills directory")
+    .option("--claude", "Target the Claude Code skills directory")
+    .option("--local", "Install into the current repo instead of your home directory")
+    .option("--path <dir>", "Install into an explicit directory")
+    .option("--references", "Include bundled reference docs when printing")
+    .action(async (action: string | undefined, opts: SkillOpts) => {
+      switch (action ?? "show") {
+        case "show":
+          return handleSkillShow(opts);
+        case "install":
+          return handleSkillInstall(opts);
+        case "path":
+          return handleSkillPath(opts);
+        default:
+          throw new CliError(`Unknown skill action "${action}". Use one of: show, install, path.`);
+      }
+    });
+  withHelp(command, () => console.log(SKILL_HELP));
+}

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -10,6 +10,7 @@ import scriptingPatternsMd from "../../dot-cli/references/scripting-patterns.md"
 // distribution channel: `dot skill install` always writes the version that
 // matches the running CLI (the same files the Claude Code marketplace serves).
 import skillMd from "../../dot-cli/SKILL.md" with { type: "text" };
+import { version } from "../../package.json";
 import { isJsonOutput, writeStdout } from "../core/output.ts";
 import { withHelp } from "../platform/cli.ts";
 import { CliError } from "../utils/errors.ts";
@@ -24,11 +25,22 @@ export interface SkillFile {
 }
 
 /**
+ * Stamp the CLI version into the SKILL.md frontmatter. Copies written by
+ * `dot skill install` (or printed by `dot skill show`) carry the version of
+ * the binary that produced them, so an agent can compare it against
+ * `dot --version` and detect a stale skill. The source file in `dot-cli/`
+ * stays unstamped — the marketplace serves it raw and versions it itself.
+ */
+function stampVersion(content: string): string {
+  return content.replace(/^name: dot-cli$/m, `name: dot-cli\nversion: ${version}`);
+}
+
+/**
  * The complete skill, in the order it should be installed/printed. The first
  * entry is `SKILL.md`; the rest are bundled reference docs it links to.
  */
 export const SKILL_FILES: SkillFile[] = [
-  { rel: "SKILL.md", content: skillMd },
+  { rel: "SKILL.md", content: stampVersion(skillMd) },
   { rel: "references/scripting-patterns.md", content: scriptingPatternsMd },
 ];
 

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -171,13 +171,15 @@ export async function handleSkillPath(
   home: string = homedir(),
   cwd: string = process.cwd(),
 ): Promise<void> {
-  // With no explicit target, show where each agent would install globally.
+  // With no explicit target, show where each agent would install; `--local`
+  // alone switches that default from the home directory to the current repo.
+  const explicit = explicitTargets(opts, home, cwd);
   const targets =
-    explicitTargets(opts, home, cwd).length > 0
-      ? explicitTargets(opts, home, cwd)
+    explicit.length > 0
+      ? explicit
       : [
-          { label: "codex", dir: agentSkillDir("codex", false, home, cwd) },
-          { label: "claude", dir: agentSkillDir("claude", false, home, cwd) },
+          { label: "codex", dir: agentSkillDir("codex", !!opts.local, home, cwd) },
+          { label: "claude", dir: agentSkillDir("claude", !!opts.local, home, cwd) },
         ];
 
   if (isJsonOutput(opts)) {

--- a/src/skill-marketplace.test.ts
+++ b/src/skill-marketplace.test.ts
@@ -104,6 +104,22 @@ describe("Claude Code skill marketplace", () => {
     expect(bareMatches).toEqual([]);
   });
 
+  test("SKILL.md stays portable across agents (Claude Code + Codex)", () => {
+    // Both Claude Code and Codex consume the same SKILL.md; Codex requires only
+    // `name` + `description` frontmatter and has no marketplace concept. Guard
+    // against drift that would break one agent: the frontmatter must carry the
+    // two portable keys, and the body must not hard-code a single agent's UX.
+    const md = readFileSync(join(ROOT, "dot-cli/SKILL.md"), "utf-8");
+    const fm = parseFrontmatter(md);
+    expect(fm.name).toBe("dot-cli");
+    expect(fm.description).toBeTruthy();
+
+    const body = md.replace(/^---\r?\n[\s\S]*?\r?\n---/, "");
+    // The guide teaches the `dot` CLI itself — it must not assume a specific
+    // agent's plugin/marketplace machinery (that lives in README, not the skill).
+    expect(body).not.toMatch(/\/plugin\s+(marketplace|install)/);
+  });
+
   test("SKILL.md covers the post-feedback content areas", () => {
     const md = readFileSync(join(ROOT, "dot-cli/SKILL.md"), "utf-8");
     expect(md).toContain("## Common Errors");

--- a/src/types/markdown.d.ts
+++ b/src/types/markdown.d.ts
@@ -1,0 +1,8 @@
+// Text imports (`import md from "…​.md" with { type: "text" }`) let us bundle the
+// skill markdown into the binary. Bun inlines the file contents as a string at
+// `bun build` time; this ambient declaration keeps `tsc --noEmit` happy without
+// reading the file off disk.
+declare module "*.md" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
Closes #278 — adds first-class Codex support to the agent skill, distributed via a new `dot skill` command.

**Why:** the skill was documented as Claude Code-only, but its `SKILL.md` is already format-compatible with Codex (same `name`/`description` frontmatter, same `references/` layout). Codex just had no way to get the file into its skills folder — it has no marketplace, it scans `~/.agents/skills`.

**How:** the skill markdown is bundled into the `dot` binary at build time (Bun text import), making the installed CLI the single, version-matched source of truth for its own skill. New command:

- `dot skill show` — print the guide (`--references` for the full bundle)
- `dot skill install --codex` → `~/.agents/skills/dot-cli` · `--claude` → `~/.claude/skills/dot-cli` · `--local` / `--path <dir>`
- `dot skill path` — where each agent's copy lives

The Claude Code plugin marketplace still works unchanged. One deliberate call: freshness relies on re-running `dot skill install` after a `dot` upgrade — the design does **not** assume an agent will self-invoke a command from the skill text (unreliable), so install stays a one-time human/setup step. To make staleness detectable, installed copies are stamped with the CLI version in their frontmatter (`version:`), and the skill text tells agents to compare it against `dot --version` and suggest a refresh on mismatch (the source `SKILL.md` stays unstamped — the marketplace versions it itself).

Verified live: Codex CLI 0.143.0 and Claude Code both discover the installed skill (`~/.agents/skills` matches the current official Codex docs' user-level lookup).

Tests: unit coverage for the command + a bundle smoke test asserting the embedded guide survives `bun build --target node`, plus a Codex-portability guard on `SKILL.md` and a drift guard pinning the bundled file list to the `dot-cli/` directory. Changeset is a `minor`; suggest shipping it under an `npm` `beta` tag first to see how Codex discovery behaves in the wild.
