### PR TITLE
fix: let --ext override builtin extensions, error on unknown names

### DIFF
--- a/.changeset/fix-ext-builtin-overrides.md
+++ b/.changeset/fix-ext-builtin-overrides.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": patch
+---
+
+Fix `--ext` silently ignoring overrides for builtin transaction extensions. The builtin skip ran before the user-override check, so e.g. `--ext '{"CheckMetadataHash":…}'` was parsed and then dropped without warning, making `CheckMetadataHash` unreachable by any route. User overrides now take priority over the builtin skip (polkadot-api itself checks `customSignedExtensions` before its own handling, so the value wins downstream). Passing an extension name the chain's metadata doesn't declare is now a clear error instead of being silently ignored.

--- a/README.md
+++ b/README.md
@@ -1490,6 +1490,8 @@ For manual override, use `--ext` with a JSON object:
 dot polkadot.tx.System.remark 0xdeadbeef --from alice --ext '{"MyExtension":{"value":"..."}}'
 ```
 
+`--ext` overrides work for `[builtin]` extensions too — for example `--ext '{"CheckMetadataHash":{"value":{"type":"Enabled"}}}'` replaces the value `polkadot-api` would fill in itself. Passing an extension name the chain doesn't declare is an error.
+
 Not sure which extensions a chain exposes? Run `dot <chain>.extensions` (see [Transaction extensions](#transaction-extensions)) to list them all with value types and a `[builtin]` / `[custom]` marker.
 
 #### Transaction options

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1872,6 +1872,8 @@ dot polkadot.tx.System.remark 0xdeadbeef --from alice \
   --ext '{"MyExtension":{"value":"..."}}'
 ```
 
+`--ext` overrides work for `[builtin]` extensions too — for example `--ext '{"CheckMetadataHash":{"value":{"type":"Enabled"}}}'` replaces the value `polkadot-api` would fill in itself. Passing an extension name the chain doesn't declare is an error.
+
 Not sure which extensions a chain exposes or which ones need a `--ext` override? Run `dot extensions --chain <chain>` (see [Transaction extensions](#transaction-extensions)) to list every extension with its value type and a `[builtin]` / `[custom]` marker.
 
 ### Transaction options

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -242,7 +242,7 @@ Use `--tip` to set a priority tip in plancks. `--nonce`, `--mortality`, and `--a
 dot polkadot.tx.System.remark 0xdead --from alice --tip 1000000 --dry-run
 ```
 
-For non-standard signed extensions, override with `--ext '{"<Identifier>":{"value":<v>}}'`. List the chain's extensions with `dot <chain>.extensions`.
+For non-standard signed extensions, override with `--ext '{"<Identifier>":{"value":<v>}}'`. This also overrides builtin extensions polkadot-api fills in itself (e.g. `CheckMetadataHash`); unknown extension names are an error. List the chain's extensions with `dot <chain>.extensions`.
 
 ## Runtime APIs
 

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -1465,6 +1465,27 @@ describe("buildCustomSignedExtensions", () => {
     const result = buildCustomSignedExtensions(meta, {});
     expect(Object.keys(result).length).toBe(0);
   });
+
+  test("user override of a builtin extension is passed through, not dropped", () => {
+    const override = { value: { type: "Enabled", value: undefined } };
+    const result = buildCustomSignedExtensions(meta, { CheckMetadataHash: override });
+    expect(result.CheckMetadataHash).toEqual(override);
+  });
+
+  test("user override of a builtin does not affect other builtins", () => {
+    const result = buildCustomSignedExtensions(meta, {
+      CheckMetadataHash: { value: { type: "Disabled", value: undefined } },
+    });
+    expect(result).not.toHaveProperty("CheckNonce");
+    expect(result).not.toHaveProperty("ChargeTransactionPayment");
+    expect(Object.keys(result)).toEqual(["CheckMetadataHash"]);
+  });
+
+  test("unknown extension name throws with the chain's extension list", () => {
+    expect(() => buildCustomSignedExtensions(meta, { CheckMetadataHsh: {} })).toThrow(
+      /Unknown transaction extension "CheckMetadataHsh".*CheckMetadataHash/s,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -342,21 +342,13 @@ export async function handleTx(
       // check rejects with "Incompatible runtime asset" even with fresh metadata.
       // Bypassing it lets us SCALE-encode the asset directly via the metadata
       // builder.
-      const skipBuiltins =
-        asset !== undefined
-          ? new Set([...PAPI_BUILTIN_EXTENSIONS].filter((e) => e !== "ChargeAssetTxPayment"))
-          : PAPI_BUILTIN_EXTENSIONS;
       if (asset !== undefined) {
         userExtOverrides.ChargeAssetTxPayment ??= {
           value: { tip: tip ?? 0n, asset_id: asset },
         };
       }
 
-      const customSignedExtensions = buildCustomSignedExtensions(
-        meta,
-        userExtOverrides,
-        skipBuiltins,
-      );
+      const customSignedExtensions = buildCustomSignedExtensions(meta, userExtOverrides);
 
       const built: Record<string, any> = {};
       if (Object.keys(customSignedExtensions).length > 0)
@@ -1565,19 +1557,30 @@ const NO_DEFAULT = Symbol("no-default");
 function buildCustomSignedExtensions(
   meta: MetadataBundle,
   userOverrides: Record<string, any>,
-  builtins: ReadonlySet<string> = PAPI_BUILTIN_EXTENSIONS,
 ): Record<string, { value?: any; additionalSigned?: any }> {
   const result: Record<string, { value?: any; additionalSigned?: any }> = {};
   const extensions = getSignedExtensions(meta);
 
-  for (const ext of extensions) {
-    if (builtins.has(ext.identifier)) continue;
+  const known = new Set(extensions.map((e) => e.identifier));
+  for (const name of Object.keys(userOverrides)) {
+    if (!known.has(name)) {
+      throw new Error(
+        `Unknown transaction extension "${name}" — this chain's extensions: ` +
+          [...known].join(", "),
+      );
+    }
+  }
 
-    // User override takes priority
+  for (const ext of extensions) {
+    // User override takes priority, even over extensions polkadot-api
+    // fills in itself (e.g. CheckMetadataHash) — papi checks
+    // customSignedExtensions before its own builtin handling.
     if (ext.identifier in userOverrides) {
       result[ext.identifier] = userOverrides[ext.identifier];
       continue;
     }
+
+    if (PAPI_BUILTIN_EXTENSIONS.has(ext.identifier)) continue;
 
     // Auto-default based on type structure
     const valueEntry = meta.lookup(ext.type);
@@ -1599,6 +1602,9 @@ function buildCustomSignedExtensions(
 }
 
 function autoDefaultForType(entry: any): any {
+  // Raw Uint8Array relies on papi 2.x passing it through unencoded
+  // (sign-extensions "input instanceof Uint8Array" branch); papi 3.0 drops
+  // that branch, so on migration void types must become decoded values.
   if (entry.type === "void") return new Uint8Array([]);
   // Option<T> → undefined tells polkadot-api to encode as None (0x00)
   if (entry.type === "option") return undefined;


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot-cli/issues/295

`--ext` overrides for builtin extensions were parsed and then silently dropped, and unknown extension names were silently accepted. This reorders the checks in `buildCustomSignedExtensions` so user overrides win, and rejects names the chain's metadata doesn't declare.

**Why:** the builtin skip ran before the user-override check, so `--ext '{"CheckMetadataHash":…}'` did nothing — making metadata-hash signing (Ledger/Vault flows) unreachable by any route, with no error. papi itself checks `customSignedExtensions` before its own handling, so we were the ones dropping it.

**How:** override check first, then the builtin skip. The `--asset` special case that removed `ChargeAssetTxPayment` from the skip set collapses into the general path (same behaviour, injected as an override). One judgment call: unknown extension names now error instead of being ignored — this also means `--asset` on a chain without `ChargeAssetTxPayment` fails loudly instead of silently charging fees in the native token.

Docs, README, and the dot-cli skill updated; unit tests cover the override-wins and unknown-name paths.