### PR TITLE
feat: select the transaction-extension version from metadata

### DIFF
--- a/.changeset/select-extension-version-from-metadata.md
+++ b/.changeset/select-extension-version-from-metadata.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": patch
+---
+
+Select the transaction-extension version from metadata instead of taking the first key. `getSignedExtensions` now uses the highest version in `transaction_extensions_by_version` (matching subxt), `buildGeneralTx` derives the v5 preamble's extension-version byte from that same key instead of hardcoding `0x00`, and `dot <chain>.extensions` surfaces which extension version it is displaying (`extensionVersion` / `availableVersions` in `--json`). Also fixes the `--unsigned` output label, which claimed `unsigned (bare)` while actually emitting a v5 General extrinsic. No behavior change on any live chain today — they all expose exactly version `{0}` — but wrong the moment one doesn't.

--- a/README.md
+++ b/README.md
@@ -1130,7 +1130,7 @@ List the transaction extensions (also known as signed extensions) a chain declar
 # List all transaction extensions on a chain
 dot polkadot.extensions
 # Output:
-# Transaction extensions on polkadot (11)
+# Transaction extensions on polkadot (11, extension version 0)
 #
 #   AuthorizeCall              unknown               [custom]
 #   ChargeTransactionPayment   Compact<u128>         [builtin]

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1456,7 +1456,7 @@ Every Substrate transaction carries a list of transaction extensions (also known
 # List every transaction extension on the chain
 dot polkadot.extensions
 # Output:
-# Transaction extensions on polkadot (11)
+# Transaction extensions on polkadot (11, extension version 0)
 #
 #   AuthorizeCall              unknown               [custom]
 #   ChargeTransactionPayment   Compact<u128>         [builtin]
@@ -1494,7 +1494,7 @@ Each entry is tagged:
   dot tx.<Pallet>.<Call> --from <acc> --chain <chain> --ext '{"<Identifier>":{"value":<v>}}'
   ```
 
-The detail view also shows the extension's `additionalSigned` type (included in the signed payload but not in the transaction body). `--json` output emits structured records with `identifier`, `valueType`, `additionalSignedType`, `valueTypeId`, `additionalSignedTypeId`, and `isBuiltin` — handy for agents and scripts that generate `--ext` payloads automatically.
+The detail view also shows the extension's `additionalSigned` type (included in the signed payload but not in the transaction body). `--json` output emits structured records with `identifier`, `valueType`, `additionalSignedType`, `valueTypeId`, `additionalSignedTypeId`, and `isBuiltin`, plus the top-level `extensionVersion` (the transaction-extension version the listed set belongs to — every live chain exposes exactly version `0` today) and `availableVersions` — handy for agents and scripts that generate `--ext` payloads automatically.
 
 This is the companion discovery surface for [Custom signed extensions](#custom-signed-extensions) below — run `dot <chain>.extensions` first to learn what the chain expects, then pass the right values to `dot tx ... --ext`.
 

--- a/src/commands/focused-inspect.test.ts
+++ b/src/commands/focused-inspect.test.ts
@@ -666,8 +666,9 @@ describe("stdout/stderr separation (pipe-safe output)", () => {
 });
 
 describe("dot extensions", () => {
-  test("lists extensions with types", async () => {
+  test("lists extensions with types and the extension version", async () => {
     const { stdout, exitCode } = await runCli(["extensions"]);
+    expect(stdout).toContain("extension version 0");
     expect(exitCode).toBe(0);
     expect(stdout).toContain("Transaction extensions");
     expect(stdout).toContain("CheckMortality");
@@ -715,6 +716,8 @@ describe("dot extensions", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed.chain).toBe("polkadot");
+    expect(parsed.extensionVersion).toBe(0);
+    expect(parsed.availableVersions).toEqual([0]);
     expect(Array.isArray(parsed.extensions)).toBe(true);
     const mortality = parsed.extensions.find((e: any) => e.identifier === "CheckMortality");
     expect(mortality).toBeDefined();

--- a/src/commands/focused-inspect.ts
+++ b/src/commands/focused-inspect.ts
@@ -15,6 +15,8 @@ import {
   getRuntimeApiNames,
   getSignedExtensionNames,
   getSignedExtensions,
+  getTransactionExtensionVersion,
+  getTransactionExtensionVersions,
   listPallets,
   parseMetadata,
 } from "../core/metadata.ts";
@@ -775,6 +777,8 @@ export async function handleExtensions(
   const meta = await loadMeta(chainName, chainConfig, opts.rpc);
 
   if (!target) {
+    const extensionVersion = getTransactionExtensionVersion(meta);
+    const availableVersions = getTransactionExtensionVersions(meta);
     const extensions = getSignedExtensions(meta)
       .map((e) => describeSignedExtension(meta, e))
       .sort((a, b) => a.identifier.localeCompare(b.identifier));
@@ -783,6 +787,8 @@ export async function handleExtensions(
       console.log(
         formatJson({
           chain: chainName,
+          extensionVersion,
+          availableVersions,
           extensions: extensions.map((e) => ({
             identifier: e.identifier,
             valueType: e.valueType,
@@ -794,7 +800,11 @@ export async function handleExtensions(
       return;
     }
 
-    printHeading(`Transaction extensions on ${chainName} (${extensions.length})`);
+    const versionNote =
+      availableVersions.length > 1
+        ? `extension version ${extensionVersion} of {${availableVersions.join(", ")}}`
+        : `extension version ${extensionVersion}`;
+    printHeading(`Transaction extensions on ${chainName} (${extensions.length}, ${versionNote})`);
     for (const e of extensions) {
       const tag = e.isBuiltin ? `${DIM}[builtin]${RESET}` : `${CYAN}[custom]${RESET}`;
       printItem(e.identifier, `${e.valueType}  ${tag}`);

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -2478,7 +2478,7 @@ describe("DOT_DRY_RUN global flag", { timeout: 15_000 }, () => {
       { env: { DOT_DRY_RUN: "1" } },
     );
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("unsigned (bare)");
+    expect(stdout).toContain("unsigned (v5 general)");
     expect(stdout).toContain("N/A (unsigned transaction)");
     // Hint goes to stderr so it never corrupts stdout.
     expect(stderr).toContain("DOT_DRY_RUN is set");

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -17,6 +17,7 @@ import {
   getOrFetchMetadata,
   getPalletNames,
   getSignedExtensions,
+  getTransactionExtensionVersion,
   listPallets,
   PAPI_BUILTIN_EXTENSIONS,
   withBlockAvailabilityHint,
@@ -447,7 +448,7 @@ export async function handleTx(
         return;
       }
       console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
-      console.log(`  ${BOLD}Type:${RESET}   unsigned (bare)`);
+      console.log(`  ${BOLD}Type:${RESET}   unsigned (v5 general)`);
       console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
       printDecodedCall(decodedObj, decodedStr);
       console.log(`  ${BOLD}Fees:${RESET}   ${DIM}N/A (unsigned transaction)${RESET}`);
@@ -587,7 +588,7 @@ export async function handleTx(
 
       console.log();
       console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
-      console.log(`  ${BOLD}Type:${RESET}   unsigned (bare)`);
+      console.log(`  ${BOLD}Type:${RESET}   unsigned (v5 general)`);
       console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
       printDecodedCall(decodedObj, decodedStr);
       console.log(`  ${BOLD}Tx:${RESET}     ${result.txHash}`);
@@ -1686,14 +1687,24 @@ function unsignedDefaultForType(identifier: string, entry: any): any {
  * defaulted for unsigned/authorized submission.
  *
  * Byte layout:
- *   compact(payload_len) | 0x45 | ext_version(0x00) | ext_extras... | call_data
+ *   compact(payload_len) | 0x45 | ext_version | ext_extras... | call_data
  */
 function buildGeneralTx(
   meta: MetadataBundle,
   callData: Uint8Array,
   userExtOverrides: Record<string, any>,
 ): Uint8Array {
-  const extensions = getSignedExtensions(meta);
+  // The preamble's extension-version byte and the extension set must come
+  // from the same key of the metadata's version map.
+  const extensionVersion = getTransactionExtensionVersion(meta);
+  if (extensionVersion === null || extensionVersion > 0xff) {
+    throw new CliError(
+      extensionVersion === null
+        ? "This chain's metadata declares no transaction-extension versions — cannot build a general transaction."
+        : `Transaction-extension version ${extensionVersion} does not fit the v5 preamble's u8 version byte.`,
+    );
+  }
+  const extensions = getSignedExtensions(meta, extensionVersion);
   const extBytes: Uint8Array[] = [];
 
   for (const ext of extensions) {
@@ -1722,8 +1733,8 @@ function buildGeneralTx(
     extBytes.push(codec.enc(value));
   }
 
-  // Assemble: 0x45 | ext_version(0x00) | ext_extras | call_data
-  const extVersion = new Uint8Array([0x00]);
+  // Assemble: 0x45 | ext_version | ext_extras | call_data
+  const extVersion = new Uint8Array([extensionVersion]);
   const versionByte = new Uint8Array([0x45]);
 
   // Calculate total payload length

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -21,6 +21,8 @@ import {
   getRuntimeApiNames,
   getSignedExtensionNames,
   getSignedExtensions,
+  getTransactionExtensionVersion,
+  getTransactionExtensionVersions,
   type Lookup,
   listPallets,
   listRuntimeApis,
@@ -239,6 +241,63 @@ describe("getSignedExtensions", () => {
       expect(typeof ext.type).toBe("number");
       expect(typeof ext.additionalSigned).toBe("number");
     }
+  });
+
+  test("preserves metadata order — never sorted", () => {
+    // Signing payloads encode extensions in metadata order, so the accessor
+    // must return them exactly as declared.
+    const raw = meta.unified.extrinsic.signedExtensions[0]!.map((e) => e.identifier);
+    expect(getSignedExtensions(meta).map((e) => e.identifier)).toEqual(raw);
+    const sorted = [...raw].sort((a, b) => a.localeCompare(b));
+    expect(raw).not.toEqual(sorted);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTransactionExtensionVersion(s) — synthetic multi-version metadata, since
+// no live chain exposes more than {0} yet
+// ---------------------------------------------------------------------------
+
+function syntheticVersionedMeta(
+  byVersion: Record<number, Array<{ identifier: string; type: number; additionalSigned: number }>>,
+): MetadataBundle {
+  return { unified: { extrinsic: { signedExtensions: byVersion } } } as unknown as MetadataBundle;
+}
+
+describe("getTransactionExtensionVersion", () => {
+  test("real metadata exposes exactly version 0", () => {
+    expect(getTransactionExtensionVersions(meta)).toEqual([0]);
+    expect(getTransactionExtensionVersion(meta)).toBe(0);
+  });
+
+  test("picks the highest version, not the first key", () => {
+    const ext = (identifier: string) => ({ identifier, type: 0, additionalSigned: 0 });
+    const synthetic = syntheticVersionedMeta({
+      0: [ext("CheckNonce")],
+      1: [ext("CheckNonce"), ext("VerifyMultiSignature")],
+    });
+    expect(getTransactionExtensionVersion(synthetic)).toBe(1);
+    expect(getSignedExtensions(synthetic).map((e) => e.identifier)).toEqual([
+      "CheckNonce",
+      "VerifyMultiSignature",
+    ]);
+  });
+
+  test("an explicit version selects that set (v4 signing always uses 0)", () => {
+    const ext = (identifier: string) => ({ identifier, type: 0, additionalSigned: 0 });
+    const synthetic = syntheticVersionedMeta({
+      0: [ext("CheckNonce")],
+      1: [ext("VerifyMultiSignature")],
+    });
+    expect(getSignedExtensions(synthetic, 0).map((e) => e.identifier)).toEqual(["CheckNonce"]);
+    expect(getSignedExtensions(synthetic, 2)).toEqual([]);
+  });
+
+  test("empty version map yields null / empty", () => {
+    const synthetic = syntheticVersionedMeta({});
+    expect(getTransactionExtensionVersion(synthetic)).toBeNull();
+    expect(getTransactionExtensionVersions(synthetic)).toEqual([]);
+    expect(getSignedExtensions(synthetic)).toEqual([]);
   });
 });
 

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -456,12 +456,38 @@ export const PAPI_BUILTIN_EXTENSIONS: ReadonlySet<string> = new Set([
   "PrevalidateAttests",
 ]);
 
-export function getSignedExtensions(meta: MetadataBundle): SignedExtensionInfo[] {
-  const byVersion = meta.unified.extrinsic.signedExtensions;
-  // Use the first (and typically only) version key
-  const versionKeys = Object.keys(byVersion);
-  if (versionKeys.length === 0) return [];
-  return byVersion[Number(versionKeys[0])] ?? [];
+/**
+ * Keys of the transaction-extension version map, ascending. The map is keyed
+ * by transaction-extension (pipeline) version, NOT extrinsic version — the
+ * frame-metadata v16 doc comment says "extrinsic versions" and is wrong: v4
+ * Signed extrinsics always use pipeline version 0, and only v5 General
+ * extrinsics carry an explicit extension-version byte. v14/v15 metadata
+ * expose exactly one entry, keyed 0.
+ */
+export function getTransactionExtensionVersions(meta: MetadataBundle): number[] {
+  return Object.keys(meta.unified.extrinsic.signedExtensions)
+    .map(Number)
+    .filter(Number.isInteger)
+    .sort((a, b) => a - b);
+}
+
+/**
+ * The transaction-extension version to encode with: the highest key in the
+ * map, matching subxt's transaction_extension_version_to_use_for_encoding.
+ * Every live chain exposes exactly {0} today; this matters the day one
+ * doesn't. Null when the map is empty.
+ */
+export function getTransactionExtensionVersion(meta: MetadataBundle): number | null {
+  const versions = getTransactionExtensionVersions(meta);
+  return versions.length > 0 ? versions[versions.length - 1]! : null;
+}
+
+export function getSignedExtensions(meta: MetadataBundle, version?: number): SignedExtensionInfo[] {
+  const chosen = version ?? getTransactionExtensionVersion(meta);
+  if (chosen === null) return [];
+  // Metadata order is normative — signing payloads encode extensions in
+  // exactly this order, so never sort or normalise it.
+  return meta.unified.extrinsic.signedExtensions[chosen] ?? [];
 }
 
 export function getSignedExtensionNames(meta: MetadataBundle): string[] {


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot-cli/issues/293

`getSignedExtensions` took the **first** key of `transaction_extensions_by_version` (numeric-string iteration → the lowest); subxt takes the max. Harmless today — every live chain exposes exactly `{0}` — but wrong the moment one doesn't, and it silently discarded versions we couldn't see.

**Why:** correct v5 signing (#294) must pick a key from this map, encode that same key as the preamble's extension-version byte, and use that key's extension set in metadata order. This PR creates the single seam that answers "which extension version am I encoding?".

**How:** `getTransactionExtensionVersion(s)` in `src/core/metadata.ts` picks the highest key (subxt's `transaction_extension_version_to_use_for_encoding`); `getSignedExtensions` takes an optional explicit version so the v4 path can keep pinning key `0` later — the map is keyed by *transaction-extension* version, not extrinsic version (the frame-metadata doc comment is wrong on this). `buildGeneralTx` now derives its preamble byte from the map instead of hardcoding `0x00` and errors clearly on an empty map. `dot <chain>.extensions` shows which version it displays (`extensionVersion`/`availableVersions` in `--json`), and the `--unsigned` label no longer claims `bare` while emitting a General extrinsic.

Covered by synthetic multi-version fixtures (no live chain exercises >1 version) plus an order-preservation test — extension order is normative for signing payloads and must never be sorted. Verified live against polkadot: `extensions` heading shows version 0, `--unsigned --encode` still emits `0x…4500…`. 1817 tests green.