### PR TITLE
feat: default to the highest extrinsic version the chain can authorize

### DIFF
--- a/.changeset/default-highest-extrinsic-version.md
+++ b/.changeset/default-highest-extrinsic-version.md
@@ -1,0 +1,5 @@
+---
+"polkadot-cli": minor
+---
+
+Sign with the highest extrinsic version the chain can authorize by default: v5 General on chains carrying `VerifyMultiSignature` (people chains on test networks today), v4 everywhere else. Every signed transaction's output now states the version used (`Type: signed (v4)` / `signed (v5 general)`; `extrinsicVersion` in `--json`), and new `--v4`/`--v5` flags force a version — a forced `--v5` on an incapable chain errors up front. This is deliberately more aggressive than subxt (which defaults to v4 whenever v4 is advertised): the capability gate checks actual authorization support, so the polkadot-js-style failure mode of building unsignable v5 transactions cannot occur.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ships with Polkadot and all system parachains preconfigured with multiple fallba
 - ✅ Sovereign accounts — store a parachain (child / sibling) or pallet (Treasury, Bounties, NominationPools, …) sovereign as a named watch-only account in one command
 - ✅ Message signing — sign arbitrary bytes with account keypairs for use as `MultiSignature` arguments
 - ✅ Unsigned/authorized transactions — submit governance-authorized calls without a signer (`--unsigned`)
-- ✅ Extrinsic V5 General signing — opt-in `--v5` on chains that carry `VerifyMultiSignature`, capability-checked up front
+- ✅ Extrinsic V5 General signing — automatic on chains that carry `VerifyMultiSignature`, capability-checked up front (`--v4`/`--v5` to force)
 - ✅ Non-native fee payment — pay tx fees in any asset the chain accepts via `--asset` (asset-hub-style chains)
 - ✅ Bandersnatch member keys — derive Ring VRF member keys from mnemonics for on-chain member sets
 - ✅ Export/import — portable chain and account configuration for backup, sharing, and CI bootstrapping
@@ -1595,19 +1595,23 @@ tx:
     create_people_collection: null
 ```
 
-#### Signed v5 General transactions (`--v5`)
+#### Extrinsic version selection (v4 / v5 General)
 
-Opt in to signing as an Extrinsic V5 "General" transaction with `--v5`. A v5 transaction has no signature field — the signature travels *inside* the `VerifyMultiSignature` transaction extension, so this only works on chains whose runtime carries that extension (currently people chains on test networks; Polkadot, Kusama, and all asset hubs do not, and must keep signing v4).
+The CLI signs with the highest extrinsic version the chain can actually authorize. A v5 "General" transaction has no signature field — the signature travels *inside* the `VerifyMultiSignature` transaction extension — so v5 is used only when the runtime advertises extrinsic version 5 **and** carries that extension (currently people chains on test networks; Polkadot, Kusama, and all asset hubs can't authorize v5 and get v4). Every signed transaction's output shows the version used (`Type: signed (v4)` / `signed (v5 general)`, `extrinsicVersion` in `--json`).
 
 ```bash
-# Sign and submit as v5 General (chain must carry VerifyMultiSignature)
-dot preview-people.tx.System.remark "hello" --from alice --v5
+# Auto: signs v5 General on a capable chain, v4 anywhere else
+dot preview-people.tx.System.remark "hello" --from alice
 
-# Dry-run with fee estimation (queried directly from the runtime)
-dot preview-people.tx.System.remark "hello" --from alice --v5 --dry-run
+# Force a version (--v5 errors clearly if the chain can't authorize it)
+dot preview-people.tx.System.remark "hello" --from alice --v4
+dot polkadot.tx.System.remark "hello" --from alice --v5   # → capability error
+
+# Dry-run shows the selected version and fees (v5 fees queried directly from the runtime)
+dot preview-people.tx.System.remark "hello" --from alice --dry-run
 ```
 
-The capability is checked up front: on a chain that can't authorize v5, the CLI refuses with a clear error instead of letting the runtime reject the submission with `UnknownOrigin`. Nonce, tip, mortality, and `--ext` overrides work exactly as on the v4 path. The default remains v4 everywhere — `--v5` is strictly opt-in.
+The capability check runs up front: a forced `--v5` on a chain that can't authorize it is refused with a clear error instead of letting the runtime reject the submission with `UnknownOrigin`. Nonce, tip, mortality, and `--ext` overrides work identically on both paths.
 
 ### File-based commands
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -23,7 +23,7 @@ A command-line tool for interacting with Polkadot-ecosystem chains. Manage chain
 - ✅ File-based commands — run any command from a YAML/JSON file with variable substitution
 - ✅ Sovereign accounts — store a parachain (child / sibling) or pallet (Treasury, Bounties, NominationPools, …) sovereign as a named watch-only account in one command
 - ✅ Unsigned/authorized transactions — submit governance-authorized calls without a signer (`--unsigned`)
-- ✅ Extrinsic V5 General signing — opt-in `--v5` on chains that carry `VerifyMultiSignature`, capability-checked up front
+- ✅ Extrinsic V5 General signing — automatic on chains that carry `VerifyMultiSignature`, capability-checked up front (`--v4`/`--v5` to force)
 - ✅ Non-native fee payment — pay tx fees in any asset the chain accepts via `--asset` (asset-hub-style chains)
 - ✅ Message signing — sign arbitrary bytes with account keypairs for use as `MultiSignature` arguments
 - ✅ Bandersnatch member keys — derive Ring VRF member keys from mnemonics for on-chain member sets
@@ -2006,19 +2006,23 @@ dot ./create-people-collection.yaml
 dot ./create-people-collection.yaml --dry-run
 ```
 
-### Signed v5 General transactions (`--v5`)
+### Extrinsic version selection (v4 / v5 General)
 
-Opt in to signing as an Extrinsic V5 "General" transaction with `--v5`. A v5 transaction has no signature field — the signature travels *inside* the `VerifyMultiSignature` transaction extension, so this only works on chains whose runtime carries that extension (currently people chains on test networks; Polkadot, Kusama, and all asset hubs do not, and must keep signing v4).
+The CLI signs with the highest extrinsic version the chain can actually authorize. A v5 "General" transaction has no signature field — the signature travels *inside* the `VerifyMultiSignature` transaction extension — so v5 is used only when the runtime advertises extrinsic version 5 **and** carries that extension (currently people chains on test networks; Polkadot, Kusama, and all asset hubs can't authorize v5 and get v4). Every signed transaction's output shows the version used (`Type: signed (v4)` / `signed (v5 general)`, `extrinsicVersion` in `--json`).
 
 ```
-# Sign and submit as v5 General (chain must carry VerifyMultiSignature)
-dot preview-people.tx.System.remark "hello" --from alice --v5
+# Auto: signs v5 General on a capable chain, v4 anywhere else
+dot preview-people.tx.System.remark "hello" --from alice
 
-# Dry-run with fee estimation (queried directly from the runtime)
-dot preview-people.tx.System.remark "hello" --from alice --v5 --dry-run
+# Force a version (--v5 errors clearly if the chain can't authorize it)
+dot preview-people.tx.System.remark "hello" --from alice --v4
+dot polkadot.tx.System.remark "hello" --from alice --v5   # → capability error
+
+# Dry-run shows the selected version and fees (v5 fees queried directly from the runtime)
+dot preview-people.tx.System.remark "hello" --from alice --dry-run
 ```
 
-The capability is checked up front: on a chain that can't authorize v5, the CLI refuses with a clear error instead of letting the runtime reject the submission with `UnknownOrigin`. Nonce, tip, mortality, and `--ext` overrides work exactly as on the v4 path (an `--ext` override for `VerifyMultiSignature` itself is rejected — that extension carries the v5 signature). The default remains v4 everywhere — `--v5` is strictly opt-in.
+The capability check runs up front: a forced `--v5` on a chain that can't authorize it is refused with a clear error instead of letting the runtime reject the submission with `UnknownOrigin`. Nonce, tip, mortality, and `--ext` overrides work identically on both paths (an `--ext` override for `VerifyMultiSignature` itself is rejected while signing v5 — that extension carries the signature; force `--v4` to set it manually).
 
 ## File-Based Commands
 

--- a/dot-cli/SKILL.md
+++ b/dot-cli/SKILL.md
@@ -244,7 +244,7 @@ dot polkadot.tx.System.remark 0xdead --from alice --tip 1000000 --dry-run
 
 For non-standard signed extensions, override with `--ext '{"<Identifier>":{"value":<v>}}'`. This also overrides builtin extensions polkadot-api fills in itself (e.g. `CheckMetadataHash`); unknown extension names are an error. List the chain's extensions with `dot <chain>.extensions`.
 
-On chains whose runtime carries the `VerifyMultiSignature` transaction extension (people chains on test networks), `--v5` signs as an Extrinsic V5 General transaction instead of v4. The CLI checks the capability up front and errors clearly on chains that can't authorize v5 (Polkadot, Kusama, and all asset hubs must sign v4). Requires `--from`; mutually exclusive with `--unsigned`.
+The CLI automatically signs with the highest extrinsic version the chain can authorize: Extrinsic V5 General on chains carrying the `VerifyMultiSignature` transaction extension (people chains on test networks), v4 everywhere else (Polkadot, Kusama, and all asset hubs). The output always shows which was used (`Type: signed (v4)` / `signed (v5 general)`; `extrinsicVersion` in `--json`). Force a version with `--v4` or `--v5` — a forced `--v5` errors clearly on chains that can't authorize it.
 
 ## Runtime APIs
 
@@ -708,7 +708,7 @@ dot verifiable verify --proof 0x<proof> --context dotns \
 | `--dry-run` / `--no-dry-run` | tx | Force / forbid dry-run (overrides `DOT_DRY_RUN`) |
 | `--dump` | query | Dump all entries of a storage map |
 | `--ext <json>` | tx | Custom signed extension values |
-| `--v5` | tx | Sign as Extrinsic V5 General (chain must carry `VerifyMultiSignature`) |
+| `--v4` / `--v5` | tx | Force the extrinsic version (default: v5 General when the chain carries `VerifyMultiSignature`, else v4) |
 | `--at <block>` | tx, query, apis | Block hash, `"best"`, or `"finalized"` to read/validate against. Defaults to finalized. Tx submission rejects `"best"`. |
 
 ## Common Errors

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,7 +108,8 @@ if (process.argv[2] === "__complete") {
       'Block hash, "best", or "finalized" to read/validate against (tx, query, apis)',
     )
     .option("--unsigned", "Submit as unsigned/bare transaction (no signer required, for tx)")
-    .option("--v5", "Sign as an Extrinsic V5 General transaction (needs chain support, for tx)")
+    .option("--v4", "Force signing as an Extrinsic V4 transaction (for tx)")
+    .option("--v5", "Force signing as an Extrinsic V5 General transaction (for tx)")
     .option("--refresh", "Refresh the cached RPC method list from the node (for rpc)")
     .action(
       async (
@@ -132,6 +133,7 @@ if (process.argv[2] === "__complete") {
           mortality?: string;
           at?: string;
           unsigned?: boolean;
+          v4?: boolean;
           v5?: boolean;
           dump?: boolean;
           refresh?: boolean;
@@ -174,6 +176,7 @@ if (process.argv[2] === "__complete") {
                 ...handlerOpts,
                 from: opts.from,
                 unsigned: opts.unsigned ?? cmd.unsigned,
+                v4: opts.v4,
                 v5: opts.v5,
                 dryRun: fileDryRun,
                 encode: opts.encode,
@@ -293,6 +296,7 @@ if (process.argv[2] === "__complete") {
               ...handlerOpts,
               from: opts.from,
               unsigned: opts.unsigned,
+              v4: opts.v4,
               v5: opts.v5,
               dryRun,
               encode: opts.encode,

--- a/src/commands/tx.test.ts
+++ b/src/commands/tx.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { isCompatible, mapLookupToTypedef } from "@polkadot-api/metadata-compatibility";
 import { Binary } from "polkadot-api";
 import { DEFAULT_CONFIG } from "../config/types.ts";
-import { getTestMetadata } from "./__fixtures__/load-metadata.ts";
+import { getPeopleMetadata, getTestMetadata } from "./__fixtures__/load-metadata.ts";
 import { runCli } from "./__fixtures__/run-cli.ts";
 import {
   autoDefaultForType,
@@ -32,6 +32,7 @@ import {
   parseTipOption,
   parseTypedArg,
   parseWaitLevel,
+  resolveExtrinsicVersion,
   sanitizeForSerialization,
   typeHint,
   unsignedDefaultForType,
@@ -1783,6 +1784,34 @@ describe("decodeCallToFileFormat", () => {
 // Layer 1: CLI integration tests (subprocess)
 // ---------------------------------------------------------------------------
 
+describe("resolveExtrinsicVersion", () => {
+  test("defaults to v4 on chains that can't authorize v5 (polkadot)", () => {
+    const { version } = resolveExtrinsicVersion(getTestMetadata(), {});
+    expect(version).toBe(4);
+  });
+
+  test("defaults to v5 on chains that carry VerifyMultiSignature (preview-people)", () => {
+    const { version, capability } = resolveExtrinsicVersion(getPeopleMetadata(), {});
+    expect(version).toBe(5);
+    expect(capability).toEqual({
+      ok: true,
+      extensionVersion: 0,
+      authIdentifier: "VerifyMultiSignature",
+    });
+  });
+
+  test("--v4 forces v4 on a v5-capable chain", () => {
+    const { version } = resolveExtrinsicVersion(getPeopleMetadata(), { v4: true });
+    expect(version).toBe(4);
+  });
+
+  test("--v5 on an incapable chain throws the capability error", () => {
+    expect(() => resolveExtrinsicVersion(getTestMetadata(), { v5: true })).toThrow(
+      "can't accept signed v5 transactions",
+    );
+  });
+});
+
 describe("dot tx CLI integration", () => {
   test("System.remark --encode outputs hex", async () => {
     const { stdout, exitCode } = await runCli(["tx.System.remark", "0xdeadbeef", "--encode"]);
@@ -1829,7 +1858,21 @@ describe("dot tx CLI integration", () => {
   test("--v5 --unsigned rejects", async () => {
     const { stderr, exitCode } = await runCli(["tx.System.remark", "0xaa", "--v5", "--unsigned"]);
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("--v5 and --unsigned are mutually exclusive");
+    expect(stderr).toContain("--v4/--v5 and --unsigned are mutually exclusive");
+  });
+
+  test("--v4 --v5 rejects", async () => {
+    const { stderr, exitCode } = await runCli([
+      "tx.System.remark",
+      "0xaa",
+      "--v4",
+      "--v5",
+      "--from",
+      "alice",
+      "--dry-run",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--v4 and --v5 are mutually exclusive");
   });
 
   test("--v5 without --from rejects", async () => {

--- a/src/commands/tx.ts
+++ b/src/commands/tx.ts
@@ -7,10 +7,14 @@ import type { PolkadotSigner } from "polkadot-api/signer";
 import { stringify as stringifyYaml } from "yaml";
 import { loadConfig, resolveChain } from "../config/store.ts";
 import { primaryRpc } from "../config/types.ts";
-import { resolveAccountSigner, resolveAccountV5Signer, toSs58 } from "../core/accounts.ts";
+import { resolveAccountKeypair, signerFromKeypair, toSs58 } from "../core/accounts.ts";
 import { type ClientHandle, createChainClient } from "../core/client.ts";
 import { papiLink, pjsAppsLink } from "../core/explorers.ts";
-import { assembleV5General, checkV5SignedCapability } from "../core/extrinsic-v5.ts";
+import {
+  assembleV5General,
+  checkV5SignedCapability,
+  type V5SignedCapability,
+} from "../core/extrinsic-v5.ts";
 import type { Lookup, MetadataBundle } from "../core/metadata.ts";
 import {
   describeCallArgs,
@@ -148,6 +152,30 @@ export function parseAtForRead(raw: string | undefined): string | undefined {
   );
 }
 
+/**
+ * Pick the extrinsic version to sign with: forced by --v4/--v5, otherwise the
+ * highest version the chain can actually authorize. v5 General signing is
+ * capability-gated — a forced --v5 on an incapable chain is refused up front
+ * instead of letting the runtime reject the submission with UnknownOrigin.
+ */
+export function resolveExtrinsicVersion(
+  meta: MetadataBundle,
+  opts: { v4?: boolean; v5?: boolean },
+): { version: 4 | 5; capability: V5SignedCapability } {
+  const capability = checkV5SignedCapability(meta);
+  if (opts.v5) {
+    if (!capability.ok) {
+      throw new CliError(
+        `--v5: this chain can't accept signed v5 transactions — ${capability.reason}. ` +
+          "Drop --v5 to sign a v4 transaction.",
+      );
+    }
+    return { version: 5, capability };
+  }
+  if (opts.v4) return { version: 4, capability };
+  return { version: capability.ok ? 5 : 4, capability };
+}
+
 export async function handleTx(
   target: string | undefined,
   args: string[],
@@ -169,6 +197,7 @@ export async function handleTx(
     tip?: string;
     mortality?: string;
     at?: string;
+    v4?: boolean;
     v5?: boolean;
     /** Pre-parsed args from a file (skip CLI string parsing, still normalize) */
     parsedArgs?: unknown;
@@ -249,13 +278,18 @@ export async function handleTx(
     return;
   }
 
-  if (opts.v5 && opts.unsigned) {
+  if (opts.v4 && opts.v5) {
+    throw new Error("--v4 and --v5 are mutually exclusive");
+  }
+  if ((opts.v4 || opts.v5) && opts.unsigned) {
     throw new Error(
-      "--v5 and --unsigned are mutually exclusive (--unsigned already emits a v5 general transaction)",
+      "--v4/--v5 and --unsigned are mutually exclusive (--unsigned always emits a v5 general transaction)",
     );
   }
-  if (opts.v5 && !opts.from) {
-    throw new Error("--v5 requires --from (it selects how the transaction is signed)");
+  if ((opts.v4 || opts.v5) && !opts.from) {
+    throw new Error(
+      `--${opts.v5 ? "v5" : "v4"} requires --from (it selects how the transaction is signed)`,
+    );
   }
 
   if (!opts.from && !opts.unsigned && !opts.encode && !opts.toYaml && !opts.toJson) {
@@ -314,12 +348,9 @@ export async function handleTx(
   const { name: chainName, chain: chainConfig } = resolveChain(config, effectiveChain);
 
   const decodeOnly = opts.encode || opts.toYaml || opts.toJson;
-  const signer =
-    decodeOnly || opts.unsigned
-      ? undefined
-      : opts.v5
-        ? await resolveAccountV5Signer(opts.from!)
-        : await resolveAccountSigner(opts.from!);
+  // Resolve the account up front (fails fast, offline); which signer wraps it
+  // depends on the extrinsic version, decided once metadata is available.
+  const keypair = decodeOnly || opts.unsigned ? undefined : await resolveAccountKeypair(opts.from!);
 
   let clientHandle: ClientHandle | undefined;
 
@@ -340,6 +371,17 @@ export async function handleTx(
       }
     }
 
+    // Pick the extrinsic version and wrap the keypair in the matching signer.
+    let extrinsicVersion: 4 | 5 = 4;
+    let v5AuthIdentifier: string | undefined;
+    let signer: PolkadotSigner | undefined;
+    if (keypair) {
+      const { version, capability } = resolveExtrinsicVersion(meta, opts);
+      extrinsicVersion = version;
+      if (capability.ok) v5AuthIdentifier = capability.authIdentifier;
+      signer = signerFromKeypair(keypair, version);
+    }
+
     // Build transaction options (custom extensions + nonce/tip/mortality/at)
     let unsafeApi: any;
     let txOptions: Record<string, any> | undefined;
@@ -353,23 +395,11 @@ export async function handleTx(
     if (!decodeOnly || opts.unsigned) {
       const userExtOverrides = parseExtOption(opts.ext);
 
-      // v5 General signing is capability-gated: refuse up front when the
-      // chain can't authorize it, instead of letting the runtime reject the
-      // submission with UnknownOrigin.
-      if (opts.v5) {
-        const cap = checkV5SignedCapability(meta);
-        if (!cap.ok) {
-          throw new CliError(
-            `--v5: this chain can't accept signed v5 transactions — ${cap.reason}. ` +
-              "Drop --v5 to sign a v4 transaction.",
-          );
-        }
-        if (cap.authIdentifier in userExtOverrides) {
-          throw new CliError(
-            `--ext override for ${cap.authIdentifier} conflicts with --v5 — ` +
-              "that extension carries the v5 signature.",
-          );
-        }
+      if (extrinsicVersion === 5 && v5AuthIdentifier && v5AuthIdentifier in userExtOverrides) {
+        throw new CliError(
+          `--ext override for ${v5AuthIdentifier} conflicts with v5 signing — ` +
+            "that extension carries the v5 signature. Force v4 with --v4 to set it manually.",
+        );
       }
 
       // When --asset is specified, handle ChargeAssetTxPayment as a custom extension
@@ -500,7 +530,7 @@ export async function handleTx(
         estimatedFees = String(
           await withStalenessSuggestion(chainName, clientHandle!, () =>
             withBlockAvailabilityHint(opts.at, () =>
-              opts.v5
+              extrinsicVersion === 5
                 ? estimateV5Fees(clientHandle!, meta, tx, signer!, txOptions)
                 : tx.getEstimatedFees(signer?.publicKey, txOptions),
             ),
@@ -514,7 +544,7 @@ export async function handleTx(
         const result: Record<string, unknown> = {
           chain: chainName,
           from: { name: opts.from, address: signerAddress },
-          ...(opts.v5 ? { v5: true } : {}),
+          extrinsicVersion,
           callHex,
           decoded: decodedStr,
           estimatedFees,
@@ -532,7 +562,7 @@ export async function handleTx(
 
       console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
       console.log(`  ${BOLD}From:${RESET}   ${opts.from} (${signerAddress})`);
-      if (opts.v5) console.log(`  ${BOLD}Type:${RESET}   signed (v5 general)`);
+      console.log(`  ${BOLD}Type:${RESET}   ${describeExtrinsicVersion(extrinsicVersion)}`);
       console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
       printDecodedCall(decodedObj, decodedStr);
       if (nonce !== undefined) console.log(`  ${BOLD}Nonce:${RESET} ${nonce}`);
@@ -705,7 +735,7 @@ export async function handleTx(
       }
       printJsonLine({
         event: result.type === "finalized" ? "finalized" : "bestBlock",
-        ...(opts.v5 ? { v5: true } : {}),
+        extrinsicVersion,
         blockNumber: result.block.number,
         blockHash,
         txHash: result.txHash,
@@ -734,7 +764,7 @@ export async function handleTx(
 
     console.log();
     console.log(`  ${BOLD}Chain:${RESET}  ${chainName}`);
-    if (opts.v5) console.log(`  ${BOLD}Type:${RESET}   signed (v5 general)`);
+    console.log(`  ${BOLD}Type:${RESET}   ${describeExtrinsicVersion(extrinsicVersion)}`);
     console.log(`  ${BOLD}Call:${RESET}   ${callHex}`);
     printDecodedCall(decodedObj, decodedStr);
     if (nonce !== undefined) console.log(`  ${BOLD}Nonce:${RESET} ${nonce}`);
@@ -796,6 +826,10 @@ export async function handleTx(
   } finally {
     clientHandle?.destroy();
   }
+}
+
+function describeExtrinsicVersion(version: 4 | 5): string {
+  return version === 5 ? "signed (v5 general)" : "signed (v4)";
 }
 
 /**

--- a/src/core/accounts.ts
+++ b/src/core/accounts.ts
@@ -337,10 +337,14 @@ export async function resolveAccountSigner(name: string): Promise<PolkadotSigner
   return getPolkadotSigner(keypair.publicKey, "Sr25519", keypair.sign);
 }
 
-/** Signer producing v5 General extrinsics (signature inside VerifyMultiSignature). */
-export async function resolveAccountV5Signer(name: string): Promise<PolkadotSigner> {
-  const keypair = await resolveAccountKeypair(name);
-  return createV5GeneralSigner(keypair.publicKey, keypair.sign);
+/** Wrap a keypair in the signer matching the chosen extrinsic version. */
+export function signerFromKeypair(
+  keypair: { publicKey: Uint8Array; sign: (msg: Uint8Array) => Uint8Array },
+  extrinsicVersion: 4 | 5,
+): PolkadotSigner {
+  return extrinsicVersion === 5
+    ? createV5GeneralSigner(keypair.publicKey, keypair.sign)
+    : getPolkadotSigner(keypair.publicKey, "Sr25519", keypair.sign);
 }
 
 export async function resolveAccountExpandedSecret(name: string): Promise<Uint8Array> {


### PR DESCRIPTION
Stacked on the v5-signing PR (merge that first; GitHub will retarget this to main):

+ feat: opt-in Extrinsic V5 General signing behind a capability gate
-> https://github.com/paritytech/polkadot-cli/pull/300

Makes v5 General the default wherever the chain can actually authorize it, instead of opt-in.

**Why:** if the capability gate is trustworthy — and it checks actual authorization support, not just the advertised version, which is what burned polkadot-js — there's no reason to hide the current extrinsic format behind a flag. Only test-network people chains are capable today, so the blast radius is small while it proves itself.

**How:** one policy function, `resolveExtrinsicVersion` — forced by `--v4`/`--v5`, otherwise highest authorizable. Every signed tx output now states the version (`Type: signed (v4)` / `signed (v5 general)`; `extrinsicVersion` in `--json`), so the selection is never silent. Judgment call: this makes us more aggressive than subxt, which defaults to v4 whenever v4 is advertised — deliberate, per the gate argument above; `--v4` is the escape hatch if ecosystem tooling chokes on v5 blocks.

Live-verified: bare `--from alice` on preview-people auto-selects v5 and lands (`0x9b14…5113`), `--v4` there forces v4, polkadot defaults to v4. Suite 1837 pass.